### PR TITLE
refactor(mcp): share MCP grid between global home and project view

### DIFF
--- a/src/components/project/mcp/McpServerGrid.tsx
+++ b/src/components/project/mcp/McpServerGrid.tsx
@@ -1,0 +1,161 @@
+import { useMemo, useState } from 'react'
+import type { McpServer } from '../../../hooks/useIPC'
+
+type McpSortKey = 'projects' | 'name' | 'source'
+const MCP_SORT_OPTIONS: { key: McpSortKey; label: string }[] = [
+  { key: 'projects', label: 'projects' },
+  { key: 'name', label: 'name' },
+  { key: 'source', label: 'source' },
+]
+
+function pageWindow(current: number, total: number): (number | 'gap')[] {
+  if (total <= 7) return Array.from({ length: total }, (_, i) => i)
+  const out: (number | 'gap')[] = [0]
+  const start = Math.max(1, current - 1)
+  const end = Math.min(total - 2, current + 1)
+  if (start > 1) out.push('gap')
+  for (let i = start; i <= end; i++) out.push(i)
+  if (end < total - 2) out.push('gap')
+  out.push(total - 1)
+  return out
+}
+
+function chunk<T>(arr: T[], size: number): T[][] {
+  const out: T[][] = []
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size))
+  return out
+}
+
+export function McpServerGrid({
+  servers,
+  onSelect,
+  pageSize = 6,
+  showSort = true,
+  headerAction,
+}: {
+  servers: McpServer[]
+  onSelect: (s: McpServer) => void
+  pageSize?: number
+  showSort?: boolean
+  headerAction?: React.ReactNode
+}) {
+  const [page, setPage] = useState(0)
+  const [sortKey, setSortKey] = useState<McpSortKey>('projects')
+
+  const sorted = useMemo(() => {
+    const arr = [...servers]
+    const displayName = (n: string) => n.replace(/^claude\.ai\s*/i, '').toLowerCase()
+    switch (sortKey) {
+      case 'name':
+        return arr.sort((a, b) => displayName(a.name).localeCompare(displayName(b.name)))
+      case 'source':
+        return arr.sort((a, b) => a.source.localeCompare(b.source) || displayName(a.name).localeCompare(displayName(b.name)))
+      case 'projects':
+      default:
+        return arr.sort((a, b) => b.enabledInProjects - a.enabledInProjects)
+    }
+  }, [servers, sortKey])
+
+  const pageCount = Math.max(1, Math.ceil(sorted.length / pageSize))
+  const safePage = Math.min(page, pageCount - 1)
+  const paged = sorted.slice(safePage * pageSize, (safePage + 1) * pageSize)
+  const rangeFrom = sorted.length === 0 ? 0 : safePage * pageSize + 1
+  const rangeTo = Math.min((safePage + 1) * pageSize, sorted.length)
+
+  return (
+    <>
+      <div className="cl-sec-head">
+        <h2>MCP servers</h2>
+        <span className="ct">
+          {`${rangeFrom}–${rangeTo} of ${sorted.length} · sorted by ${MCP_SORT_OPTIONS.find(o => o.key === sortKey)?.label ?? 'projects'}`}
+        </span>
+        {headerAction}
+        {showSort && sorted.length > 1 && (
+          <span className="cl-sortbar" style={{ marginLeft: 'auto' }}>
+            <span className="label">SORT BY</span>
+            {MCP_SORT_OPTIONS.map((o, i) => (
+              <span key={o.key} style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+                {i > 0 && <span className="sep">·</span>}
+                <button
+                  type="button"
+                  className={`opt${sortKey === o.key ? ' on' : ''}`}
+                  onClick={() => { setSortKey(o.key); setPage(0) }}
+                >
+                  {o.label}
+                </button>
+              </span>
+            ))}
+          </span>
+        )}
+      </div>
+
+      {chunk(paged, 3).map((group, gi) => (
+        <div
+          key={gi}
+          className="cl-mcp-row"
+          style={{ gridTemplateColumns: `repeat(${group.length}, 1fr)` }}
+        >
+          {group.map((s, i) => {
+            const tone = ['', 'violet', 'cyan'][(gi * 3 + i) % 3]
+            const total = s.enabledInProjects + s.disabledInProjects
+            return (
+              <button
+                key={s.name}
+                type="button"
+                className={`cl-mcp-cell ${tone}`}
+                onClick={() => onSelect(s)}
+              >
+                <div className="led-row"><span className="led" /> {s.source}</div>
+                <div className="mcp-name">{s.name.replace(/^claude\.ai\s*/i, '')}</div>
+                <div className="tools">active in <b>{s.enabledInProjects}</b> of {total} projects</div>
+                <div className="frac">{s.enabledInProjects}<small>/{total}</small></div>
+              </button>
+            )
+          })}
+        </div>
+      ))}
+
+      {pageCount > 1 && (
+        <div className="cl-pag">
+          <span className="cl-pag-meter">
+            PAGE <b>{String(safePage + 1).padStart(2, '0')}</b> / {String(pageCount).padStart(2, '0')}
+          </span>
+          <div className="cl-pag-side">
+            <button
+              type="button"
+              className="cl-pag-btn"
+              disabled={safePage === 0}
+              onClick={() => setPage(safePage - 1)}
+            >
+              <span className="arrow">←</span> PREV
+            </button>
+            <div className="cl-pag-nums">
+              {pageWindow(safePage, pageCount).map((p, i) =>
+                p === 'gap' ? (
+                  <span key={`gap-${i}`} className="cl-pag-ellipsis">…</span>
+                ) : (
+                  <button
+                    key={p}
+                    type="button"
+                    className={`cl-pag-num${p === safePage ? ' on' : ''}`}
+                    onClick={() => setPage(p)}
+                  >
+                    {String(p + 1).padStart(2, '0')}
+                  </button>
+                ),
+              )}
+            </div>
+            <button
+              type="button"
+              className="cl-pag-btn"
+              disabled={safePage >= pageCount - 1}
+              onClick={() => setPage(safePage + 1)}
+            >
+              NEXT <span className="arrow">→</span>
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/components/project/overview/GlobalHomeView.tsx
+++ b/src/components/project/overview/GlobalHomeView.tsx
@@ -12,11 +12,11 @@ import { View } from '../types'
 import type { ProjectCost } from '../../../types'
 import { Lens } from './Lens'
 import { DuplicateProjectsBadge } from './DuplicateProjectsNotice'
+import { McpServerGrid } from '../mcp/McpServerGrid'
 
 type Project = { hash: string; realPath: string }
 
 const PROJECTS_PAGE_SIZE = 5
-const MCP_PAGE_SIZE = 6
 
 type SortKey = 'tokens' | 'cost' | 'sessions' | 'name'
 const SORT_OPTIONS: { key: SortKey; label: string }[] = [
@@ -24,13 +24,6 @@ const SORT_OPTIONS: { key: SortKey; label: string }[] = [
   { key: 'cost', label: 'cost' },
   { key: 'sessions', label: 'sessions' },
   { key: 'name', label: 'name' },
-]
-
-type McpSortKey = 'projects' | 'name' | 'source'
-const MCP_SORT_OPTIONS: { key: McpSortKey; label: string }[] = [
-  { key: 'projects', label: 'projects' },
-  { key: 'name', label: 'name' },
-  { key: 'source', label: 'source' },
 ]
 
 function pageWindow(current: number, total: number): (number | 'gap')[] {
@@ -69,8 +62,6 @@ export function GlobalHomeView({
   const [procs, setProcs] = useState<ClaudeProcess[]>([])
   const [projectsPage, setProjectsPage] = useState(0)
   const [sortKey, setSortKey] = useState<SortKey>('tokens')
-  const [mcpPage, setMcpPage] = useState(0)
-  const [mcpSortKey, setMcpSortKey] = useState<McpSortKey>('projects')
   useEffect(() => {
     let alive = true
     async function load() {
@@ -125,34 +116,7 @@ export function GlobalHomeView({
     () => [...(mcpData?.cloudServers ?? []), ...(mcpData?.localServers ?? [])],
     [mcpData],
   )
-  const sortedMcpServers = useMemo(() => {
-    const arr = [...mcpServers]
-    const displayName = (n: string) => n.replace(/^claude\.ai\s*/i, '').toLowerCase()
-    switch (mcpSortKey) {
-      case 'name':
-        return arr.sort((a, b) => displayName(a.name).localeCompare(displayName(b.name)))
-      case 'source':
-        return arr.sort((a, b) => a.source.localeCompare(b.source) || displayName(a.name).localeCompare(displayName(b.name)))
-      case 'projects':
-      default:
-        return arr.sort((a, b) => b.enabledInProjects - a.enabledInProjects)
-    }
-  }, [mcpServers, mcpSortKey])
-  const mcpPageCount = Math.max(1, Math.ceil(sortedMcpServers.length / MCP_PAGE_SIZE))
-  const safeMcpPage = Math.min(mcpPage, mcpPageCount - 1)
-  const pagedMcpServers = sortedMcpServers.slice(
-    safeMcpPage * MCP_PAGE_SIZE,
-    (safeMcpPage + 1) * MCP_PAGE_SIZE,
-  )
-  const mcpRangeFrom = sortedMcpServers.length === 0 ? 0 : safeMcpPage * MCP_PAGE_SIZE + 1
-  const mcpRangeTo = Math.min((safeMcpPage + 1) * MCP_PAGE_SIZE, sortedMcpServers.length)
   const claudeMdLines = (globalClaudeMd ?? '').split('\n').length
-
-  function chunk<T>(arr: T[], size: number): T[][] {
-    const out: T[][] = []
-    for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size))
-    return out
-  }
 
   return (
     <div style={{ position: 'relative' }}>
@@ -352,93 +316,10 @@ export function GlobalHomeView({
       {/* ─── MCP SERVERS ──────────────────────────────── */}
       {mcpServers.length > 0 && (
         <section className="cl-section">
-          <div className="cl-sec-head">
-            <h2>MCP servers</h2>
-            <span className="ct">
-              {`${mcpRangeFrom}–${mcpRangeTo} of ${sortedMcpServers.length} · sorted by ${MCP_SORT_OPTIONS.find(o => o.key === mcpSortKey)?.label ?? 'projects'}`}
-            </span>
-            <span className="cl-sortbar" style={{ marginLeft: 'auto' }}>
-              <span className="label">SORT BY</span>
-              {MCP_SORT_OPTIONS.map((o, i) => (
-                <span key={o.key} style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
-                  {i > 0 && <span className="sep">·</span>}
-                  <button
-                    type="button"
-                    className={`opt${mcpSortKey === o.key ? ' on' : ''}`}
-                    onClick={() => { setMcpSortKey(o.key); setMcpPage(0) }}
-                  >
-                    {o.label}
-                  </button>
-                </span>
-              ))}
-            </span>
-          </div>
-          {chunk(pagedMcpServers, 3).map((group, gi) => (
-            <div
-              key={gi}
-              className="cl-mcp-row"
-              style={{ gridTemplateColumns: `repeat(${group.length}, 1fr)` }}
-            >
-              {group.map((s, i) => {
-                const tone = ['', 'violet', 'cyan'][(gi * 3 + i) % 3]
-                const total = s.enabledInProjects + s.disabledInProjects
-                return (
-                  <button
-                    key={s.name}
-                    type="button"
-                    className={`cl-mcp-cell ${tone}`}
-                    onClick={() => onNavigate({ type: 'mcp-detail', server: s, totalProjects: total })}
-                  >
-                    <div className="led-row"><span className="led" /> {s.source}</div>
-                    <div className="mcp-name">{s.name.replace(/^claude\.ai\s*/i, '')}</div>
-                    <div className="tools">active in <b>{s.enabledInProjects}</b> of {total} projects</div>
-                    <div className="frac">{s.enabledInProjects}<small>/{total}</small></div>
-                  </button>
-                )
-              })}
-            </div>
-          ))}
-          {mcpPageCount > 1 && (
-            <div className="cl-pag">
-              <span className="cl-pag-meter">
-                PAGE <b>{String(safeMcpPage + 1).padStart(2, '0')}</b> / {String(mcpPageCount).padStart(2, '0')}
-              </span>
-              <div className="cl-pag-side">
-                <button
-                  type="button"
-                  className="cl-pag-btn"
-                  disabled={safeMcpPage === 0}
-                  onClick={() => setMcpPage(safeMcpPage - 1)}
-                >
-                  <span className="arrow">←</span> PREV
-                </button>
-                <div className="cl-pag-nums">
-                  {pageWindow(safeMcpPage, mcpPageCount).map((p, i) =>
-                    p === 'gap' ? (
-                      <span key={`gap-${i}`} className="cl-pag-ellipsis">…</span>
-                    ) : (
-                      <button
-                        key={p}
-                        type="button"
-                        className={`cl-pag-num${p === safeMcpPage ? ' on' : ''}`}
-                        onClick={() => setMcpPage(p)}
-                      >
-                        {String(p + 1).padStart(2, '0')}
-                      </button>
-                    ),
-                  )}
-                </div>
-                <button
-                  type="button"
-                  className="cl-pag-btn"
-                  disabled={safeMcpPage >= mcpPageCount - 1}
-                  onClick={() => setMcpPage(safeMcpPage + 1)}
-                >
-                  NEXT <span className="arrow">→</span>
-                </button>
-              </div>
-            </div>
-          )}
+          <McpServerGrid
+            servers={mcpServers}
+            onSelect={s => onNavigate({ type: 'mcp-detail', server: s, totalProjects: s.enabledInProjects + s.disabledInProjects })}
+          />
         </section>
       )}
     </div>

--- a/src/components/project/overview/ProjectOverviewContent.tsx
+++ b/src/components/project/overview/ProjectOverviewContent.tsx
@@ -19,6 +19,7 @@ import { View } from '../types'
 import { fmt, fmtModel, sessionTitle } from '../utils'
 import type { SessionSummary, ProjectCost } from '../../../types'
 import { Lens } from './Lens'
+import { McpServerGrid } from '../mcp/McpServerGrid'
 
 export type ProjectSection = 'overview' | 'sessions' | 'memory' | 'skills' | 'agents' | 'mcp'
 
@@ -517,28 +518,23 @@ export function ProjectView({
 
       {section === 'mcp' && (
         <section className="cl-section" style={{ paddingTop: 38 }}>
-          <div className="cl-sec-head">
-            <h2>MCP servers</h2>
-            <span className="ct">{enabledMcp.length} active · project-scoped</span>
-            <button className="all" type="button" onClick={() => onNavigate({ type: 'global-mcp' })}>Manage</button>
-          </div>
           {enabledMcp.length === 0 ? (
-            <div className="cl-empty">No MCP servers active for this project.</div>
+            <>
+              <div className="cl-sec-head">
+                <h2>MCP servers</h2>
+                <span className="ct">0 active · project-scoped</span>
+                <button className="all" type="button" onClick={() => onNavigate({ type: 'global-mcp' })}>Manage</button>
+              </div>
+              <div className="cl-empty">No MCP servers active for this project.</div>
+            </>
           ) : (
-            <div className="cl-mcp-row" style={{ gridTemplateColumns: `repeat(${Math.min(3, enabledMcp.length)}, 1fr)` }}>
-              {enabledMcp.slice(0, 3).map((s, i) => {
-                const tone = ['', 'violet', 'cyan'][i % 3]
-                const total = s.enabledInProjects + s.disabledInProjects
-                return (
-                  <button key={s.name} type="button" className={`cl-mcp-cell ${tone}`} onClick={() => onNavigate({ type: 'global-mcp' })}>
-                    <div className="led-row"><span className="led" /> {s.source}</div>
-                    <div className="mcp-name">{s.name.replace(/^claude\.ai\s*/i, '')}</div>
-                    <div className="tools">active in <b>{s.enabledInProjects}</b> of {total} projects</div>
-                    <div className="frac">{s.enabledInProjects}<small>/{total}</small></div>
-                  </button>
-                )
-              })}
-            </div>
+            <McpServerGrid
+              servers={enabledMcp}
+              onSelect={s => onNavigate({ type: 'mcp-detail', server: s, totalProjects: s.enabledInProjects + s.disabledInProjects })}
+              headerAction={
+                <button className="all" type="button" onClick={() => onNavigate({ type: 'global-mcp' })}>Manage</button>
+              }
+            />
           )}
 
           <div className="cl-sec-head" style={{ marginTop: 42 }}>


### PR DESCRIPTION
## Summary
- Extract the MCP servers grid (3-col `cl-mcp-cell` cards, sort by projects/name/source, 6-per-page pagination) into a shared `McpServerGrid` component.
- Reuse it in `GlobalHomeView` (global MCP section) and `ProjectOverviewContent` (project view → MCP section), removing the duplicated inline grid and the truncated 3-card preview in the project view.
- Project view passes a `headerAction` slot so the existing "Manage" link to global MCP is preserved.

## Test plan
- [ ] Open global home → MCP servers: cards in 3-col grid with sort + pagination, clicking opens `mcp-detail`.
- [ ] Open a project → MCP section: same grid + pagination, "Manage" button still navigates to global MCP.
- [ ] Project with 0 enabled MCP servers still shows the empty state.