### PR TITLE
fix(security): run ai:run via spawn args array without shell (#17)

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -654,16 +654,23 @@ ipcMain.handle('ai:run', async (event, instruction: string, inputContent: string
     currentAiProcess = null;
   }
 
+  const { existsSync, statSync } = await import('fs');
+  if (!projectPath || !existsSync(projectPath) || !statSync(projectPath).isDirectory()) {
+    return err(`Project directory not found on disk: ${projectPath}. The project may have been moved or deleted.`);
+  }
+
   return new Promise<IpcResult<null>>((resolve) => {
-    // Con shell:true su Unix, spawn(cmd, args) diventa: /bin/sh -c cmd arg1 arg2
-    // dove arg1/arg2 sono $0/$1 della shell, NON argomenti di cmd.
-    // Soluzione: passare tutto come stringa singola con args=[].
-    const escapedInstruction = instruction.replace(/'/g, "'\\''");
-    const cmd = `claude -p '${escapedInstruction}' --model Haiku --allowedTools 'Read,Glob,Grep,WebSearch,WebFetch' --no-session-persistence`;
+    // execFile-style: nessuna shell, l'istruzione passa come argomento separato
+    // (niente string-building né escaping fragile — cfr. agents:dispatchBg).
+    const args = [
+      '-p', instruction,
+      '--model', 'Haiku',
+      '--allowedTools', 'Read,Glob,Grep,WebSearch,WebFetch',
+      '--no-session-persistence',
+    ];
     const localBinPath = join(os.homedir(), '.local', 'bin');
-    const proc = spawn(cmd, [], {
+    const proc = spawn('claude', args, {
       cwd: projectPath,
-      shell: true,
       env: { ...process.env, PATH: `${localBinPath}:/usr/local/bin:${process.env.PATH || ''}` },
     });
     currentAiProcess = proc;


### PR DESCRIPTION
Fixes #17.

## Problem
The `ai:run` IPC handler built a shell command string with manual POSIX quote-escaping and ran it via `spawn(..., { shell: true })`. The escaping was correct (so this was not a known injection today), but string-building + shell is fragile, inconsistent with sibling handlers, and `projectPath` (used as `cwd`) was unvalidated.

## Fix
- Replace the shell command string with `spawn('claude', argsArray, {...})` and **no** `shell`, passing the instruction as a discrete argument — no escaping needed. This matches the safe pattern already used by `agents:dispatchBg` and `runClaudeCommand`.
- Validate that `projectPath` exists and is a directory before running (same message/style as `agents:dispatchBg`).
- `stdout`/`stderr` streaming to `ai:chunk`/`ai:error` is unchanged (`spawn` is still required here for streaming, unlike `execFile`).

## Verification
- `tsc -p tsconfig.electron.json --noEmit` passes.

Part of #28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)