### PR TITLE
fix: repository audit bugs (#13 #14 #18 #19 #20)

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,5 +1,5 @@
 import { app, BrowserWindow, dialog, ipcMain } from 'electron';
-import { basename, join } from 'path';
+import { basename, isAbsolute, join, resolve, sep } from 'path';
 import os from 'os';
 import { mkdtempSync, rmSync, writeFileSync } from 'fs';
 import chokidar from 'chokidar';
@@ -46,6 +46,55 @@ function assertValidHash(hash: string): void {
     || hash.includes('/') || hash.includes('\\') || hash.includes('\0')) {
     throw new Error(`Invalid project hash: ${JSON.stringify(hash)}`);
   }
+}
+
+// Valida l'hash e costruisce il path della cartella progetto in un colpo solo,
+// così nessun handler può dimenticare la validazione (vedi #13).
+function projectDir(hash: string): string {
+  assertValidHash(hash);
+  return join(PROJECTS_DIR, hash);
+}
+
+const CLAUDE_MD_BASENAMES: ReadonlySet<string> = new Set(['CLAUDE.md', 'CLAUDE.local.md']);
+
+// Un filename fornito dal renderer dev'essere un singolo segmento (no traversal):
+// gli handler memory/sessions lo concatenano a un dir di progetto già validato.
+function assertValidFilename(filename: string): void {
+  if (typeof filename !== 'string' || filename.length === 0
+    || filename === '.' || filename === '..'
+    || filename !== basename(filename)
+    || filename.includes('\\') || filename.includes('\0')) {
+    throw new Error(`Invalid filename: ${JSON.stringify(filename)}`);
+  }
+}
+
+interface SafeWritePathOptions {
+  allowedBasenames?: ReadonlySet<string>;
+  // I CLAUDE.md di progetto possono stare fuori dalla home (realPath = cwd letto dal .jsonl),
+  // quindi il containment nella home si applica solo ai path sotto ~/.claude (markdownFile:*).
+  requireUnderHome?: boolean;
+}
+
+// Valida un path fornito dal renderer prima di scriverci/cancellarlo (vedi #14):
+// dev'essere assoluto, normalizzato (collassa `..`/`.`) e con un basename ammesso
+// (allowlist) oppure `.md`; opzionalmente contenuto nella home. Ritorna il path normalizzato.
+function assertSafeWritePath(filePath: string, opts: SafeWritePathOptions = {}): string {
+  if (!filePath || typeof filePath !== 'string') throw new Error('Missing filePath');
+  if (!isAbsolute(filePath)) throw new Error('Path must be absolute');
+  const resolved = resolve(filePath);
+  if (opts.requireUnderHome) {
+    const home = os.homedir();
+    if (resolved !== home && !resolved.startsWith(home + sep)) {
+      throw new Error('Path must be under home directory');
+    }
+  }
+  const base = basename(resolved);
+  if (opts.allowedBasenames) {
+    if (!opts.allowedBasenames.has(base)) throw new Error(`Refusing to write file: ${base}`);
+  } else if (!base.toLowerCase().endsWith('.md')) {
+    throw new Error('Only .md files are allowed');
+  }
+  return resolved;
 }
 
 function ok<T>(data: T): IpcResult<T> {
@@ -146,7 +195,7 @@ ipcMain.handle('memory:listProjects', async (): Promise<IpcResult<Array<{ hash: 
 
 ipcMain.handle('memory:getProject', async (_event, hash: string) => {
   try {
-    const projectPath = join(PROJECTS_DIR, hash);
+    const projectPath = projectDir(hash);
     const realPath = resolveRealPath(PROJECTS_DIR, hash);
     const md = await readMemory(projectPath, realPath);
     return ok(serializeMemoryData(md));
@@ -209,7 +258,8 @@ ipcMain.handle('claudeMd:writeGlobal', async (_event, content: string) => {
 
 ipcMain.handle('claudeMd:writeFile', async (_event, filePath: string, content: string) => {
   try {
-    writeClaudeMdFile(filePath, content);
+    const safePath = assertSafeWritePath(filePath, { allowedBasenames: CLAUDE_MD_BASENAMES });
+    writeClaudeMdFile(safePath, content);
     return ok(null);
   } catch (e) {
     return err(e);
@@ -219,15 +269,10 @@ ipcMain.handle('claudeMd:writeFile', async (_event, filePath: string, content: s
 ipcMain.handle('markdownFile:write', async (_event, filePath: string, content: string) => {
   try {
     const fs = require('fs') as typeof import('fs');
-    if (!filePath || typeof filePath !== 'string') throw new Error('Missing filePath');
-    if (!filePath.startsWith('/')) throw new Error('Path must be absolute');
-    if (filePath.includes('..')) throw new Error('Path traversal not allowed');
-    if (!filePath.toLowerCase().endsWith('.md')) throw new Error('Only .md files are writable');
-    const home = os.homedir();
-    if (!filePath.startsWith(home + '/')) throw new Error('Path must be under home directory');
-    const dir = require('path').dirname(filePath) as string;
+    const safePath = assertSafeWritePath(filePath, { requireUnderHome: true });
+    const dir = require('path').dirname(safePath) as string;
     if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(filePath, content, 'utf-8');
+    fs.writeFileSync(safePath, content, 'utf-8');
     return ok(null);
   } catch (e) {
     return err(e);
@@ -238,16 +283,11 @@ ipcMain.handle('markdownFile:delete', async (_event, filePath: string, opts?: { 
   try {
     const fs = require('fs') as typeof import('fs');
     const path = require('path') as typeof import('path');
-    if (!filePath || typeof filePath !== 'string') throw new Error('Missing filePath');
-    if (!filePath.startsWith('/')) throw new Error('Path must be absolute');
-    if (filePath.includes('..')) throw new Error('Path traversal not allowed');
-    if (!filePath.toLowerCase().endsWith('.md')) throw new Error('Only .md files are deletable');
-    const home = os.homedir();
-    if (!filePath.startsWith(home + '/')) throw new Error('Path must be under home directory');
-    if (fs.existsSync(filePath)) fs.rmSync(filePath);
+    const safePath = assertSafeWritePath(filePath, { requireUnderHome: true });
+    if (fs.existsSync(safePath)) fs.rmSync(safePath);
     // Per le skill (skills/<name>/SKILL.md) rimuovi la cartella contenitore se resta vuota.
     if (opts?.pruneEmptyDir) {
-      const dir = path.dirname(filePath);
+      const dir = path.dirname(safePath);
       if (fs.existsSync(dir) && fs.readdirSync(dir).length === 0) fs.rmSync(dir, { recursive: false });
     }
     return ok(null);
@@ -270,12 +310,8 @@ ipcMain.handle('claudeMd:deleteGlobal', async () => {
 ipcMain.handle('claudeMd:deleteFile', async (_event, filePath: string) => {
   try {
     const fs = require('fs') as typeof import('fs');
-    if (!filePath || typeof filePath !== 'string') throw new Error('Missing filePath');
-    if (!filePath.startsWith('/')) throw new Error('Path must be absolute');
-    if (filePath.includes('..')) throw new Error('Path traversal not allowed');
-    const home = os.homedir();
-    if (!filePath.startsWith(home + '/')) throw new Error('Path must be under home directory');
-    if (fs.existsSync(filePath)) fs.rmSync(filePath);
+    const safePath = assertSafeWritePath(filePath, { allowedBasenames: CLAUDE_MD_BASENAMES });
+    if (fs.existsSync(safePath)) fs.rmSync(safePath);
     return ok(null);
   } catch (e) {
     return err(e);
@@ -350,7 +386,7 @@ ipcMain.handle('settings:getCleanupPeriodDays', async () => {
 
 ipcMain.handle('sessions:listByProject', async (_event, hash: string) => {
   try {
-    const projectPath = join(PROJECTS_DIR, hash);
+    const projectPath = projectDir(hash);
     const sessions = await getSessionList(projectPath);
     return ok(sessions);
   } catch (e) {
@@ -360,7 +396,7 @@ ipcMain.handle('sessions:listByProject', async (_event, hash: string) => {
 
 ipcMain.handle('memory:createTopic', async (_event, hash: string, input: TopicInput) => {
   try {
-    const memoryDir = join(PROJECTS_DIR, hash, 'memory');
+    const memoryDir = join(projectDir(hash), 'memory');
     const filename = createTopic(memoryDir, input);
     return ok({ filename });
   } catch (e) { return err(e); }
@@ -368,7 +404,8 @@ ipcMain.handle('memory:createTopic', async (_event, hash: string, input: TopicIn
 
 ipcMain.handle('memory:updateTopic', async (_event, hash: string, filename: string, input: TopicInput) => {
   try {
-    const memoryDir = join(PROJECTS_DIR, hash, 'memory');
+    assertValidFilename(filename);
+    const memoryDir = join(projectDir(hash), 'memory');
     updateTopic(memoryDir, filename, input);
     return ok(null);
   } catch (e) { return err(e); }
@@ -376,7 +413,8 @@ ipcMain.handle('memory:updateTopic', async (_event, hash: string, filename: stri
 
 ipcMain.handle('memory:deleteTopic', async (_event, hash: string, filename: string) => {
   try {
-    const memoryDir = join(PROJECTS_DIR, hash, 'memory');
+    assertValidFilename(filename);
+    const memoryDir = join(projectDir(hash), 'memory');
     deleteTopic(memoryDir, filename);
     return ok(null);
   } catch (e) { return err(e); }
@@ -384,7 +422,8 @@ ipcMain.handle('memory:deleteTopic', async (_event, hash: string, filename: stri
 
 ipcMain.handle('sessions:getChat', async (_event, hash: string, filename: string) => {
   try {
-    const projectPath = join(PROJECTS_DIR, hash);
+    assertValidFilename(filename);
+    const projectPath = projectDir(hash);
     const filePath = await findSessionFile(projectPath, filename);
     if (!filePath) return err(new Error(`File sessione non trovato: ${filename}`));
     const messages = readChatSession(filePath);
@@ -394,7 +433,7 @@ ipcMain.handle('sessions:getChat', async (_event, hash: string, filename: string
 
 ipcMain.handle('tasks:getByProject', async (_event, hash: string) => {
   try {
-    const projectPath = join(PROJECTS_DIR, hash);
+    const projectPath = projectDir(hash);
     const groups = await getProjectTasks(projectPath, TASKS_DIR);
     return ok(groups);
   } catch (e) {
@@ -404,7 +443,7 @@ ipcMain.handle('tasks:getByProject', async (_event, hash: string) => {
 
 ipcMain.handle('plans:getByProject', async (_event, hash: string) => {
   try {
-    const projectPath = join(PROJECTS_DIR, hash);
+    const projectPath = projectDir(hash);
     const groups = await getProjectPlans(projectPath);
     return ok(groups);
   } catch (e) {
@@ -549,7 +588,7 @@ async function runClaudeCommand(args: string[]): Promise<IpcResult<string>> {
 
 ipcMain.handle('projects:delete', async (_event, hash: string) => {
   try {
-    const projectPath = join(PROJECTS_DIR, hash);
+    const projectPath = projectDir(hash);
     const { rmSync } = await import('fs');
     rmSync(projectPath, { recursive: true, force: true });
     return ok(null);
@@ -691,7 +730,7 @@ ipcMain.handle('live:getSessions', async () => {
 
 ipcMain.handle('live:startWatch', async (event, hash: string) => {
   try {
-    const projectPath = join(PROJECTS_DIR, hash);
+    const projectPath = projectDir(hash);
     const started = await startLiveMonitor(projectPath, (liveEvent) => {
       if (!event.sender.isDestroyed()) {
         event.sender.send('live:event', liveEvent);

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -215,14 +215,14 @@ ipcMain.handle('cost:getSummary', async () => {
 
 ipcMain.handle('cost:getByProject', async (_event, hash: string) => {
   try {
-    const projectPath = join(PROJECTS_DIR, hash);
-    const { usage, sessionCount } = await getProjectUsage(projectPath);
+    const projectPath = projectDir(hash);
+    const { usage, sessionCount, cost } = await getProjectUsage(projectPath);
     const result = {
       project: hash,
       inputTokens: usage.inputTokens,
       outputTokens: usage.outputTokens,
       totalTokens: usage.totalTokens,
-      cost: (usage.inputTokens / 1_000_000) * 3.0 + (usage.outputTokens / 1_000_000) * 15.0,
+      cost,
       sessionsCount: sessionCount,
     };
     return ok(result);

--- a/electron/modules/cost-tracker.ts
+++ b/electron/modules/cost-tracker.ts
@@ -235,23 +235,49 @@ async function findSessionFiles(projectPath: string): Promise<string[]> {
   return glob('*.jsonl', { cwd: projectPath, absolute: true });
 }
 
-export async function getProjectUsage(
-  projectPath: string
-): Promise<{ usage: UsageData; sessionCount: number }> {
+interface ProjectAggregate {
+  inputTokens: number;
+  outputTokens: number;
+  cacheWriteTokens: number;
+  cacheReadTokens: number;
+  totalTokens: number;
+  cost: number;
+  sessionCount: number;
+}
+
+// Aggrega token e costo di un progetto usando la pricing table per-modello
+// (modello dominante + cache token), così summary e per-progetto coincidono.
+async function aggregateProject(projectPath: string): Promise<ProjectAggregate> {
   const files = await findSessionFiles(projectPath);
-  let inputTokens = 0, outputTokens = 0, cacheWrite = 0, cacheRead = 0;
+  let inputTokens = 0, outputTokens = 0, cacheWriteTokens = 0, cacheReadTokens = 0;
+  const modelCounts: Record<string, number> = {};
 
   for (const f of files) {
     const s = parseJsonlSession(f);
-    inputTokens  += s.inputTokens;
-    outputTokens += s.outputTokens;
-    cacheWrite   += s.cacheWriteTokens;
-    cacheRead    += s.cacheReadTokens;
+    inputTokens      += s.inputTokens;
+    outputTokens     += s.outputTokens;
+    cacheWriteTokens += s.cacheWriteTokens;
+    cacheReadTokens  += s.cacheReadTokens;
+    if (s.model) modelCounts[s.model] = (modelCounts[s.model] ?? 0) + 1;
   }
 
+  const dominantModel = Object.entries(modelCounts).sort((a, b) => b[1] - a[1])[0]?.[0];
+  const cost = calculateCost(inputTokens, outputTokens, cacheWriteTokens, cacheReadTokens, dominantModel);
+
   return {
-    usage: { inputTokens, outputTokens, totalTokens: inputTokens + outputTokens },
-    sessionCount: files.length,
+    inputTokens, outputTokens, cacheWriteTokens, cacheReadTokens,
+    totalTokens: inputTokens + outputTokens, cost, sessionCount: files.length,
+  };
+}
+
+export async function getProjectUsage(
+  projectPath: string
+): Promise<{ usage: UsageData; sessionCount: number; cost: number }> {
+  const a = await aggregateProject(projectPath);
+  return {
+    usage: { inputTokens: a.inputTokens, outputTokens: a.outputTokens, totalTokens: a.totalTokens },
+    sessionCount: a.sessionCount,
+    cost: a.cost,
   };
 }
 
@@ -262,32 +288,16 @@ export async function calculateCostSummary(claudeDir: string): Promise<ProjectCo
 
     for (const projectPath of projectDirs) {
       try {
-        const files = await findSessionFiles(projectPath);
-        let inputTokens = 0, outputTokens = 0, cacheWrite = 0, cacheRead = 0;
-        const modelCounts: Record<string, number> = {};
-
-        for (const f of files) {
-          const s = parseJsonlSession(f);
-          inputTokens  += s.inputTokens;
-          outputTokens += s.outputTokens;
-          cacheWrite   += s.cacheWriteTokens;
-          cacheRead    += s.cacheReadTokens;
-          if (s.model) modelCounts[s.model] = (modelCounts[s.model] ?? 0) + 1;
-        }
-
-        const totalTokens = inputTokens + outputTokens;
-        if (totalTokens === 0) continue;
-
-        const dominantModel = Object.entries(modelCounts).sort((a, b) => b[1] - a[1])[0]?.[0];
-        const cost = calculateCost(inputTokens, outputTokens, cacheWrite, cacheRead, dominantModel);
+        const a = await aggregateProject(projectPath);
+        if (a.totalTokens === 0) continue;
 
         costs.push({
           project: projectPath.split('/').pop() || 'unknown',
-          inputTokens,
-          outputTokens,
-          totalTokens,
-          cost,
-          sessionsCount: files.length,
+          inputTokens: a.inputTokens,
+          outputTokens: a.outputTokens,
+          totalTokens: a.totalTokens,
+          cost: a.cost,
+          sessionsCount: a.sessionCount,
         });
       } catch {
         // progetto non leggibile

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -92,7 +92,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
     getCleanupPeriodDays: () => ipcRenderer.invoke('settings:getCleanupPeriodDays'),
   },
   onDataChanged: (callback: () => void) => {
-    ipcRenderer.on('data:changed', () => callback());
+    const handler = () => callback();
+    ipcRenderer.on('data:changed', handler);
+    return () => ipcRenderer.removeListener('data:changed', handler);
   },
   live: {
     getProcesses: () => ipcRenderer.invoke('live:getProcesses'),

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import { Component, type ReactNode } from 'react'
+import { QueryError } from './QueryError'
 
 interface Props {
   children: ReactNode
@@ -18,24 +19,11 @@ export class ErrorBoundary extends Component<Props, State> {
   render() {
     if (this.state.error) {
       return (
-        <div className="flex items-center justify-center h-full">
-          <div className="text-center max-w-md px-6">
-            <div className="w-12 h-12 rounded-xl bg-red-500/10 border border-red-500/20 flex items-center justify-center mx-auto mb-4">
-              <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
-                <path d="M10 6v5M10 14h.01" stroke="#f87171" strokeWidth="1.5" strokeLinecap="round"/>
-                <circle cx="10" cy="10" r="8.5" stroke="#f87171" strokeWidth="1.3"/>
-              </svg>
-            </div>
-            <p className="text-[14px] font-semibold text-[#e0e2f0] mb-2">Something went wrong</p>
-            <p className="text-[12px] text-[#787e98] font-mono break-all">{this.state.error.message}</p>
-            <button
-              onClick={() => this.setState({ error: null })}
-              className="mt-5 px-4 py-1.5 rounded-lg border border-[#252836] hover:bg-[#1c2235] transition-colors text-[12px] text-[#9096b0]"
-            >
-              Retry
-            </button>
-          </div>
-        </div>
+        <QueryError
+          title="Something went wrong"
+          error={this.state.error}
+          onRetry={() => this.setState({ error: null })}
+        />
       )
     }
     return this.props.children

--- a/src/components/QueryError.tsx
+++ b/src/components/QueryError.tsx
@@ -1,0 +1,67 @@
+interface QueryErrorProps {
+  /** The thrown/returned error to surface (Error, string, or anything). */
+  error?: unknown
+  /** Optional retry handler — renders a "Retry" button when provided. */
+  onRetry?: () => void
+  /** Headline shown above the error message. */
+  title?: string
+}
+
+function messageOf(error: unknown): string {
+  if (error instanceof Error) return error.message
+  if (typeof error === 'string') return error
+  if (error) return String(error)
+  return 'An unexpected error occurred.'
+}
+
+/**
+ * Shared "failed to load" panel used both by `ErrorBoundary` (render crashes)
+ * and by data-fetching views (React Query `isError`). Theme-aware via `--cl-*`.
+ */
+export function QueryError({ error, onRetry, title = 'Failed to load' }: QueryErrorProps) {
+  return (
+    <div className="flex items-center justify-center h-full w-full" style={{ minHeight: 220 }}>
+      <div className="text-center" style={{ maxWidth: 420, padding: '0 24px' }}>
+        <div
+          style={{
+            width: 48,
+            height: 48,
+            borderRadius: 14,
+            margin: '0 auto 16px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            background: 'var(--cl-danger-soft)',
+            border: '1px solid color-mix(in srgb, var(--cl-danger) 26%, transparent)',
+          }}
+        >
+          <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+            <path d="M10 6v5M10 14h.01" stroke="var(--cl-danger)" strokeWidth="1.5" strokeLinecap="round" />
+            <circle cx="10" cy="10" r="8.5" stroke="var(--cl-danger)" strokeWidth="1.3" />
+          </svg>
+        </div>
+        <p style={{ fontSize: 14, fontWeight: 600, color: 'var(--cl-ink)', marginBottom: 6 }}>{title}</p>
+        <p style={{ fontSize: 12, color: 'var(--cl-ink-3)', fontFamily: 'var(--font-mono, monospace)', wordBreak: 'break-word' }}>
+          {messageOf(error)}
+        </p>
+        {onRetry && (
+          <button
+            onClick={onRetry}
+            style={{
+              marginTop: 20,
+              padding: '6px 16px',
+              borderRadius: 8,
+              border: '1px solid var(--cl-line)',
+              background: 'transparent',
+              color: 'var(--cl-ink-2)',
+              fontSize: 12,
+              cursor: 'pointer',
+            }}
+          >
+            Retry
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/project/chat/ChatView.tsx
+++ b/src/components/project/chat/ChatView.tsx
@@ -9,6 +9,7 @@ import { ToolDetailPanel } from './ToolDetailPanel'
 import { MessageBubble } from './MessageBubble'
 import { TopBar } from '../shared/TopBar'
 import { SessionGraphView } from './graph/SessionGraphView'
+import { QueryError } from '../../QueryError'
 
 type ViewMode = 'chat' | 'timeline'
 
@@ -343,7 +344,7 @@ export function ChatView({
   session: SessionSummary
   onBack: () => void
 }) {
-  const { data: messages, isLoading } = useChatSession(project.hash, session.filename)
+  const { data: messages, isLoading, isError, error, refetch } = useChatSession(project.hash, session.filename)
   const projectName = project.realPath.split('/').pop() ?? project.realPath
   const [viewMode, setViewMode] = useState<ViewMode>('chat')
   const [detailsFilter, setDetailsFilter] = useState<ChatDetailsFilter>('minimal')
@@ -459,6 +460,10 @@ export function ChatView({
 
       {selectedTool ? (
         <ToolDetailPanel group={selectedTool} onBack={() => setSelectedTool(null)} />
+      ) : isError ? (
+        <div className="cl-chat-workspace">
+          <QueryError title="Failed to load transcript" error={error} onRetry={() => refetch()} />
+        </div>
       ) : viewMode === 'timeline' ? (
         <div className="cl-chat-workspace cl-chat-workspace--tl">
           {isLoading ? (

--- a/src/components/project/overview/ProjectOverviewContent.tsx
+++ b/src/components/project/overview/ProjectOverviewContent.tsx
@@ -175,6 +175,13 @@ function Bars({ buckets, metric }: { buckets: TimelineBucket[]; metric: StatMetr
 
 const MEM_PREVIEW_MAX = 70
 
+const CLAUDE_MD_SCOPE_LABEL: Record<'global' | 'project' | 'local' | 'subdir', string> = {
+  project: 'Project',
+  local: 'Local',
+  subdir: 'Subdir',
+  global: 'Global',
+}
+
 // Ripulisce la sintassi markdown e tronca per un'anteprima pulita su una riga.
 function memPreview(raw: string): string {
   const clean = raw
@@ -299,8 +306,11 @@ export function ProjectView({
     return all.filter(s => !s.disabledProjectPaths.includes(project.realPath))
   }, [mcpData, project.realPath])
 
-  const projectClaudeMd = claudeMd?.layers.find(l => l.scope === 'project')
   const claudeMdLayers = claudeMd?.layers.length ?? 0
+  const claudeMdLayerList = useMemo(() => {
+    const order = { project: 0, local: 1, subdir: 2, global: 3 } as const
+    return [...(claudeMd?.layers ?? [])].sort((a, b) => order[a.scope] - order[b.scope])
+  }, [claudeMd])
   const skillCount = allSkills.length
   const agents = useMemo(() => {
     const seen = new Map<string, typeof globalAgents[number]>()
@@ -425,11 +435,41 @@ export function ProjectView({
             />
           </section>
 
+          <section className="cl-section">
+            <div className="cl-sec-head">
+              <h2>CLAUDE.md</h2>
+              <span className="ct">{claudeMdLayers} {claudeMdLayers === 1 ? 'layer' : 'layers'} · global → project → local → subdir</span>
+            </div>
+            {claudeMdLayers === 0 ? (
+              <div className="cl-empty">No CLAUDE.md instructions for this project.</div>
+            ) : (
+              <div className="cl-tile-grid">
+                {claudeMdLayerList.map((l, i) => {
+                  const lines = l.content.split('\n').length
+                  const path = l.scope === 'global'
+                    ? '~/.claude/CLAUDE.md'
+                    : l.filePath.startsWith(project.realPath + '/')
+                      ? l.filePath.slice(project.realPath.length + 1)
+                      : l.filePath
+                  return (
+                    <button key={l.filePath} type="button" className={`cl-tile ${i === 0 ? 'accent' : ''}`}
+                      onClick={() => l.scope === 'global'
+                        ? onNavigate({ type: 'global-claudemd' })
+                        : onNavigate({ type: 'project-claudemd', project, layer: l })}>
+                      <span className="glyph">M</span>
+                      <div style={{ minWidth: 0 }}>
+                        <div className="t-name">{CLAUDE_MD_SCOPE_LABEL[l.scope]}</div>
+                        <div className="t-desc">{path}</div>
+                      </div>
+                      <span className="t-meta"><b>{lines}</b> lines</span>
+                    </button>
+                  )
+                })}
+              </div>
+            )}
+          </section>
+
           <section className="cl-config-strip">
-            <button className={`item ${claudeMdLayers ? 'on' : ''}`} type="button"
-              onClick={() => projectClaudeMd ? onNavigate({ type: 'project-claudemd', project, layer: projectClaudeMd }) : onNavigate({ type: 'global-claudemd' })}>
-              <span className="pip" /><span>CLAUDE.md</span><span className="num">{claudeMdLayers} layer{claudeMdLayers === 1 ? '' : 's'}</span>
-            </button>
             <button className={`item ${skillCount ? 'on' : ''}`} type="button" onClick={() => onNavigate({ type: 'project-skills', project })}>
               <span className="pip" /><span>Skills</span><span className="num">{skillCount}</span>
             </button>

--- a/src/hooks/useIPC.ts
+++ b/src/hooks/useIPC.ts
@@ -197,7 +197,7 @@ declare global {
       settings: {
         getCleanupPeriodDays: () => Promise<IpcResult<number>>
       }
-      onDataChanged: (callback: () => void) => void
+      onDataChanged: (callback: () => void) => () => void
       live: {
         getProcesses: () => Promise<IpcResult<ClaudeProcess[]>>
         getSessions: () => Promise<IpcResult<BgSession[]>>
@@ -562,7 +562,7 @@ export function useDataChangedRefetch() {
   const qc = useQueryClient()
 
   useEffect(() => {
-    window.electronAPI.onDataChanged(() => {
+    const unsubscribe = window.electronAPI.onDataChanged(() => {
       qc.invalidateQueries('memory:projects')
       qc.invalidateQueries('memory:project')
       qc.invalidateQueries('cost:summary')
@@ -580,5 +580,6 @@ export function useDataChangedRefetch() {
       qc.invalidateQueries('agents:project')
       qc.invalidateQueries('mcp:global')
     })
+    return unsubscribe
   }, [qc])
 }

--- a/src/tabs/ProjectOverview.tsx
+++ b/src/tabs/ProjectOverview.tsx
@@ -336,37 +336,31 @@ export default function ProjectOverview() {
         return <ProjectClaudeMdView layer={view.layer} onBack={() => setView({ type: 'overview' })} />
       case 'chat':
         return (
-          <ErrorBoundary key={view.session.filename}>
-            <ChatView
-              project={view.project}
-              session={view.session}
-              onBack={() => view.from === 'agents-live'
-                ? setView({ type: 'agents-live', project: view.project })
-                : setView({ type: 'sessions', project: view.project })
-              }
-            />
-          </ErrorBoundary>
+          <ChatView
+            project={view.project}
+            session={view.session}
+            onBack={() => view.from === 'agents-live'
+              ? setView({ type: 'agents-live', project: view.project })
+              : setView({ type: 'sessions', project: view.project })
+            }
+          />
         )
       case 'memory-topic':
         return (
-          <ErrorBoundary key={view.topic.filename}>
-            <MemoryTopicView
-              topic={view.topic}
-              content={view.content}
-              hash={view.hash}
-              onBack={() => selected ? setView({ type: 'project-memory', project: selected }) : goGlobal()}
-            />
-          </ErrorBoundary>
+          <MemoryTopicView
+            topic={view.topic}
+            content={view.content}
+            hash={view.hash}
+            onBack={() => selected ? setView({ type: 'project-memory', project: selected }) : goGlobal()}
+          />
         )
       case 'plan-detail':
         return (
-          <ErrorBoundary key={view.plan.filePath}>
-            <PlanDetailView
-              plan={view.plan}
-              project={view.project}
-              onBack={() => setView({ type: 'project-plans', project: view.project })}
-            />
-          </ErrorBoundary>
+          <PlanDetailView
+            plan={view.plan}
+            project={view.project}
+            onBack={() => setView({ type: 'project-plans', project: view.project })}
+          />
         )
       case 'analytics':
         return <AnalyticsView project={view.project} onBack={() => setView({ type: 'overview' })} />
@@ -383,10 +377,14 @@ export default function ProjectOverview() {
   }
 
   // Deep views take over the full surface (preserve their existing chrome).
+  // A boundary keyed by the view isolates a sub-view crash and auto-clears it on
+  // navigation, instead of bubbling to the app-level boundary and resetting all state.
   if (!isEditorialCore) {
     return (
       <div className="cl-app">
-        <div style={{ flex: 1, overflow: 'hidden' }}>{renderDeepView()}</div>
+        <div style={{ flex: 1, overflow: 'hidden' }}>
+          <ErrorBoundary key={JSON.stringify(view)}>{renderDeepView()}</ErrorBoundary>
+        </div>
         {projectToDelete && (
           <DeleteProjectDialog
             project={projectToDelete}
@@ -455,23 +453,25 @@ export default function ProjectOverview() {
 
       {/* ─── Main ────────────────────────────────────────── */}
       <div className="cl-main">
-        {isGlobalHome ? (
-          <GlobalHomeView onNavigate={setView} onSelectProject={selectProject} />
-        ) : isGlobalLiveAgents ? (
-          <AgentsLiveView
-            embedded
-            onBack={goGlobal}
-            onOpenSession={(project, session) => setView({ type: 'chat', project, session, from: 'agents-live' })}
-          />
-        ) : selected ? (
-          <ProjectView
-            key={selected.hash}
-            project={selected}
-            section={sectionFromView(view)}
-            onNavigate={setView}
-            onOpenProjectSearch={openProjectSearch}
-          />
-        ) : null}
+        <ErrorBoundary key={scope === 'project' ? `project:${selected?.hash ?? 'none'}` : view.type}>
+          {isGlobalHome ? (
+            <GlobalHomeView onNavigate={setView} onSelectProject={selectProject} />
+          ) : isGlobalLiveAgents ? (
+            <AgentsLiveView
+              embedded
+              onBack={goGlobal}
+              onOpenSession={(project, session) => setView({ type: 'chat', project, session, from: 'agents-live' })}
+            />
+          ) : selected ? (
+            <ProjectView
+              key={selected.hash}
+              project={selected}
+              section={sectionFromView(view)}
+              onNavigate={setView}
+              onOpenProjectSearch={openProjectSearch}
+            />
+          ) : null}
+        </ErrorBoundary>
       </div>
 
       {projectToDelete && (


### PR DESCRIPTION
Fixes the **bug**-labelled findings from the repository audit Epic #28. Each area is a separate commit; the full build (`tsc` electron + `vite` renderer) passes and each fix was adversarially reviewed before commit.

## Fixes

### Security
- **#13 — path traversal via project `hash`.** New `projectDir(hash)` helper validates (`assertValidHash`) and builds the path in one step; every hash-taking IPC handler now routes through it (memory/cost/sessions/tasks/plans, `projects:delete`, `live:startWatch`). Also added `assertValidFilename()` to `memory:updateTopic/deleteTopic` and `sessions:getChat` to block traversal through the filename segment (same class, surfaced during review).
- **#14 — arbitrary file write/delete.** New `assertSafeWritePath()` (absolute + `path.resolve()` to collapse `..` + basename allowlist) replaces the fragile `includes('..')` check. Home-containment is enforced for `markdownFile:*` (plans under `~/.claude`) but **not** for `claudeMd:*`, so project `CLAUDE.md` files living outside `$HOME` stay editable (the allowlist `{CLAUDE.md, CLAUDE.local.md}` is the guard there).

### Correctness
- **#18 — per-project cost used a hardcoded flat Sonnet rate.** Extracted a shared `aggregateProject()` in `cost-tracker.ts` (dominant model + cache tokens via the `PRICING` table), reused by both `calculateCostSummary` and `getProjectUsage`, so per-project cost now matches the global summary.
- **#19 — `onDataChanged` leaked IPC listeners.** Now returns a `removeListener` disposer, consumed by `useDataChangedRefetch`'s effect cleanup.
- **#20 — React Query error states unhandled.** New theme-aware `QueryError` panel (reused by `ErrorBoundary`); `ChatView` renders it on `isError` instead of a blank screen. Per-view inline boundaries replaced by one keyed boundary around deep views + one around the editorial core, keyed so `ProjectView` is not remounted on sub-tab switches.

## Note
- **#2** (CLAUDE.md hierarchy only showing the first layer) was already resolved by `d2ebf88` (layers rendered as a navigable tile grid) — closing it separately.

Closes #13, closes #14, closes #18, closes #19, closes #20.
Part of #28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)