### PR TITLE
Refactor MCP server UI to grid layout with enhanced card design

### DIFF
--- a/src/components/project/mcp/GlobalMcpView.tsx
+++ b/src/components/project/mcp/GlobalMcpView.tsx
@@ -130,7 +130,7 @@ export function GlobalMcpView({
                   <h2>Cloud</h2>
                   <span className="ct">connected · across {totalProjects} projects</span>
                 </div>
-                <div className="cl-mcp-list">
+                <div className="cl-mcp-grid">
                   {cloud.map(s => (
                     <McpServerCard key={s.name} server={s} totalProjects={totalProjects} onSelect={onSelectServer} />
                   ))}
@@ -144,7 +144,7 @@ export function GlobalMcpView({
                   <h2>Local</h2>
                   <span className="ct">~/.claude/settings.json</span>
                 </div>
-                <div className="cl-mcp-list">
+                <div className="cl-mcp-grid">
                   {local.map(s => (
                     <McpServerCard key={s.name} server={s} totalProjects={totalProjects} onSelect={onSelectServer} />
                   ))}

--- a/src/components/project/mcp/McpServerCard.tsx
+++ b/src/components/project/mcp/McpServerCard.tsx
@@ -59,6 +59,7 @@ export function McpServerCard({
   const displayName = server.name.replace(/^claude\.ai\s*/i, '')
   const color = mcpServiceColor(server.name)
   const initial = displayName.trim()[0]?.toUpperCase() ?? '?'
+  const meta = mcpServiceMeta(server.name)
 
   const isLocal = server.source === 'local'
   const fullyEnabled = server.disabledInProjects === 0
@@ -66,26 +67,27 @@ export function McpServerCard({
   const statusColor = fullyEnabled ? 'var(--cl-ok)' : fullyDisabled ? 'var(--cl-danger)' : 'var(--cl-warn)'
 
   const envKeys = server.env ? Object.keys(server.env) : []
-  const commandLine = server.command
-    ? `${server.command}${server.args?.length ? ' ' + server.args.join(' ') : ''}`
-    : null
   const pct = totalProjects > 0 ? Math.round((server.enabledInProjects / totalProjects) * 100) : 0
 
   return (
-    <button type="button" className="cl-mcp-item" onClick={() => onSelect(server)}>
+    <button type="button" className="cl-mcp-card" onClick={() => onSelect(server)}>
       <span
         className="badge"
-        style={{ background: `color-mix(in oklch, ${color} 14%, transparent)`, border: `1px solid color-mix(in oklch, ${color} 28%, transparent)`, color }}
+        style={{
+          background: `color-mix(in oklch, ${color} 14%, transparent)`,
+          border: `1px solid color-mix(in oklch, ${color} 28%, transparent)`,
+          color,
+        }}
       >
         {initial}
       </span>
 
-      <div style={{ minWidth: 0 }}>
-        <div className="m-head">
-          <span className="m-name">{displayName}</span>
-          <span className="m-led" style={{ background: statusColor }} />
+      <div className="body">
+        <div className="head">
+          <span className="name">{displayName}</span>
+          <span className="led" style={{ background: statusColor }} />
           <span
-            className="m-src"
+            className="src"
             style={
               isLocal
                 ? { background: 'var(--cl-warn-soft)', color: 'var(--cl-warn)' }
@@ -95,34 +97,30 @@ export function McpServerCard({
             {server.source}
           </span>
         </div>
-        <div className="m-sub" title={commandLine ?? undefined}>
-          {isLocal
-            ? (commandLine ?? 'local server')
-            : fullyEnabled
-              ? 'enabled everywhere'
-              : fullyDisabled
-                ? 'disabled everywhere'
-                : `disabled in ${server.disabledInProjects} ${server.disabledInProjects === 1 ? 'project' : 'projects'}`}
-        </div>
-      </div>
+        <div className="cat">{meta.category}</div>
+        <div className="desc">{meta.description}</div>
 
-      <div className="m-right">
-        {!isLocal && totalProjects > 0 && (
-          <div className="m-prog">
-            <span className="m-frac">{server.enabledInProjects}<small>/{totalProjects}</small></span>
-            <span className="cl-mcp-bar">
-              <i style={{ width: `${pct}%`, background: statusColor }} />
-            </span>
-          </div>
-        )}
-        {isLocal && envKeys.length > 0 && (
-          <span className="m-frac" style={{ fontSize: 13, color: 'var(--cl-ink-3)' }}>
-            {envKeys.length} env
-          </span>
-        )}
-        <svg className="chev-right" width="13" height="13" viewBox="0 0 10 10" fill="none">
-          <path d="M3.5 2l3 3-3 3" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
-        </svg>
+        <div className="foot">
+          {!isLocal && totalProjects > 0 && (
+            <>
+              <span className="frac">
+                {server.enabledInProjects}<small>/{totalProjects}</small>
+              </span>
+              <span className="bar"><i style={{ width: `${pct}%`, background: statusColor }} /></span>
+              <span className="pct">{pct}%</span>
+            </>
+          )}
+          {isLocal && (
+            <>
+              {envKeys.length > 0 && (
+                <span className="env"><b>{envKeys.length}</b> env</span>
+              )}
+              {server.command && (
+                <span className="cmd" title={server.command}>{server.command}</span>
+              )}
+            </>
+          )}
+        </div>
       </div>
     </button>
   )

--- a/src/components/project/mcp/McpServerDetailView.tsx
+++ b/src/components/project/mcp/McpServerDetailView.tsx
@@ -35,12 +35,19 @@ function TopBar({ onBack, name }: { onBack: () => void; name: string }) {
   )
 }
 
-function ProjectRow({ path, color }: { path: string; color: string }) {
+function ProjectCard({ path, color }: { path: string; color: string }) {
+  const name = path.split('/').pop() ?? path
+  const initial = (name[0] ?? '?').toUpperCase()
   return (
-    <div className="d-proj">
-      <span className="dot" style={{ background: color }} />
-      <span className="name">{path.split('/').pop() ?? path}</span>
-      <span className="path" title={path}>{path}</span>
+    <div className="cl-mcp-proj">
+      <span className="glyph" style={{ color, borderColor: color }}>
+        {initial}
+        <span className="led" style={{ background: color }} />
+      </span>
+      <div style={{ minWidth: 0 }}>
+        <div className="name">{name}</div>
+        <div className="path" title={path}>{path}</div>
+      </div>
     </div>
   )
 }
@@ -149,7 +156,7 @@ export function McpServerDetailView({
               <h2>Configuration</h2>
               <span className="ct">~/.claude/settings.json</span>
             </div>
-            <div className="cl-mcp-detail" style={{ paddingTop: 0 }}>
+            <div className="cl-mcp-config">
               {commandLine && (
                 <>
                   <div className="d-label">Command</div>
@@ -176,9 +183,9 @@ export function McpServerDetailView({
               <h2>Enabled</h2>
               <span className="ct">{server.enabledProjectPaths.length} {server.enabledProjectPaths.length === 1 ? 'project' : 'projects'}</span>
             </div>
-            <div className="cl-mcp-detail" style={{ paddingTop: 0 }}>
+            <div className="cl-mcp-projs">
               {server.enabledProjectPaths.map(p => (
-                <ProjectRow key={p} path={p} color="var(--cl-ok)" />
+                <ProjectCard key={p} path={p} color="var(--cl-ok)" />
               ))}
             </div>
           </section>
@@ -190,9 +197,9 @@ export function McpServerDetailView({
               <h2>Disabled</h2>
               <span className="ct">{server.disabledProjectPaths.length} {server.disabledProjectPaths.length === 1 ? 'project' : 'projects'}</span>
             </div>
-            <div className="cl-mcp-detail" style={{ paddingTop: 0 }}>
+            <div className="cl-mcp-projs">
               {server.disabledProjectPaths.map(p => (
-                <ProjectRow key={p} path={p} color="var(--cl-danger)" />
+                <ProjectCard key={p} path={p} color="var(--cl-danger)" />
               ))}
             </div>
           </section>

--- a/src/index.css
+++ b/src/index.css
@@ -712,68 +712,143 @@ body {
 }
 .cl-mcp-metrics .met .num small { font-size: 14px; font-weight: 400; color: var(--cl-ink-4); }
 
-.cl-mcp-list { border-top: 1px solid var(--cl-ink); }
-.cl-mcp-item {
+/* MCP — refined catalog grid (GlobalMcpView) */
+.cl-mcp-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0;
+  border-top: 1px solid var(--cl-ink);
+  border-bottom: 1px solid var(--cl-line-soft);
+}
+.cl-mcp-card {
+  padding: 22px 28px 22px 0;
+  border-bottom: 1px solid var(--cl-line-soft);
+  cursor: pointer;
+  display: grid;
+  grid-template-columns: 44px 1fr;
+  gap: 18px; align-items: start;
+  transition: background 100ms;
+  background: transparent; border-left: none; border-top: none;
   width: 100%; text-align: left; font: inherit; color: inherit;
-  background: transparent; border: none; cursor: pointer;
-  display: grid; grid-template-columns: auto 1fr auto; align-items: center; gap: 18px;
-  padding: 18px 0; border-top: 1px solid var(--cl-line-soft);
-  transition: background 120ms, padding 120ms;
+  min-width: 0;
 }
-.cl-mcp-item:first-child { border-top: none; }
-.cl-mcp-item.static { cursor: default; }
-.cl-mcp-item:not(.static):hover { background: var(--cl-accent-soft); padding-left: 14px; padding-right: 14px; }
-.cl-mcp-item .badge {
-  width: 42px; height: 42px; border-radius: 11px; flex-shrink: 0;
+.cl-mcp-card:nth-child(odd) { padding-left: 0; padding-right: 36px; border-right: 1px solid var(--cl-line-soft); }
+.cl-mcp-card:nth-child(even) { padding-left: 36px; border-right: none; }
+.cl-mcp-card:hover { background: var(--cl-accent-soft); }
+.cl-mcp-card .badge {
+  width: 44px; height: 44px; border-radius: 12px; flex-shrink: 0;
   display: flex; align-items: center; justify-content: center;
-  font-family: var(--font-mono); font-size: 16px; font-weight: 600;
+  font-family: var(--font-mono); font-size: 18px; font-weight: 600;
 }
-.cl-mcp-item .m-head { display: flex; align-items: center; gap: 9px; min-width: 0; }
-.cl-mcp-item .m-name { font-size: 16px; font-weight: 600; letter-spacing: -0.015em; color: var(--cl-ink); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.cl-mcp-item .m-led { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; }
-.cl-mcp-item .m-src {
+.cl-mcp-card .body { min-width: 0; }
+.cl-mcp-card .head { display: flex; align-items: center; gap: 9px; min-width: 0; }
+.cl-mcp-card .name {
+  font-size: 17px; font-weight: 600; letter-spacing: -0.015em;
+  color: var(--cl-ink); overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.cl-mcp-card .led { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; }
+.cl-mcp-card .src {
   font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.12em;
   text-transform: uppercase; padding: 2px 7px; border-radius: 999px; flex-shrink: 0;
+  margin-left: auto;
 }
-.cl-mcp-item .m-sub {
-  font-family: var(--font-mono); font-size: 11px; color: var(--cl-ink-3);
-  margin-top: 5px; line-height: 1.5; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+.cl-mcp-card .cat {
+  font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.16em;
+  text-transform: uppercase; color: var(--cl-ink-4); margin-top: 8px;
 }
-.cl-mcp-item .m-right { display: flex; align-items: center; gap: 16px; }
-.cl-mcp-item .m-prog { display: flex; flex-direction: column; align-items: flex-end; gap: 6px; }
-.cl-mcp-item .m-frac { font-family: var(--font-mono); font-size: 20px; font-weight: 600; color: var(--cl-ink); line-height: 1; }
-.cl-mcp-item .m-frac small { color: var(--cl-ink-4); font-size: 11px; font-weight: 400; }
+.cl-mcp-card .desc {
+  font-size: 13px; color: var(--cl-ink-3);
+  margin-top: 10px; line-height: 1.55;
+  display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.cl-mcp-card .foot {
+  display: flex; align-items: center; gap: 12px;
+  margin-top: 16px; min-width: 0;
+}
+.cl-mcp-card .foot .frac {
+  font-family: var(--font-mono); font-size: 12.5px;
+  color: var(--cl-ink-2); font-weight: 500; flex-shrink: 0;
+}
+.cl-mcp-card .foot .frac small { color: var(--cl-ink-4); font-weight: 400; }
+.cl-mcp-card .foot .bar {
+  flex: 1; height: 3px; border-radius: 2px; background: var(--cl-line); overflow: hidden; min-width: 40px;
+}
+.cl-mcp-card .foot .bar i { display: block; height: 100%; border-radius: 2px; }
+.cl-mcp-card .foot .pct {
+  font-family: var(--font-mono); font-size: 11px; color: var(--cl-ink-4); flex-shrink: 0;
+}
+.cl-mcp-card .foot .env {
+  font-family: var(--font-mono); font-size: 11px; color: var(--cl-ink-3); flex-shrink: 0;
+}
+.cl-mcp-card .foot .env b { color: var(--cl-ink-2); font-weight: 500; }
+.cl-mcp-card .foot .cmd {
+  font-family: var(--font-mono); font-size: 11px; color: var(--cl-ink-4);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;
+}
+
+/* Generic horizontal progress bar — used both inside cards and on detail */
 .cl-mcp-bar { width: 96px; height: 3px; border-radius: 2px; background: var(--cl-line); overflow: hidden; }
 .cl-mcp-bar i { display: block; height: 100%; border-radius: 2px; }
-.cl-mcp-item .chev { color: var(--cl-ink-4); transition: transform 150ms; flex-shrink: 0; }
-.cl-mcp-item .chev.open { transform: rotate(180deg); }
-.cl-mcp-item .chev-right { color: var(--cl-ink-4); flex-shrink: 0; transition: transform 150ms; }
-.cl-mcp-item:hover .chev-right { transform: translateX(3px); color: var(--cl-accent); }
 
-.cl-mcp-detail {
-  padding: 4px 0 20px 60px;
+/* MCP — local configuration block (detail view) */
+.cl-mcp-config {
   border-top: 1px solid var(--cl-line-soft);
-  margin-top: -1px;
 }
-.cl-mcp-detail .d-label {
+.cl-mcp-config .d-label {
   font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.14em;
   text-transform: uppercase; color: var(--cl-ink-4); padding-top: 16px; margin-bottom: 10px;
 }
-.cl-mcp-detail .d-cmd {
+.cl-mcp-config .d-cmd {
   font-family: var(--font-mono); font-size: 12px; color: var(--cl-ink-2);
   background: var(--cl-paper-2); border: 1px solid var(--cl-line-soft);
   border-radius: 8px; padding: 10px 12px; word-break: break-all; line-height: 1.6;
 }
-.cl-mcp-detail .d-env { display: flex; flex-wrap: wrap; gap: 6px; }
-.cl-mcp-detail .d-env .k {
+.cl-mcp-config .d-env { display: flex; flex-wrap: wrap; gap: 6px; }
+.cl-mcp-config .d-env .k {
   font-family: var(--font-mono); font-size: 11px; color: var(--cl-ink-2);
   background: var(--cl-paper-2); border: 1px solid var(--cl-line-soft);
   border-radius: 999px; padding: 3px 10px;
 }
-.cl-mcp-detail .d-proj { display: flex; align-items: center; gap: 9px; padding: 5px 0; }
-.cl-mcp-detail .d-proj .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--cl-danger); flex-shrink: 0; }
-.cl-mcp-detail .d-proj .name { font-size: 12.5px; color: var(--cl-ink-2); }
-.cl-mcp-detail .d-proj .path { font-family: var(--font-mono); font-size: 10.5px; color: var(--cl-ink-4); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+/* MCP — refined project grid (detail view) */
+.cl-mcp-projs {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0;
+  border-top: 1px solid var(--cl-ink);
+  border-bottom: 1px solid var(--cl-line-soft);
+}
+.cl-mcp-proj {
+  padding: 18px 28px 18px 0;
+  border-bottom: 1px solid var(--cl-line-soft);
+  display: grid;
+  grid-template-columns: 30px 1fr;
+  gap: 14px; align-items: center;
+  min-width: 0;
+}
+.cl-mcp-proj:nth-child(odd) { padding-left: 0; padding-right: 36px; border-right: 1px solid var(--cl-line-soft); }
+.cl-mcp-proj:nth-child(even) { padding-left: 36px; }
+.cl-mcp-proj .glyph {
+  width: 28px; height: 28px; border-radius: 50%;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-family: var(--font-mono); font-size: 11px; font-weight: 700;
+  border: 1.5px solid currentColor;
+  position: relative;
+}
+.cl-mcp-proj .glyph .led {
+  position: absolute; right: -2px; bottom: -2px;
+  width: 9px; height: 9px; border-radius: 50%;
+  border: 2px solid var(--cl-paper);
+}
+.cl-mcp-proj .name {
+  font-size: 14px; font-weight: 600; letter-spacing: -0.01em;
+  color: var(--cl-ink); overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.cl-mcp-proj .path {
+  font-family: var(--font-mono); font-size: 10.5px; color: var(--cl-ink-4);
+  margin-top: 3px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
 
 /* Rules */
 .cl-rules { border-top: 1px solid var(--cl-ink); }


### PR DESCRIPTION
## Summary
Redesigned the MCP (Model Context Protocol) server catalog and detail views from a vertical list layout to a refined two-column grid layout with improved visual hierarchy and information density.

## Key Changes

**CSS Styling (`src/index.css`)**
- Replaced `.cl-mcp-list` / `.cl-mcp-item` with `.cl-mcp-grid` / `.cl-mcp-card` using CSS Grid (2-column layout)
- Updated card styling: larger badge (44px), improved spacing, and hover effects
- Added new semantic classes for card structure: `.body`, `.head`, `.name`, `.led`, `.src`, `.cat`, `.desc`, `.foot`
- Introduced `.cl-mcp-projs` grid for project listings in detail view with `.cl-mcp-proj` cards
- Refactored project cards with glyph badges (circular with status indicator) instead of simple dots
- Renamed `.cl-mcp-detail` to `.cl-mcp-config` for clarity
- Added support for multi-line description truncation (2 lines max) and improved footer metrics display

**McpServerCard Component (`src/components/project/mcp/McpServerCard.tsx`)**
- Updated class names to match new grid-based CSS (`.cl-mcp-card`, `.body`, `.head`, `.name`, `.led`, `.src`, `.foot`)
- Replaced command-line display with category and description from `mcpServiceMeta()`
- Reorganized footer to show: enabled/disabled fraction, progress bar, percentage, environment count, and command (for local servers)
- Improved badge styling with inline color-mix calculations

**McpServerDetailView Component (`src/components/project/mcp/McpServerDetailView.tsx`)**
- Renamed `ProjectRow` to `ProjectCard` with enhanced visual design
- Updated project cards to use circular glyph badges with status LED indicators
- Changed `.cl-mcp-detail` references to `.cl-mcp-config` and `.cl-mcp-projs`
- Improved project card layout with better typography hierarchy

**GlobalMcpView Component (`src/components/project/mcp/GlobalMcpView.tsx`)**
- Updated container class from `.cl-mcp-list` to `.cl-mcp-grid`

## Implementation Details
- Grid layout uses `grid-template-columns: repeat(2, 1fr)` with alternating left/right padding and borders for visual separation
- Cards maintain consistent spacing (22px vertical, 28px horizontal) with proper alignment
- Status indicators (LED dots) now integrated into card headers and project glyphs
- Progress bars and metrics reorganized into a flexible footer section
- All changes are CSS-first with minimal JavaScript modifications, ensuring maintainability

https://claude.ai/code/session_01Mvzhh23DMVYftKgmhDCVwE