### PR TITLE
feat(projects): detect and merge duplicate project folders

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -22,13 +22,25 @@ import { getGlobalMcp } from './modules/mcp-reader';
 import { findClaudeProcesses } from './modules/process-scanner';
 import { getBgSessions } from './modules/bg-sessions-reader';
 import { startLiveMonitor, stopLiveMonitor } from './modules/live-monitor';
-import { hashToPath, resolveRealPath } from './utils';
+import { detectDuplicateProjects } from './modules/duplicate-detector';
+import { computeMergePlan } from './modules/duplicate-merger';
+import { executeMerge } from './modules/duplicate-merge-executor';
+import { hashToPath, resolveRealPath, invalidateCwdCache } from './utils';
 import { registerScreenshotHandlers } from './screenshotFixtures';
 
 const CLAUDE_DIR = join(os.homedir(), '.claude');
 const PROJECTS_DIR = join(CLAUDE_DIR, 'projects');
 
 type IpcResult<T> = { data: T | null; error: string | null };
+
+// Un hash di progetto è il nome di una cartella figlia diretta di PROJECTS_DIR:
+// rifiuta separatori/traversal per impedire operazioni fuori da PROJECTS_DIR.
+function assertValidHash(hash: string): void {
+  if (typeof hash !== 'string' || hash.length === 0 || hash === '.' || hash === '..'
+    || hash.includes('/') || hash.includes('\\') || hash.includes('\0')) {
+    throw new Error(`Invalid project hash: ${JSON.stringify(hash)}`);
+  }
+}
 
 function ok<T>(data: T): IpcResult<T> {
   return { data, error: null };
@@ -298,6 +310,47 @@ ipcMain.handle('projects:delete', async (_event, hash: string) => {
   }
 });
 
