### PR TITLE
fix(security): harden main BrowserWindow (#16)

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, dialog, ipcMain } from 'electron';
+import { app, BrowserWindow, dialog, ipcMain, shell } from 'electron';
 import { basename, isAbsolute, join, resolve, sep } from 'path';
 import os from 'os';
 import { mkdtempSync, rmSync, writeFileSync } from 'fs';
@@ -168,7 +168,27 @@ function createWindow() {
       preload: join(__dirname, 'preload.js'),
       contextIsolation: true,
       nodeIntegration: false,
+      sandbox: true,
     },
+  });
+
+  // Open external links (window.open from Markdown) in the system browser, deny in-app windows
+  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+    if (url.startsWith('http://') || url.startsWith('https://')) {
+      shell.openExternal(url);
+    }
+    return { action: 'deny' };
+  });
+
+  // Block navigation away from the app origin
+  const appOrigin = isDev ? 'http://localhost:5173' : 'file://';
+  mainWindow.webContents.on('will-navigate', (event, url) => {
+    if (!url.startsWith(appOrigin)) {
+      event.preventDefault();
+      if (url.startsWith('http://') || url.startsWith('https://')) {
+        shell.openExternal(url);
+      }
+    }
   });
 
   if (isDev) {


### PR DESCRIPTION
## Summary
Hardens the main Electron `BrowserWindow` per the Electron security checklist. Resolves #16.

- Enable `sandbox: true` on the main window `webPreferences` (the preload uses only `ipcRenderer`, which is sandbox-safe).
- Add `setWindowOpenHandler` that opens `http(s)` links in the system browser and denies in-app window creation.
- Add a `will-navigate` handler that blocks navigation away from the app origin, opening external `http(s)` links in the system browser instead.

This brings the main window in line with the PDF export window, which already sets `sandbox: true`.

## Testing
- `tsc -p tsconfig.electron.json --noEmit` passes.
- Verified `electron/preload.ts` imports only `contextBridge`/`ipcRenderer` (no Node-only APIs), so it works under the sandbox.