### PR TITLE
chore(deps): drop unused playwright-core and add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      # Bundle low-risk dev/type/lint tooling into a single PR to reduce noise.
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+    labels:
+      - dependencies
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "claudelens-app",
       "version": "1.5.0",
+      "license": "MIT",
       "dependencies": {
         "@tailwindcss/typography": "^0.5.19",
         "chokidar": "^3.6.0",
@@ -38,7 +39,6 @@
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.26",
         "globals": "^15.15.0",
-        "playwright-core": "^1.60.0",
         "postcss": "^8.4.38",
         "prettier": "^3.8.3",
         "tailwindcss": "^3.4.4",
@@ -8186,19 +8186,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/playwright-core": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
-      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/plist": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.26",
     "globals": "^15.15.0",
-    "playwright-core": "^1.60.0",
     "postcss": "^8.4.38",
     "prettier": "^3.8.3",
     "tailwindcss": "^3.4.4",


### PR DESCRIPTION
## Summary

Tackles part of the dependency-hygiene cleanup tracked in #26. This PR covers two of its points — removing the unused `playwright-core` dependency and adding a Dependabot configuration. The remaining items (Electron/TypeScript upgrades, react-query v3 → @tanstack/react-query v5 migration) stay open.

## Changes

- **Remove `playwright-core`**: dropped the unused devDependency from `package.json` and `package-lock.json`. No test script or source file references it, so it only added lockfile/footprint noise.
- **Add `.github/dependabot.yml`**: weekly update checks for the `npm` and `github-actions` ecosystems. Low-risk dev-dependency minor/patch bumps are grouped into a single PR to reduce noise, and all PRs are labeled `dependencies`.

## Notes

`package-lock.json` also picks up a benign `"license": "MIT"` field re-added by npm during resolution.

Part of #26