### PR TITLE
Add AI-generated and first-message session titles

### DIFF
--- a/electron/modules/cost-tracker.ts
+++ b/electron/modules/cost-tracker.ts
@@ -30,6 +30,8 @@ export interface SessionSummary {
   model?: string;          // modello dominante (retrocompatibilità)
   models: Record<string, number>; // conteggio messaggi per modello
   customTitle?: string;
+  aiTitle?: string;
+  firstUserMessage?: string;
 }
 
 // ─── Pricing table (prezzi per milione di token) ──────────────────────────────
@@ -105,11 +107,15 @@ interface ParsedSession {
   model: string | undefined;  // modello dominante
   models: Record<string, number>;
   customTitle?: string;
+  aiTitle?: string;
+  firstUserMessage?: string;
 }
 
 interface LineData {
   date: string;
   customTitle: string | undefined;
+  aiTitle: string | undefined;
+  firstUserMessage: string | undefined;
   inputTokens: number;
   outputTokens: number;
   cacheWriteTokens: number;
@@ -117,18 +123,51 @@ interface LineData {
   model: string | undefined;
 }
 
+function extractFirstUserText(json: Record<string, unknown>): string | undefined {
+  if (json.type !== 'user') return undefined;
+  if (json.isMeta === true || json.isSidechain === true) return undefined;
+  const msg = json.message as Record<string, unknown> | undefined;
+  if (!msg) return undefined;
+  const raw = msg.content;
+
+  let text = '';
+  if (typeof raw === 'string') {
+    text = raw;
+  } else if (Array.isArray(raw)) {
+    for (const block of raw) {
+      if (block && typeof block === 'object') {
+        const b = block as Record<string, unknown>;
+        if (b.type === 'text' && typeof b.text === 'string') {
+          text = b.text;
+          break;
+        }
+      }
+    }
+  }
+
+  // Salta messaggi tecnici (caveat, comandi, tool_result)
+  const stripped = text.replace(/<[^>]+>/g, '').trim();
+  if (!stripped) return undefined;
+  if (stripped.startsWith('Caveat:') || stripped.startsWith('[Request interrupted')) return undefined;
+  return stripped;
+}
+
 function parseJsonlLine(line: string): LineData | null {
   try {
     const json = JSON.parse(line);
     const date = json.timestamp ? new Date(json.timestamp).toISOString() : '';
     const customTitle = json.type === 'custom-title' ? (json.customTitle as string | undefined) : undefined;
+    const aiTitle = json.type === 'ai-title' ? (json.aiTitle as string | undefined) : undefined;
+    const firstUserMessage = extractFirstUserText(json as Record<string, unknown>);
     const usage = json.message?.usage;
-    if (!usage && !date && !customTitle) return null;
+    if (!usage && !date && !customTitle && !aiTitle && !firstUserMessage) return null;
 
     const model: string | undefined = json.message?.model;
     return {
       date,
       customTitle,
+      aiTitle,
+      firstUserMessage,
       inputTokens:      usage?.input_tokens                  ?? 0,
       outputTokens:     usage?.output_tokens                 ?? 0,
       cacheWriteTokens: usage?.cache_creation_input_tokens   ?? 0,
@@ -144,6 +183,7 @@ function parseJsonlSession(filePath: string): ParsedSession {
   const result: ParsedSession = {
     inputTokens: 0, outputTokens: 0, cacheWriteTokens: 0, cacheReadTokens: 0,
     messageCount: 0, date: '', model: undefined, models: {}, customTitle: undefined,
+    aiTitle: undefined, firstUserMessage: undefined,
   };
 
   if (!existsSync(filePath)) return result;
@@ -157,6 +197,8 @@ function parseJsonlSession(filePath: string): ParsedSession {
       if (!parsed) continue;
 
       if (parsed.customTitle) result.customTitle = parsed.customTitle;
+      if (parsed.aiTitle) result.aiTitle = parsed.aiTitle;
+      if (!result.firstUserMessage && parsed.firstUserMessage) result.firstUserMessage = parsed.firstUserMessage;
       if (!result.date && parsed.date) result.date = parsed.date;
 
       if (parsed.inputTokens || parsed.outputTokens) {
@@ -282,6 +324,8 @@ export async function getSessionList(projectPath: string): Promise<SessionSummar
         model: s.model,
         models: s.models,
         customTitle: s.customTitle,
+        aiTitle: s.aiTitle,
+        firstUserMessage: s.firstUserMessage,
       });
     } catch {
       // sessione non leggibile

--- a/src/components/project/chat/ChatView.tsx
+++ b/src/components/project/chat/ChatView.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useChatSession } from '../../../hooks/useIPC'
 import { SessionSummary } from '../../../hooks/useIPC'
-import { fmt, fmtDate, fmtModel, modelColor } from '../utils'
+import { fmt, fmtDate, fmtModel, modelColor, sessionTitle } from '../utils'
 import { buildProcessedMessages, isMemoryFile, ChatDetailsFilter, ToolGroup } from './utils'
 import { ToolDetailPanel } from './ToolDetailPanel'
 import { MessageBubble } from './MessageBubble'
@@ -40,7 +40,8 @@ export function ChatView({
     .sort((a, b) => b[1] - a[1])
   const totalToolCalls = toolSummary.reduce((s, [, c]) => s + c, 0)
 
-  const sessionTitle = session.customTitle || fmtDate(session.date)
+  const title = sessionTitle(session)
+  const sessionId = session.filename.replace(/\.jsonl$/, '').slice(0, 8)
   const primaryModel = session.models ? Object.keys(session.models).filter(k => k !== '<synthetic>')[0] ?? null : null
 
   return (
@@ -93,7 +94,7 @@ export function ChatView({
           textOverflow: 'ellipsis',
           whiteSpace: 'nowrap',
         }}>
-          {sessionTitle}
+          {title}
         </span>
 
         <div style={{ display: 'inline-flex', alignItems: 'center', gap: '10px', marginLeft: 'auto' }}>
@@ -196,14 +197,14 @@ export function ChatView({
             color: 'var(--cl-ink)',
             marginBottom: '10px',
           }}>
-            {sessionTitle}
+            {title}
           </h1>
           <div style={{
             fontFamily: 'var(--font-mono)',
             fontSize: '11px',
             color: 'var(--cl-ink-3)',
           }}>
-            {session.filename}
+            <span title={session.filename}>#{sessionId}</span>
             {primaryModel && (
               <span style={{ color: modelColor(primaryModel), marginLeft: '12px' }}>
                 {fmtModel(primaryModel)}

--- a/src/components/project/overview/ProjectOverviewContent.tsx
+++ b/src/components/project/overview/ProjectOverviewContent.tsx
@@ -16,7 +16,7 @@ import {
   ClaudeProcess,
 } from '../../../hooks/useIPC'
 import { View } from '../types'
-import { fmt, fmtModel } from '../utils'
+import { fmt, fmtModel, sessionTitle } from '../utils'
 import type { SessionSummary, ProjectCost } from '../../../types'
 import { Lens } from './Lens'
 
@@ -668,10 +668,12 @@ function SessionRows({ sessions, cleanupDays, onOpen }: { sessions: SessionSumma
             <span className="idx">{String(i + 1).padStart(2, '0')}</span>
             <div style={{ minWidth: 0 }}>
               <div className="title" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                {s.customTitle || `Session ${shortWhen(s.date)}`}
+                <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {sessionTitle(s)}
+                </span>
                 <ExpiryTag date={s.date} cleanupDays={cleanupDays} />
               </div>
-              <div className="file">{s.filename}</div>
+              <div className="file">{fmt(s.messageCount)} msg · ${s.estimatedCost.toFixed(2)}</div>
             </div>
             <span className={`model ${fam}`}><span className="dot" /> {s.model ? fmtModel(s.model) : '—'}</span>
             <span className="toks">{fmt(s.totalTokens)}<small>tok</small></span>

--- a/src/components/project/utils.ts
+++ b/src/components/project/utils.ts
@@ -4,6 +4,21 @@ export function fmtDate(d: string) {
   return new Date(d).toLocaleString('it-IT', { dateStyle: 'medium', timeStyle: 'short' })
 }
 
+// Restituisce un titolo umano per la sessione, in ordine di priorità:
+// 1) customTitle (impostato dall'utente)  2) aiTitle (generato da Claude)
+// 3) primo messaggio utente troncato       4) fallback "Untitled session"
+export function sessionTitle(s: {
+  customTitle?: string
+  aiTitle?: string
+  firstUserMessage?: string
+}, maxLen = 80): string {
+  const raw = s.customTitle?.trim() || s.aiTitle?.trim() || s.firstUserMessage?.trim()
+  if (!raw) return 'Untitled session'
+  const firstLine = raw.split('\n')[0].trim() || raw.trim()
+  if (firstLine.length <= maxLen) return firstLine
+  return firstLine.slice(0, maxLen - 1).trimEnd() + '…'
+}
+
 // Converte l'ID modello in nome leggibile: "claude-sonnet-4-6" → "Sonnet 4.6"
 export function fmtModel(m: string): string {
   const s = m.replace(/^claude-/, '')

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,6 +72,8 @@ export interface SessionSummary {
   model?: string
   models: Record<string, number>
   customTitle?: string
+  aiTitle?: string
+  firstUserMessage?: string
 }
 
 export interface RuleFile {


### PR DESCRIPTION
## Summary
Enhance session titling with AI-generated titles and automatic extraction of the first user message, providing better session identification in the UI.

## Changes

**Backend (`electron/modules/cost-tracker.ts`)**
- Added `aiTitle` and `firstUserMessage` fields to `SessionSummary` and `ParsedSession` interfaces
- Implemented `extractFirstUserText()` to parse the first non-meta user message from session JSON, handling both string and block-array content formats
- Updated `parseJsonlLine()` to extract AI-generated titles (from `ai-title` type entries) and first user messages
- Modified `parseJsonlSession()` to accumulate these fields across session lines

**Frontend utilities (`src/components/project/utils.ts`)**
- Added `sessionTitle()` helper function that prioritizes session titles in order:
  1. User-set `customTitle`
  2. AI-generated `aiTitle`
  3. First user message (truncated)
  4. Fallback "Untitled session"
- Includes configurable max length (default 80 chars) with ellipsis truncation

**UI updates**
- `ChatView.tsx`: Use new `sessionTitle()` function; display session ID (first 8 chars of filename) instead of full filename
- `ProjectOverviewContent.tsx`: Use `sessionTitle()` in session list; replace filename display with message count and cost summary

## Implementation Details
- First user message extraction skips technical messages (caveat, interrupted requests) and meta/sidechain entries
- Handles both string content and multi-block message formats (e.g., text blocks in arrays)
- HTML tags are stripped before validation
- Session title function gracefully handles missing fields and truncates long text with ellipsis

https://claude.ai/code/session_01V5mbQzSTFhL8eUckN4iAcP