+ipcMain.handle('projects:detectDuplicates', async () => {
+  try {
+    return ok(detectDuplicateProjects(PROJECTS_DIR));
+  } catch (e) {
+    return err(e);
+  }
+});
+
+ipcMain.handle('projects:planMerge', async (_event, sourceHash: string, destHash: string) => {
+  try {
+    assertValidHash(sourceHash);
+    assertValidHash(destHash);
+    return ok(computeMergePlan(PROJECTS_DIR, sourceHash, destHash));
+  } catch (e) {
+    return err(e);
+  }
+});
+
+ipcMain.handle('projects:executeMerge', async (_event, sourceHash: string, destHash: string) => {
+  try {
+    assertValidHash(sourceHash);
+    assertValidHash(destHash);
+  } catch (e) {
+    return err(e);
+  }
+  pauseWatcher();
+  try {
+    const result = executeMerge(PROJECTS_DIR, sourceHash, destHash);
+    return ok(result);
+  } catch (e) {
+    return err(e);
+  } finally {
+    // Il contenuto delle due cartelle è cambiato (o è stato ripristinato dal rollback):
+    // invalida la cache del cwd e notifica un solo refresh.
+    invalidateCwdCache(sourceHash);
+    invalidateCwdCache(destHash);
+    resumeWatcher();
+    mainWindow?.webContents.send('data:changed');
+  }
+});
+
 ipcMain.handle('mcp:getGlobal', async () => {
   try {
     return ok(getGlobalMcp());
@@ -432,7 +485,11 @@ ipcMain.handle('sessions:newInTerminal', async (_event, realPath: string) => {
   } catch (e) { return err(e); }
 });
 
-// File watcher
+// File watcher — pausa rientrante (gestisce eventuali merge concorrenti).
+let watcherPauseDepth = 0;
+function pauseWatcher() { watcherPauseDepth += 1; }
+function resumeWatcher() { if (watcherPauseDepth > 0) watcherPauseDepth -= 1; }
+
 function startWatcher() {
   const watcher = chokidar.watch(PROJECTS_DIR, {
     ignoreInitial: true,
@@ -440,6 +497,7 @@ function startWatcher() {
   });
 
   const notify = () => {
+    if (watcherPauseDepth > 0) return;
     mainWindow?.webContents.send('data:changed');
   };
 

--- a/electron/modules/duplicate-detector.ts
+++ b/electron/modules/duplicate-detector.ts
@@ -1,0 +1,176 @@
+import { readdirSync, statSync, existsSync } from 'fs';
+import { join, basename } from 'path';
+import { resolveRealPath } from '../utils';
+
+/** Una singola cartella history in ~/.claude/projects/ candidata a duplicato. */
+export interface DuplicateFolder {
+  hash: string;
+  /** cwd autoritativo letto dai .jsonl quando disponibile, altrimenti fallback lossy da hashToPath. */
+  realPath: string;
+  /** true se realPath proviene da un .jsonl (affidabile), false se è il fallback ricostruito dal nome cartella. */
+  realPathAuthoritative: boolean;
+  /** Numero di file di sessione .jsonl nella cartella. */
+  sessionCount: number;
+  /** mtime ISO della sessione più recente, null se nessuna sessione. */
+  lastActivity: string | null;
+  /** Numero di topic .md in memory/ (escluso MEMORY.md). */
+  memoryTopicCount: number;
+  /** true se esiste memory/MEMORY.md. */
+  hasMemoryIndex: boolean;
+}
+
+/** Gruppo di cartelle che con buona probabilità sono lo stesso progetto aperto da path diversi. */
+export interface DuplicateGroup {
+  /** Chiave di raggruppamento: basename del realPath normalizzato (lowercase). */
+  key: string;
+  /** Nome leggibile del progetto (basename della cartella suggerita come primaria). */
+  name: string;
+  /** Cartelle del gruppo, ordinate con la primaria suggerita per prima. */
+  folders: DuplicateFolder[];
+}
+
+function scanFolder(projectsDir: string, hash: string): DuplicateFolder {
+  const dir = join(projectsDir, hash);
+
+  let sessionCount = 0;
+  let lastMtime = 0;
+  try {
+    for (const entry of readdirSync(dir)) {
+      if (!entry.endsWith('.jsonl')) continue;
+      sessionCount++;
+      const m = statSync(join(dir, entry)).mtimeMs;
+      if (m > lastMtime) lastMtime = m;
+    }
+  } catch {
+    // cartella illeggibile: resta a 0
+  }
+
+  let memoryTopicCount = 0;
+  let hasMemoryIndex = false;
+  const memoryDir = join(dir, 'memory');
+  if (existsSync(memoryDir)) {
+    try {
+      for (const entry of readdirSync(memoryDir)) {
+        if (!entry.endsWith('.md')) continue;
+        if (entry === 'MEMORY.md') hasMemoryIndex = true;
+        else memoryTopicCount++;
+      }
+    } catch {
+      // ignore
+    }
+  }
+
+  const realPath = resolveRealPath(projectsDir, hash);
+  // Il path è affidabile quando proviene dal cwd di una sessione. Senza sessioni
+  // resolveRealPath ricade per forza sul fallback lossy di hashToPath (path stimato).
+  // (Confrontare realPath con hashToPath sarebbe ambiguo: per i path senza '.'/'~'/spazi
+  // il fallback coincide con quello reale e marcherebbe a torto come stimato.)
+  const realPathAuthoritative = sessionCount > 0;
+
+  return {
+    hash,
+    realPath,
+    realPathAuthoritative,
+    sessionCount,
+    lastActivity: lastMtime > 0 ? new Date(lastMtime).toISOString() : null,
+    memoryTopicCount,
+    hasMemoryIndex,
+  };
+}
+
+/** Ordina le cartelle di un gruppo: la più "viva" (attività recente, poi più sessioni) per prima. */
+function sortPrimaryFirst(a: DuplicateFolder, b: DuplicateFolder): number {
+  const ta = a.lastActivity ? Date.parse(a.lastActivity) : 0;
+  const tb = b.lastActivity ? Date.parse(b.lastActivity) : 0;
+  if (tb !== ta) return tb - ta;
+  return b.sessionCount - a.sessionCount;
+}
+
+/**
+ * Rileva i progetti duplicati: cartelle history distinte che si riferiscono allo
+ * stesso progetto (stesso basename del path, case-insensitive).
+ *
+ * Operazione read-only: si limita a *segnalare* i candidati. L'identità non è certa
+ * (basename uguali possono appartenere a progetti diversi, es. due repo "api"), quindi
+ * la conferma e l'eventuale merge restano all'utente.
+ */
+/** Chiave di confronto tollerante: minuscolo, senza separatori (`.`, `-`, spazi, `/`). */
+function normKey(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+/**
+ * Chiavi candidate per una cartella-residuo (senza cwd affidabile): code di token
+ * crescenti del nome hash, normalizzate. Dalla più specifica (più token) alla meno.
+ * Es. `-Users-…-Documents-SARA2-0` → ['documentssara20', 'sara20', '0'].
+ * Serve a riconoscere che `…-Documents-SARA2-0` è lo stesso progetto di `SARA2.0`
+ * (→ 'sara20'), nonostante l'hash lossy non permetta di ricostruirne il basename.
+ */
+function candidateKeysFromHash(hash: string, maxRun = 5): string[] {
+  const tokens = hash.replace(/^-/, '').split('-').filter(Boolean);
+  const out: string[] = [];
+  for (let run = Math.min(maxRun, tokens.length); run >= 1; run--) {
+    const key = normKey(tokens.slice(tokens.length - run).join(''));
+    if (key) out.push(key);
+  }
+  return out;
+}
+
+export function detectDuplicateProjects(projectsDir: string): DuplicateGroup[] {
+  let hashes: string[];
+  try {
+    hashes = readdirSync(projectsDir).filter(name => {
+      try {
+        return statSync(join(projectsDir, name)).isDirectory();
+      } catch {
+        return false;
+      }
+    });
+  } catch {
+    return [];
+  }
+
+  const folders = hashes.map(hash => scanFolder(projectsDir, hash));
+
+  // Pass 1: le cartelle con cwd affidabile definiscono i gruppi (chiave = basename normalizzato).
+  const byKey = new Map<string, DuplicateFolder[]>();
+  const authoritativeKeys = new Set<string>();
+  for (const folder of folders) {
+    if (!folder.realPathAuthoritative) continue;
+    const key = normKey(basename(folder.realPath));
+    if (!key) continue;
+    (byKey.get(key) ?? byKey.set(key, []).get(key)!).push(folder);
+    authoritativeKeys.add(key);
+  }
+
+  // Pass 2: le cartelle-residuo (senza cwd) si agganciano a un gruppo autoritativo se
+  // una loro coda di token combacia; altrimenti restano sul proprio basename lossy
+  // (così due residui con lo stesso nome lossy continuano a raggrupparsi tra loro).
+  for (const folder of folders) {
+    if (folder.realPathAuthoritative) continue;
+    const matched = candidateKeysFromHash(folder.hash).find(k => authoritativeKeys.has(k));
+    const key = matched ?? normKey(basename(folder.realPath));
+    if (!key) continue;
+    (byKey.get(key) ?? byKey.set(key, []).get(key)!).push(folder);
+  }
+
+  const groups: DuplicateGroup[] = [];
+  for (const [key, folders] of byKey) {
+    if (folders.length < 2) continue; // solo gruppi con più di una cartella
+    folders.sort(sortPrimaryFirst);
+    groups.push({
+      key,
+      name: basename(folders[0].realPath),
+      folders,
+    });
+  }
+
+  // Gruppi con più sessioni totali per primi (più rilevanti da riordinare).
+  groups.sort((a, b) => {
+    const sa = a.folders.reduce((s, f) => s + f.sessionCount, 0);
+    const sb = b.folders.reduce((s, f) => s + f.sessionCount, 0);
+    return sb - sa;
+  });
+
+  return groups;
+}

--- a/electron/modules/duplicate-merge-executor.ts
+++ b/electron/modules/duplicate-merge-executor.ts
@@ -1,0 +1,282 @@
+import {
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+  copyFileSync,
+  renameSync,
+  unlinkSync,
+  rmSync,
+  mkdirSync,
+  existsSync,
+  statSync,
+  utimesSync,
+  cpSync,
+} from 'fs';
+import { join, dirname } from 'path';
+import { computeMergePlan, MergePlan } from './duplicate-merger';
+
+export interface MergeResult {
+  movedSessions: number;
+  renamedSessions: number;
+  movedSidecars: number;
+  cwdRewrittenFiles: number;
+  memoryCopied: number;
+  memoryRenamed: number;
+  memorySkipped: number;
+  sourceDeleted: boolean;
+  backupPath: string;
+  warnings: string[];
+}
+
+/**
+ * Riscrive in modo field-scoped il solo campo top-level `cwd` di ogni riga JSONL,
+ * e soltanto quando vale esattamente `from` (la root della source): così non tocca
+ * eventuali cwd inattesi e lascia intatte le righe malformate.
+ */
+function rewriteCwd(content: string, from: string, to: string): { text: string; changed: boolean } {
+  let changed = false;
+  const out = content.split('\n').map(line => {
+    if (!line || line.indexOf('"cwd"') === -1) return line;
+    try {
+      const obj = JSON.parse(line);
+      if (obj.cwd === from) {
+        obj.cwd = to;
+        changed = true;
+        return JSON.stringify(obj);
+      }
+    } catch {
+      // riga malformata → invariata
+    }
+    return line;
+  });
+  return { text: out.join('\n'), changed };
+}
+
+/** Sposta una directory; se source e dest sono su volumi diversi (EXDEV) ricade su copia+rimozione. */
+function moveDir(srcPath: string, destPath: string): void {
+  try {
+    renameSync(srcPath, destPath);
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === 'EXDEV') {
+      cpSync(srcPath, destPath, { recursive: true });
+      rmSync(srcPath, { recursive: true, force: true });
+    } else {
+      throw e;
+    }
+  }
+}
+
+/** Scrive atomico (tmp + rename nella stessa dir) e replica l'mtime di origine. */
+function writeAtomicPreservingMtime(srcPath: string, destPath: string, content: string): void {
+  const tmp = `${destPath}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(tmp, content, 'utf-8');
+  renameSync(tmp, destPath);
+  try {
+    const st = statSync(srcPath);
+    utimesSync(destPath, st.atime, st.mtime);
+  } catch {
+    // se non riusciamo a leggere/replicare l'mtime, non è bloccante
+  }
+}
+
+function descriptionFor(filename: string, sourceMemDir: string, sourceIndexLines: string[]): string {
+  // 1) riga indice della source che referenzia il file
+  const line = sourceIndexLines.find(l => l.includes(`(${filename})`));
+  if (line) {
+    const m = line.match(/—\s*(.*)$/) || line.match(/-\s*(.*)$/);
+    if (m && m[1]) return m[1].trim();
+  }
+  // 2) frontmatter description del topic
+  try {
+    const content = readFileSync(join(sourceMemDir, filename), 'utf-8');
+    const fm = content.match(/^---\n([\s\S]*?)\n---/);
+    const d = fm && fm[1].match(/^description:\s*(.*)$/m);
+    if (d && d[1]) return d[1].trim();
+  } catch {
+    /* ignore */
+  }
+  return '';
+}
+
+function appendIndexLine(memoryMdPath: string, filename: string, description: string): void {
+  const line = `- [${filename}](${filename}) — ${description}`;
+  if (existsSync(memoryMdPath)) {
+    const current = readFileSync(memoryMdPath, 'utf-8');
+    if (current.includes(`(${filename})`)) return; // idempotente: riga già presente
+    writeFileSync(memoryMdPath, current.replace(/\s*$/, '') + '\n' + line + '\n', 'utf-8');
+  } else {
+    writeFileSync(memoryMdPath, `# Memory Index\n\n${line}\n`, 'utf-8');
+  }
+}
+
+/** Riscrive il campo `name:` del frontmatter al nuovo slug (per i conflict-rename). */
+function rewriteFrontmatterName(content: string, newSlug: string): string {
+  return content.replace(/^(---\n)([\s\S]*?)(\n---)/, (_full, open, body, close) => {
+    const newBody = body.replace(/^name:[ \t]*.*$/m, `name: ${newSlug}`);
+    return `${open}${newBody}${close}`;
+  });
+}
+
+/**
+ * Esegue il merge della cartella source dentro la dest applicando il piano.
+ * Distruttivo: crea prima un backup completo della source (fuori da projects/),
+ * poi sposta sessioni (con cwd rewrite) e i loro sidecar, fonde memory/, aggiorna
+ * l'indice e — solo se la source resta effettivamente vuota — la elimina.
+ *
+ * In caso di errore a metà operazione esegue un **rollback best-effort**: rimuove
+ * ciò che ha creato nella dest, ripristina MEMORY.md e ricostruisce la source dal
+ * backup, così non resta uno stato ibrido. Il chiamante (main.ts) mette in pausa il
+ * watcher e notifica un solo refresh al termine.
+ */
+export function executeMerge(projectsDir: string, sourceHash: string, destHash: string): MergeResult {
+  // ── Ricalcola il piano (TOCTOU): lo stato su disco potrebbe essere cambiato ──
+  const plan: MergePlan = computeMergePlan(projectsDir, sourceHash, destHash);
+  if (plan.blockers.length > 0) {
+    throw new Error(`Merge blocked: ${plan.blockers.join('; ')}`);
+  }
+
+  const sourceDir = join(projectsDir, sourceHash);
+  const destDir = join(projectsDir, destHash);
+
+  // ── Backup completo della source, fuori dalla dir watchata da chokidar ──
+  const backupRoot = join(dirname(projectsDir), '.claudelens-backups');
+  mkdirSync(backupRoot, { recursive: true });
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const backupPath = join(backupRoot, `${sourceHash}__${stamp}`);
+  cpSync(sourceDir, backupPath, { recursive: true });
+
+  const warnings = [...plan.warnings];
+
+  // ── Stato per il rollback ──────────────────────────────────────────────────────
+  const sourceMemDir = join(sourceDir, 'memory');
+  const destMemDir = join(destDir, 'memory');
+  const memoryMdPath = join(destMemDir, 'MEMORY.md');
+  const createdInDest: string[] = []; // percorsi creati nella dest, da rimuovere su rollback
+  const destMemDirExisted = existsSync(destMemDir);
+  const destMemoryMdExisted = existsSync(memoryMdPath);
+  const destMemoryMdOriginal = destMemoryMdExisted ? readFileSync(memoryMdPath, 'utf-8') : null;
+
+  function rollback(): void {
+    for (const p of [...createdInDest].reverse()) {
+      try { rmSync(p, { recursive: true, force: true }); } catch { /* best-effort */ }
+    }
+    try {
+      if (!destMemDirExisted) {
+        rmSync(destMemDir, { recursive: true, force: true });
+      } else if (destMemoryMdExisted && destMemoryMdOriginal !== null) {
+        writeFileSync(memoryMdPath, destMemoryMdOriginal, 'utf-8');
+      } else if (!destMemoryMdExisted && existsSync(memoryMdPath)) {
+        rmSync(memoryMdPath, { force: true });
+      }
+    } catch { /* best-effort */ }
+    try {
+      rmSync(sourceDir, { recursive: true, force: true });
+      cpSync(backupPath, sourceDir, { recursive: true });
+    } catch { /* best-effort: il backup resta comunque disponibile */ }
+  }
+
+  let movedSessions = 0;
+  let renamedSessions = 0;
+  let cwdRewrittenFiles = 0;
+  let movedSidecars = 0;
+  let memoryCopied = 0;
+  let memoryRenamed = 0;
+  let memorySkipped = 0;
+
+  try {
+    // ── Sessioni ─────────────────────────────────────────────────────────────────
+    for (const s of plan.sessions) {
+      const srcPath = join(sourceDir, s.filename);
+      const destPath = join(destDir, s.targetName);
+      let content = readFileSync(srcPath, 'utf-8');
+      if (plan.cwdRewrite) {
+        const r = rewriteCwd(content, plan.cwdRewrite.from, plan.cwdRewrite.to);
+        content = r.text;
+        if (r.changed) cwdRewrittenFiles += 1;
+      }
+      writeAtomicPreservingMtime(srcPath, destPath, content);
+      createdInDest.push(destPath);
+      unlinkSync(srcPath);
+      movedSessions += 1;
+      if (s.collides) renamedSessions += 1;
+    }
+
+    // ── Directory sidecar di sessione (tool-results/, subagents/, …) ───────────────
+    for (const sc of plan.sidecars) {
+      if (sc.collides) continue; // già avvisato nel piano: non sovrascrivere la dest
+      const destSidecar = join(destDir, sc.name);
+      moveDir(join(sourceDir, sc.name), destSidecar);
+      createdInDest.push(destSidecar);
+      movedSidecars += 1;
+    }
+
+    // ── Memory ─────────────────────────────────────────────────────────────────────
+    const sourceIndexLines = (() => {
+      try {
+        return readFileSync(join(sourceMemDir, 'MEMORY.md'), 'utf-8').split('\n');
+      } catch {
+        return [];
+      }
+    })();
+    const hasMemoryWork = plan.memory.some(m => m.kind === 'copy' || m.kind === 'conflict-rename');
+    if (hasMemoryWork && !destMemDirExisted) mkdirSync(destMemDir, { recursive: true });
+
+    for (const m of plan.memory) {
+      if (m.kind === 'identical') {
+        memorySkipped += 1;
+        continue;
+      }
+      const srcPath = join(sourceMemDir, m.filename);
+      const desc = descriptionFor(m.filename, sourceMemDir, sourceIndexLines);
+      if (m.kind === 'copy') {
+        const dest = join(destMemDir, m.filename);
+        copyFileSync(srcPath, dest);
+        createdInDest.push(dest);
+        appendIndexLine(memoryMdPath, m.filename, desc);
+        memoryCopied += 1;
+      } else if (m.kind === 'conflict-rename' && m.targetName) {
+        const newSlug = m.targetName.replace(/\.md$/, '');
+        const content = rewriteFrontmatterName(readFileSync(srcPath, 'utf-8'), newSlug);
+        const dest = join(destMemDir, m.targetName);
+        writeFileSync(dest, content, 'utf-8');
+        createdInDest.push(dest);
+        appendIndexLine(memoryMdPath, m.targetName, desc);
+        memoryRenamed += 1;
+      }
+    }
+
+    // ── Cleanup source ──────────────────────────────────────────────────────────────
+    // Recheck reale (non il valore pre-merge del piano): tutte le sessioni e i sidecar
+    // spostabili sono stati consumati, e memory/ è stata fusa nella dest. La source è
+    // cancellabile solo se non resta nient'altro oltre a memory/ e .DS_Store.
+    let remaining: string[] = [];
+    try {
+      remaining = readdirSync(sourceDir).filter(n => n !== '.DS_Store' && n !== 'memory');
+    } catch { /* source assente: nessun residuo */ }
+
+    let sourceDeleted = false;
+    if (remaining.length === 0) {
+      rmSync(sourceDir, { recursive: true, force: true });
+      sourceDeleted = true;
+    } else {
+      warnings.push(`Source folder kept: still contains ${remaining.join(', ')}. Backup at ${backupPath}.`);
+    }
+
+    return {
+      movedSessions,
+      renamedSessions,
+      movedSidecars,
+      cwdRewrittenFiles,
+      memoryCopied,
+      memoryRenamed,
+      memorySkipped,
+      sourceDeleted,
+      backupPath,
+      warnings,
+    };
+  } catch (e) {
+    rollback();
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new Error(`Merge failed and was rolled back (backup at ${backupPath}): ${msg}`);
+  }
+}

--- a/electron/modules/duplicate-merger.ts
+++ b/electron/modules/duplicate-merger.ts
@@ -1,0 +1,245 @@
+import { readdirSync, readFileSync, existsSync, statSync } from 'fs';
+import { join } from 'path';
+import { resolveRealPath } from '../utils';
+
+/** Spostamento di un file di sessione dalla source alla dest. */
+export interface SessionMove {
+  filename: string;
+  /** true se nella dest esiste già un file con lo stesso nome (rename difensivo necessario). */
+  collides: boolean;
+  /** nome di destinazione effettivo (diverso da filename solo se collides). */
+  targetName: string;
+}
+
+export type MemoryActionKind =
+  | 'copy'             // nessun file con lo stesso nome nella dest → copia diretta
+  | 'identical'        // file con lo stesso nome e contenuto identico → skip
+  | 'conflict-rename'; // stesso nome, contenuto diverso → copia rinominata
+
+export interface MemoryAction {
+  filename: string;
+  kind: MemoryActionKind;
+  /** nome di destinazione quando kind === 'conflict-rename'. */
+  targetName?: string;
+}
+
+/** Directory sidecar di sessione (UUID/) che contiene tool-results/, subagents/, ecc. */
+export interface SidecarMove {
+  name: string;
+  /** true se una directory con lo stesso nome esiste già nella dest (verrà saltata). */
+  collides: boolean;
+}
+
+export interface MergePlan {
+  source: { hash: string; realPath: string; authoritative: boolean };
+  dest: { hash: string; realPath: string; authoritative: boolean };
+  /** Riscrittura cwd da applicare ai .jsonl spostati; null se non necessaria/possibile. */
+  cwdRewrite: { from: string; to: string } | null;
+  sessions: SessionMove[];
+  /** Directory sidecar per-sessione da spostare insieme ai .jsonl. */
+  sidecars: SidecarMove[];
+  memory: MemoryAction[];
+  /** true se MEMORY.md va rigenerato (la source ha topic o un indice da fondere). */
+  regenerateIndex: boolean;
+  /** true se la cartella source resterà priva di contenuti dopo il merge. */
+  sourceEmptyAfter: boolean;
+  /** Condizioni che impediscono il merge sicuro: vanno risolte prima di procedere. */
+  blockers: string[];
+  /** Avvisi non bloccanti. */
+  warnings: string[];
+}
+
+function listFiles(dir: string, predicate: (name: string) => boolean): string[] {
+  try {
+    return readdirSync(dir).filter(predicate);
+  } catch {
+    return [];
+  }
+}
+
+function listSubdirs(dir: string): string[] {
+  try {
+    return readdirSync(dir).filter(name => {
+      try {
+        return statSync(join(dir, name)).isDirectory();
+      } catch {
+        return false;
+      }
+    });
+  } catch {
+    return [];
+  }
+}
+
+function readCwdSet(filePath: string): Set<string> {
+  const out = new Set<string>();
+  try {
+    for (const line of readFileSync(filePath, 'utf-8').split('\n')) {
+      if (!line || line.indexOf('"cwd"') === -1) continue;
+      try {
+        const obj = JSON.parse(line);
+        if (typeof obj.cwd === 'string' && obj.cwd.startsWith('/')) out.add(obj.cwd);
+      } catch {
+        // riga malformata
+      }
+    }
+  } catch {
+    // file illeggibile
+  }
+  return out;
+}
+
+function uniqueRenameTarget(baseName: string, taken: Set<string>): string {
+  // baseName es. "feedback_x.md" → prova "feedback_x_2.md", "_3", ...
+  const dot = baseName.lastIndexOf('.');
+  const stem = dot === -1 ? baseName : baseName.slice(0, dot);
+  const ext = dot === -1 ? '' : baseName.slice(dot);
+  let i = 2;
+  let candidate = `${stem}_${i}${ext}`;
+  while (taken.has(candidate)) {
+    i += 1;
+    candidate = `${stem}_${i}${ext}`;
+  }
+  return candidate;
+}
+
+/**
+ * Calcola — in sola lettura — cosa comporterebbe fondere la cartella `sourceHash`
+ * dentro `destHash`. Non scrive nulla: produce il piano che alimenta il dialog di
+ * conferma e, successivamente, l'esecuzione.
+ */
+export function computeMergePlan(projectsDir: string, sourceHash: string, destHash: string): MergePlan {
+  const sourceDir = join(projectsDir, sourceHash);
+  const destDir = join(projectsDir, destHash);
+
+  const sourceSessions = listFiles(sourceDir, f => f.endsWith('.jsonl'));
+  const destSessions = listFiles(destDir, f => f.endsWith('.jsonl'));
+
+  const sourceReal = resolveRealPath(projectsDir, sourceHash);
+  const destReal = resolveRealPath(projectsDir, destHash);
+  const sourceAuthoritative = sourceSessions.length > 0;
+  const destAuthoritative = destSessions.length > 0;
+
+  const blockers: string[] = [];
+  const warnings: string[] = [];
+
+  if (sourceHash === destHash) {
+    blockers.push('Source and destination are the same folder.');
+  }
+  if (!existsSync(sourceDir)) {
+    blockers.push('Source folder no longer exists.');
+  }
+  if (!existsSync(destDir)) {
+    blockers.push('Destination folder no longer exists.');
+  }
+
+  // ── Sessioni ───────────────────────────────────────────────────────────────
+  const destSessionSet = new Set(destSessions);
+  const sessions: SessionMove[] = sourceSessions.map(filename => {
+    const collides = destSessionSet.has(filename);
+    return {
+      filename,
+      collides,
+      targetName: collides ? uniqueRenameTarget(filename, destSessionSet) : filename,
+    };
+  });
+
+  // ── Riscrittura cwd ──────────────────────────────────────────────────────────
+  let cwdRewrite: { from: string; to: string } | null = null;
+  if (sourceSessions.length > 0) {
+    if (!destAuthoritative) {
+      // Senza sessioni nella dest il cwd nuovo non è ricavabile in modo affidabile.
+      blockers.push(
+        'Cannot determine the destination cwd reliably: the destination folder has no sessions to read it from.',
+      );
+    } else if (sourceReal !== destReal) {
+      cwdRewrite = { from: sourceReal, to: destReal };
+      // Verifica che la source contenga davvero quel cwd (sanity check informativo).
+      const sample = sourceSessions
+        .map(f => readCwdSet(join(sourceDir, f)))
+        .find(set => set.size > 0);
+      if (sample && !sample.has(sourceReal)) {
+        warnings.push('Source sessions reference a cwd different from the resolved source path; rewrite will target the destination cwd anyway.');
+      }
+    }
+  }
+
+  // ── Memory ───────────────────────────────────────────────────────────────────
+  const sourceMemDir = join(sourceDir, 'memory');
+  const destMemDir = join(destDir, 'memory');
+  const sourceTopics = listFiles(sourceMemDir, f => f.endsWith('.md') && f !== 'MEMORY.md');
+  const destTopicSet = new Set(listFiles(destMemDir, f => f.endsWith('.md') && f !== 'MEMORY.md'));
+  const takenTargets = new Set(destTopicSet);
+
+  const memory: MemoryAction[] = [];
+  for (const filename of sourceTopics) {
+    if (!destTopicSet.has(filename)) {
+      memory.push({ filename, kind: 'copy' });
+      takenTargets.add(filename);
+      continue;
+    }
+    // stesso nome: confronta il contenuto
+    let identical = false;
+    try {
+      const a = readFileSync(join(sourceMemDir, filename), 'utf-8');
+      const b = readFileSync(join(destMemDir, filename), 'utf-8');
+      identical = a === b;
+    } catch {
+      // se illeggibile, trattalo come conflitto prudenziale
+    }
+    if (identical) {
+      memory.push({ filename, kind: 'identical' });
+    } else {
+      const targetName = uniqueRenameTarget(filename, takenTargets);
+      takenTargets.add(targetName);
+      memory.push({ filename, kind: 'conflict-rename', targetName });
+      warnings.push(`Memory "${filename}" exists in both with different content → kept as "${targetName}". Wikilinks to its slug may become ambiguous.`);
+    }
+  }
+
+  const sourceHasMemoryIndex = existsSync(join(sourceMemDir, 'MEMORY.md'));
+  const regenerateIndex =
+    memory.some(m => m.kind === 'copy' || m.kind === 'conflict-rename') || sourceHasMemoryIndex;
+
+  // ── Directory sidecar di sessione (UUID/ con tool-results/, subagents/, …) ──────
+  // Sono tutte le sottocartelle della source diverse da memory/. Vanno spostate
+  // insieme ai .jsonl, altrimenti tool-results e subagent transcripts restano orfani.
+  const destSubdirSet = new Set(listSubdirs(destDir));
+  const sidecars: SidecarMove[] = listSubdirs(sourceDir)
+    .filter(name => name !== 'memory')
+    .map(name => {
+      const collides = destSubdirSet.has(name);
+      if (collides) {
+        warnings.push(`Session folder "${name}" already exists in the destination → left in place (not overwritten).`);
+      }
+      return { name, collides };
+    });
+  const movableSidecars = new Set(sidecars.filter(s => !s.collides).map(s => s.name));
+
+  // ── Stato finale della source ──────────────────────────────────────────────────
+  // Il merge consuma sessioni (.jsonl), memory/ e le sidecar spostabili. La source
+  // è cancellabile solo se non resta nient'altro (oltre a .DS_Store).
+  let sourceEntries: string[] = [];
+  try {
+    sourceEntries = readdirSync(sourceDir);
+  } catch {
+    /* ignore */
+  }
+  const leftovers = sourceEntries.filter(
+    n => n !== 'memory' && n !== '.DS_Store' && !n.endsWith('.jsonl') && !movableSidecars.has(n),
+  );
+  const sourceEmptyAfter = leftovers.length === 0;
+
+  return {
+    source: { hash: sourceHash, realPath: sourceReal, authoritative: sourceAuthoritative },
+    dest: { hash: destHash, realPath: destReal, authoritative: destAuthoritative },
+    cwdRewrite,
+    sessions,
+    sidecars,
+    memory,
+    regenerateIndex,
+    sourceEmptyAfter,
+    blockers,
+    warnings,
+  };
+}

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -45,6 +45,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
   projects: {
     delete: (hash: string) => ipcRenderer.invoke('projects:delete', hash),
+    detectDuplicates: () => ipcRenderer.invoke('projects:detectDuplicates'),
+    planMerge: (sourceHash: string, destHash: string) =>
+      ipcRenderer.invoke('projects:planMerge', sourceHash, destHash),
+    executeMerge: (sourceHash: string, destHash: string) =>
+      ipcRenderer.invoke('projects:executeMerge', sourceHash, destHash),
   },
   ai: {
     run: (instruction: string, inputContent: string, projectPath: string) =>

--- a/electron/utils.ts
+++ b/electron/utils.ts
@@ -15,6 +15,12 @@ export function pathToHash(realPath: string): string {
 // Cache per evitare di rileggere lo stesso jsonl più volte nella stessa sessione.
 const cwdCache = new Map<string, string>()
 
+/** Invalida la cache del cwd dopo che il contenuto di una cartella è cambiato (es. merge). */
+export function invalidateCwdCache(hash?: string): void {
+  if (hash) cwdCache.delete(hash)
+  else cwdCache.clear()
+}
+
 export function resolveRealPath(projectsDir: string, hash: string): string {
   const cached = cwdCache.get(hash)
   if (cached) return cached

--- a/src/components/project/overview/DuplicateProjectsNotice.tsx
+++ b/src/components/project/overview/DuplicateProjectsNotice.tsx
@@ -1,0 +1,302 @@
+import { useState } from 'react'
+import {
+  useDuplicateProjects,
+  useExecuteMerge,
+  planMerge,
+  type DuplicateFolder,
+  type MergePlan,
+  type MergeResult,
+} from '../../../hooks/useIPC'
+import { View } from '../types'
+import { BackButton } from '../shared/BackButton'
+import { MergeConfirmDialog } from '../shared/MergeConfirmDialog'
+
+function shortWhen(iso: string | null): string {
+  if (!iso) return 'no sessions'
+  const d = new Date(iso)
+  if (isNaN(d.getTime())) return '—'
+  return d.toLocaleString('en-US', { day: '2-digit', month: 'short', year: '2-digit' })
+}
+
+function FolderRow({
+  folder,
+  primary,
+  onMerge,
+}: {
+  folder: DuplicateFolder
+  primary: boolean
+  onMerge?: () => void
+}) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        padding: '10px 14px',
+        borderRadius: 8,
+        border: '1px solid var(--cl-line)',
+        background: primary ? 'var(--cl-ok-soft, transparent)' : 'transparent',
+      }}
+    >
+      <span
+        style={{
+          fontFamily: 'var(--font-mono)',
+          fontSize: 10,
+          fontWeight: 700,
+          letterSpacing: '0.06em',
+          textTransform: 'uppercase',
+          color: primary ? 'var(--cl-ok)' : 'var(--cl-warn)',
+          minWidth: 84,
+        }}
+      >
+        {primary ? '● primary' : '○ duplicate'}
+      </span>
+      <div style={{ minWidth: 0, flex: 1 }}>
+        <div
+          style={{
+            fontFamily: 'var(--font-mono)',
+            fontSize: 12,
+            color: 'var(--cl-ink)',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+          title={folder.realPath}
+        >
+          {folder.realPath}
+          {!folder.realPathAuthoritative && (
+            <span style={{ color: 'var(--cl-warn)', marginLeft: 8 }}>· estimated path</span>
+          )}
+        </div>
+        <div style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--cl-ink-2, var(--cl-ink))', opacity: 0.6 }}>
+          {folder.sessionCount} sessions · {folder.memoryTopicCount} memory
+          {folder.hasMemoryIndex ? ' (+index)' : ''} · last {shortWhen(folder.lastActivity)}
+        </div>
+      </div>
+      {onMerge && (
+        <button
+          type="button"
+          onClick={onMerge}
+          style={{
+            flexShrink: 0,
+            fontFamily: 'var(--font-mono)',
+            fontSize: 11,
+            fontWeight: 600,
+            padding: '5px 10px',
+            borderRadius: 6,
+            border: '1px solid var(--cl-line)',
+            background: 'transparent',
+            color: 'var(--cl-ink)',
+            cursor: 'pointer',
+          }}
+        >
+          Merge into primary →
+        </button>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Compact signal shown in the global home: a clickable row that opens the
+ * dedicated view. Renders nothing when there are no duplicates.
+ */
+export function DuplicateProjectsBadge({ onNavigate }: { onNavigate: (v: View) => void }) {
+  const { data: groups = [] } = useDuplicateProjects()
+  if (groups.length === 0) return null
+
+  return (
+    <button
+      type="button"
+      onClick={() => onNavigate({ type: 'duplicates' })}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 10,
+        width: '100%',
+        padding: '8px 14px',
+        margin: '0 0 18px',
+        borderRadius: 8,
+        border: '1px solid var(--cl-line)',
+        background: 'var(--cl-warn-soft)',
+        cursor: 'pointer',
+        textAlign: 'left',
+      }}
+    >
+      <span style={{ color: 'var(--cl-warn)', fontSize: 13 }}>⚠</span>
+      <span style={{ fontSize: 13, color: 'var(--cl-ink)', flex: 1 }}>
+        {groups.length} possible duplicate {groups.length === 1 ? 'project' : 'projects'} detected
+      </span>
+      <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--cl-ink)', opacity: 0.55 }}>
+        details →
+      </span>
+    </button>
+  )
+}
+
+/** Dedicated view: short explanation + the intercepted duplicates. */
+export function DuplicateProjectsView({ onBack }: { onBack: () => void }) {
+  const { data: groups = [] } = useDuplicateProjects()
+  const executeMerge = useExecuteMerge()
+  const [dialog, setDialog] = useState<
+    { plan: MergePlan; source: DuplicateFolder; dest: DuplicateFolder; sourceName: string; destName: string } | null
+  >(null)
+  const [planError, setPlanError] = useState<string | null>(null)
+  const [result, setResult] = useState<MergeResult | null>(null)
+
+  function name(realPath: string): string {
+    return realPath.split('/').pop() || realPath
+  }
+
+  async function openMerge(source: DuplicateFolder, dest: DuplicateFolder) {
+    setPlanError(null)
+    try {
+      const plan = await planMerge(source.hash, dest.hash)
+      setDialog({ plan, source, dest, sourceName: name(source.realPath), destName: name(dest.realPath) })
+    } catch (e) {
+      setPlanError(e instanceof Error ? e.message : String(e))
+    }
+  }
+
+  async function confirmMerge() {
+    if (!dialog) return
+    try {
+      const res = await executeMerge.mutateAsync({
+        sourceHash: dialog.source.hash,
+        destHash: dialog.dest.hash,
+      })
+      setDialog(null)
+      setResult(res)
+    } catch (e) {
+      setPlanError(e instanceof Error ? e.message : String(e))
+      setDialog(null)
+    }
+  }
+
+  return (
+    <div style={{ height: '100%', overflow: 'auto', padding: '20px 28px' }}>
+      <BackButton label="Global" onClick={onBack} />
+
+      <div className="cl-sec-head" style={{ marginTop: 12 }}>
+        <h2>Possible duplicates</h2>
+        <span className="ct">
+          {groups.length} {groups.length === 1 ? 'project' : 'projects'} appear in multiple paths
+        </span>
+      </div>
+
+      <div
+        style={{
+          fontSize: 13,
+          lineHeight: 1.5,
+          color: 'var(--cl-ink)',
+          opacity: 0.8,
+          margin: '14px 0 22px',
+          padding: '12px 16px',
+          borderRadius: 8,
+          background: 'var(--cl-warn-soft)',
+          border: '1px solid var(--cl-line)',
+          maxWidth: 720,
+        }}
+      >
+        Claude Code identifies projects by <b>absolute path</b>: the same project opened from
+        different folders (e.g. moved from Desktop to Projects) produces separate histories. The
+        old folder often keeps only its <code style={{ fontFamily: 'var(--font-mono)' }}>memory/</code>,
+        because sessions get removed by Claude Code's retention. ClaudeLens{' '}
+        <b>flags them</b> — nothing is moved until you choose to merge a folder into the primary one.
+      </div>
+
+      {planError && (
+        <div
+          style={{
+            fontSize: 12,
+            color: 'var(--cl-danger)',
+            margin: '0 0 16px',
+            padding: '8px 12px',
+            borderRadius: 8,
+            border: '1px solid var(--cl-danger)',
+            background: 'var(--cl-danger-soft)',
+            maxWidth: 720,
+          }}
+        >
+          Failed to compute merge plan: {planError}
+        </div>
+      )}
+
+      {groups.length === 0 ? (
+        <div className="cl-empty">No duplicates detected.</div>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 20, maxWidth: 860 }}>
+          {groups.map(group => (
+            <div key={group.key}>
+              <div
+                style={{
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 12,
+                  fontWeight: 700,
+                  letterSpacing: '0.04em',
+                  color: 'var(--cl-ink)',
+                  marginBottom: 8,
+                }}
+              >
+                {group.name}{' '}
+                <span style={{ opacity: 0.5, fontWeight: 400 }}>· {group.folders.length} folders</span>
+              </div>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                {group.folders.map((folder, i) => (
+                  <FolderRow
+                    key={folder.hash}
+                    folder={folder}
+                    primary={i === 0}
+                    onMerge={i === 0 ? undefined : () => openMerge(folder, group.folders[0])}
+                  />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {dialog && (
+        <MergeConfirmDialog
+          plan={dialog.plan}
+          sourceName={dialog.sourceName}
+          destName={dialog.destName}
+          isLoading={executeMerge.isLoading}
+          canExecute={true}
+          onConfirm={confirmMerge}
+          onCancel={() => setDialog(null)}
+        />
+      )}
+
+      {result && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-[var(--cl-paper-2)] rounded-lg shadow-lg p-6 max-w-md w-full mx-4">
+            <h3 className="text-[15px] font-semibold text-[var(--cl-ink)] mb-3">Merge complete</h3>
+            <ul className="text-[13px] text-[var(--cl-ink-3)] space-y-1 mb-4">
+              <li>{result.movedSessions} sessions moved{result.renamedSessions > 0 ? ` (${result.renamedSessions} renamed)` : ''}</li>
+              <li>{result.movedSidecars} session data folders moved</li>
+              <li>{result.cwdRewrittenFiles} sessions had their cwd rewritten</li>
+              <li>{result.memoryCopied} memory copied · {result.memoryRenamed} renamed · {result.memorySkipped} identical</li>
+              <li>{result.sourceDeleted ? 'Source folder deleted' : 'Source folder kept'}</li>
+            </ul>
+            <div className="bg-[var(--cl-paper-3)] border border-[var(--cl-line)] rounded-lg p-3 mb-4 font-mono text-[11px] text-[var(--cl-ink-3)] break-all">
+              backup: {result.backupPath}
+            </div>
+            {result.warnings.length > 0 && (
+              <ul className="text-[12px] text-[var(--cl-warn)] list-disc pl-4 space-y-1 mb-4">
+                {result.warnings.map((w, i) => <li key={i}>{w}</li>)}
+              </ul>
+            )}
+            <button
+              onClick={() => setResult(null)}
+              className="w-full px-4 py-2 rounded-lg bg-[var(--cl-accent)] text-[var(--cl-on-accent)] text-[13px] font-medium"
+            >
+              Done
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/project/overview/GlobalHomeView.tsx
+++ b/src/components/project/overview/GlobalHomeView.tsx
@@ -12,6 +12,7 @@ import {
 import { View } from '../types'
 import type { ProjectCost } from '../../../types'
 import { Lens } from './Lens'
+import { DuplicateProjectsBadge } from './DuplicateProjectsNotice'
 
 type Project = { hash: string; realPath: string }
 
@@ -144,6 +145,9 @@ export function GlobalHomeView({
           <span><b>{mcpServers.length}</b> MCP servers</span>
         </div>
       </section>
+
+      {/* ─── DUPLICATE PROJECTS (segnale compatto) ────── */}
+      <DuplicateProjectsBadge onNavigate={onNavigate} />
 
       {/* ─── LIVE PROCESSES ───────────────────────────── */}
       {procs.length > 0 && (

--- a/src/components/project/shared/MergeConfirmDialog.tsx
+++ b/src/components/project/shared/MergeConfirmDialog.tsx
@@ -1,0 +1,139 @@
+import type { MergePlan } from '../../../hooks/useIPC'
+
+interface MergeConfirmDialogProps {
+  plan: MergePlan
+  sourceName: string
+  destName: string
+  isLoading: boolean
+  /** Finché l'esecuzione del merge non è disponibile, il bottone di conferma resta disattivato. */
+  canExecute: boolean
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export function MergeConfirmDialog({
+  plan,
+  sourceName,
+  destName,
+  isLoading,
+  canExecute,
+  onConfirm,
+  onCancel,
+}: MergeConfirmDialogProps) {
+  const moved = plan.sessions.length
+  const renamed = plan.sessions.filter(s => s.collides).length
+  const memCopy = plan.memory.filter(m => m.kind === 'copy').length
+  const memConflicts = plan.memory.filter(m => m.kind === 'conflict-rename')
+  const memIdentical = plan.memory.filter(m => m.kind === 'identical').length
+  const hasBlockers = plan.blockers.length > 0
+  const confirmDisabled = hasBlockers || !canExecute || isLoading
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-[var(--cl-paper-2)] rounded-lg shadow-lg p-6 max-w-lg w-full mx-4 max-h-[85vh] overflow-auto">
+        <h3 className="text-[15px] font-semibold text-[var(--cl-ink)] mb-1">Merge into primary</h3>
+        <p className="text-[13px] text-[var(--cl-ink-3)] mb-4">
+          Move <span className="font-mono">{sourceName}</span> into{' '}
+          <span className="font-mono">{destName}</span>.
+        </p>
+
+        {/* Blockers — stop the merge */}
+        {hasBlockers && (
+          <div className="rounded-lg border border-[var(--cl-danger)] bg-[var(--cl-danger-soft)] p-3 mb-4">
+            <div className="text-[12px] font-semibold text-[var(--cl-danger)] mb-1">Cannot merge</div>
+            <ul className="text-[12px] text-[var(--cl-ink-3)] list-disc pl-4 space-y-1">
+              {plan.blockers.map((b, i) => <li key={i}>{b}</li>)}
+            </ul>
+          </div>
+        )}
+
+        {/* Plan summary */}
+        <div className="space-y-3 text-[13px] text-[var(--cl-ink-3)] mb-4">
+          <PlanRow label="Sessions">
+            {moved === 0 ? 'none' : `${moved} moved${renamed > 0 ? ` (${renamed} renamed to avoid collision)` : ''}`}
+          </PlanRow>
+
+          <PlanRow label="Session data">
+            {plan.sidecars.length === 0
+              ? 'none'
+              : `${plan.sidecars.filter(s => !s.collides).length} folders moved${plan.sidecars.some(s => s.collides) ? ` (${plan.sidecars.filter(s => s.collides).length} kept in place)` : ''}`}
+          </PlanRow>
+
+          <PlanRow label="cwd rewrite">
+            {plan.cwdRewrite ? (
+              <span className="font-mono text-[11px] break-all">
+                {plan.cwdRewrite.from} → {plan.cwdRewrite.to}
+              </span>
+            ) : 'not needed'}
+          </PlanRow>
+
+          <PlanRow label="Memory">
+            {memCopy + memConflicts.length + memIdentical === 0
+              ? 'none'
+              : `${memCopy} copied · ${memConflicts.length} conflict${memConflicts.length === 1 ? '' : 's'} · ${memIdentical} identical (skipped)`}
+            {memConflicts.length > 0 && (
+              <ul className="mt-1 text-[11px] font-mono text-[var(--cl-ink-4)] list-disc pl-4">
+                {memConflicts.map(m => (
+                  <li key={m.filename}>{m.filename} → {m.targetName}</li>
+                ))}
+              </ul>
+            )}
+          </PlanRow>
+
+          <PlanRow label="Index">
+            {plan.regenerateIndex ? 'MEMORY.md updated' : 'unchanged'}
+          </PlanRow>
+
+          <PlanRow label="Source folder">
+            {plan.sourceEmptyAfter
+              ? 'deleted (empty after merge)'
+              : 'kept (still contains other files)'}
+          </PlanRow>
+        </div>
+
+        {/* Warnings — non-blocking */}
+        {plan.warnings.length > 0 && (
+          <div className="rounded-lg border border-[var(--cl-line)] bg-[var(--cl-warn-soft)] p-3 mb-4">
+            <div className="text-[12px] font-semibold text-[var(--cl-warn)] mb-1">Warnings</div>
+            <ul className="text-[12px] text-[var(--cl-ink-3)] list-disc pl-4 space-y-1">
+              {plan.warnings.map((w, i) => <li key={i}>{w}</li>)}
+            </ul>
+          </div>
+        )}
+
+        <p className="text-[11px] text-[var(--cl-ink-4)] mb-5">
+          A backup of the source folder is created before any change.
+          {!canExecute && ' Execution is not available yet — this is a preview of the plan.'}
+        </p>
+
+        <div className="flex gap-3">
+          <button
+            onClick={onCancel}
+            className="flex-1 px-4 py-2 rounded-lg border border-[var(--cl-line)] hover:bg-[var(--cl-paper-3)] transition-colors text-[13px] font-medium text-[var(--cl-ink-3)]"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={confirmDisabled}
+            title={!canExecute ? 'Merge execution is not available yet' : undefined}
+            className="flex-1 px-4 py-2 rounded-lg bg-[var(--cl-accent)] hover:bg-[var(--cl-accent)] disabled:opacity-40 transition-colors text-[13px] font-medium text-[var(--cl-on-accent)]"
+          >
+            {isLoading ? 'Merging…' : 'Merge'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function PlanRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex gap-3">
+      <span className="text-[11px] font-mono uppercase tracking-wide text-[var(--cl-ink-4)] min-w-[96px] pt-0.5">
+        {label}
+      </span>
+      <div className="flex-1 min-w-0">{children}</div>
+    </div>
+  )
+}

--- a/src/components/project/types.ts
+++ b/src/components/project/types.ts
@@ -24,6 +24,7 @@ export type View =
   | { type: 'ai-assistant'; project: { hash: string; realPath: string } }
   | { type: 'live-monitor'; project: { hash: string; realPath: string } }
   | { type: 'agents-live'; project?: { hash: string; realPath: string } }
+  | { type: 'duplicates' }
 
 export const TYPE_STYLES: Record<string, string> = {
   user:      'bg-blue-950/20 text-blue-400 ring-1 ring-blue-700/30',

--- a/src/hooks/useIPC.ts
+++ b/src/hooks/useIPC.ts
@@ -48,6 +48,62 @@ export type {
 
 type IpcResult<T> = { data: T | null; error: string | null }
 
+export interface DuplicateFolder {
+  hash: string
+  realPath: string
+  realPathAuthoritative: boolean
+  sessionCount: number
+  lastActivity: string | null
+  memoryTopicCount: number
+  hasMemoryIndex: boolean
+}
+
+export interface DuplicateGroup {
+  key: string
+  name: string
+  folders: DuplicateFolder[]
+}
+
+export interface SessionMove {
+  filename: string
+  collides: boolean
+  targetName: string
+}
+
+export type MemoryActionKind = 'copy' | 'identical' | 'conflict-rename'
+
+export interface MemoryAction {
+  filename: string
+  kind: MemoryActionKind
+  targetName?: string
+}
+
+export interface MergeResult {
+  movedSessions: number
+  renamedSessions: number
+  movedSidecars: number
+  cwdRewrittenFiles: number
+  memoryCopied: number
+  memoryRenamed: number
+  memorySkipped: number
+  sourceDeleted: boolean
+  backupPath: string
+  warnings: string[]
+}
+
+export interface MergePlan {
+  source: { hash: string; realPath: string; authoritative: boolean }
+  dest: { hash: string; realPath: string; authoritative: boolean }
+  cwdRewrite: { from: string; to: string } | null
+  sessions: SessionMove[]
+  sidecars: { name: string; collides: boolean }[]
+  memory: MemoryAction[]
+  regenerateIndex: boolean
+  sourceEmptyAfter: boolean
+  blockers: string[]
+  warnings: string[]
+}
+
 declare global {
   interface Window {
     electronAPI: {
@@ -60,6 +116,9 @@ declare global {
       }
       projects: {
         delete: (hash: string) => Promise<IpcResult<null>>
+        detectDuplicates: () => Promise<IpcResult<DuplicateGroup[]>>
+        planMerge: (sourceHash: string, destHash: string) => Promise<IpcResult<MergePlan>>
+        executeMerge: (sourceHash: string, destHash: string) => Promise<IpcResult<MergeResult>>
       }
       cost: {
         getSummary: () => Promise<IpcResult<ProjectCost[]>>
@@ -124,6 +183,33 @@ async function unwrap<T>(promise: Promise<IpcResult<T>>): Promise<T> {
 export function useMemoryProjects() {
   return useQuery('memory:projects', () =>
     unwrap(window.electronAPI.memory.listProjects())
+  )
+}
+
+export function useDuplicateProjects() {
+  return useQuery('projects:duplicates', () =>
+    unwrap(window.electronAPI.projects.detectDuplicates())
+  )
+}
+
+/** Calcola il piano di merge (read-only) per una coppia source → dest. */
+export function planMerge(sourceHash: string, destHash: string): Promise<MergePlan> {
+  return unwrap(window.electronAPI.projects.planMerge(sourceHash, destHash))
+}
+
+/** Mutation: esegue il merge e invalida le query sui duplicati/progetti. */
+export function useExecuteMerge() {
+  const qc = useQueryClient()
+  return useMutation(
+    ({ sourceHash, destHash }: { sourceHash: string; destHash: string }) =>
+      unwrap(window.electronAPI.projects.executeMerge(sourceHash, destHash)),
+    {
+      onSuccess: () => {
+        qc.invalidateQueries('projects:duplicates')
+        qc.invalidateQueries('memory:projects')
+        qc.invalidateQueries('cost:summary')
+      },
+    },
   )
 }
 

--- a/src/tabs/ProjectOverview.tsx
+++ b/src/tabs/ProjectOverview.tsx
@@ -30,6 +30,7 @@ import { AiAssistantView } from '../components/project/ai-assistant/AiAssistantV
 // ─── Editorial core
 import { ProjectView, type ProjectSection } from '../components/project/overview/ProjectOverviewContent'
 import { GlobalHomeView } from '../components/project/overview/GlobalHomeView'
+import { DuplicateProjectsView } from '../components/project/overview/DuplicateProjectsNotice'
 import { ProjectSubtabs } from '../components/project/overview/ProjectSubtabs'
 
 type Project = { hash: string; realPath: string }
@@ -221,6 +222,8 @@ export default function ProjectOverview() {
             onOpenSession={(project, session) => setView({ type: 'chat', project, session })}
           />
         )
+      case 'duplicates':
+        return <DuplicateProjectsView onBack={goGlobal} />
       default:
         return null
     }


### PR DESCRIPTION
## Summary

Claude Code keys project history by **absolute path**, so the same project opened from different paths (e.g. moved Desktop → Projects, or iCloud → Projects) produces separate folders under `~/.claude/projects/`. This adds detection of those duplicates and an **on-demand, opt-in merge**.

Nothing is moved or modified until the user explicitly confirms a merge.

## What's included

**Backend (`electron/modules/`)**
- `duplicate-detector.ts` — read-only grouping by normalized basename. Leftover folders that have no sessions (so their real `cwd` can't be read) attach to their authoritative group via token-tail matching, since the lossy hash (`/`,`.`,`~` → `-`) can't be reversed reliably.
- `duplicate-merger.ts` — read-only **merge plan**: sessions to move, session sidecar dirs (`<uuid>/` with `tool-results/`, `subagents/`), field-scoped `cwd` rewrite, memory actions (copy / conflict-rename / identical), blockers and warnings.
- `duplicate-merge-executor.ts` — destructive apply: full source backup first (outside `projects/`), cross-volume-safe moves (`EXDEV` fallback), mtime preservation, idempotent index update, real source-empty recheck before deletion, and **best-effort rollback** from backup on error.

**IPC / main**
- `projects:detectDuplicates | planMerge | executeMerge` handlers with hash validation (rejects path traversal) and a **reentrant** chokidar watcher pause; `cwdCache` invalidated after merge.

**UI (`src/`)**
- Compact badge on the global home → dedicated "Possible duplicates" view → merge confirm dialog (plan preview) → result screen. All UI text in English.

## Safety properties

- Read-only detection & planning; merge requires explicit confirmation.
- Automatic backup of the source folder before any change (`~/.claude/.claudelens-backups/`).
- `cwd` rewrite is **field-scoped** (parses each JSONL line, rewrites only the top-level `cwd` when it equals the source root) — never a blind text replace; malformed lines pass through untouched.
- Source folder deleted only when genuinely empty after the merge.
- Best-effort rollback restores source + dest + `MEMORY.md` if anything fails mid-way.

## Validation

No automated test suite in this repo — validated against real `~/.claude/` data and with targeted sandbox scenarios (rollback on mid-merge failure, idempotent index, real source recheck, hash validation, EXDEV cross-volume moves, malformed JSONL preservation, memory conflict rename + frontmatter fix). `tsc` clean for both electron and renderer.

## Known follow-ups (not in this PR)

- Backups accumulate in `~/.claude/.claudelens-backups/` with no retention/cleanup yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)