### PR TITLE
chore: migrate react-query v3 to @tanstack/react-query v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/typography": "^0.5.19",
+        "@tanstack/react-query": "^5.100.14",
         "chokidar": "^3.6.0",
         "glob": "^10.4.1",
         "highlight.js": "^11.11.1",
@@ -17,7 +18,6 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-markdown": "^9.0.1",
-        "react-query": "^3.39.3",
         "recharts": "^3.8.0",
         "rehype-highlight": "^7.0.2",
         "remark-frontmatter": "^5.0.0",
@@ -300,6 +300,7 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -2034,6 +2035,32 @@
         "node": ">=4"
       }
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.100.14",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.14.tgz",
+      "integrity": "sha512-5X41dGpxgeaHISCRW2oYwcSycZeULZzAunaudXT9ov1KOTj9xwt0CH6hbwqP1/z74ZWF7rYFnDpyYH07XFcZew==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.100.14",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.14.tgz",
+      "integrity": "sha512-oOr6aRdSFEwWhzxEkD/9ZcItM3+LjBSkeVmadWKwUssAHTsqd/7bOjWrX4AbvEkoEhgAxzN0Xk6H/aYzXiYBAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.100.14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -3240,15 +3267,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/big-integer": {
-      "version": "1.6.52",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
-      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
-      "license": "Unlicense",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -3289,22 +3307,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/broadcast-channel": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz",
-      "integrity": "sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "detect-node": "^2.1.0",
-        "js-sha3": "0.8.0",
-        "microseconds": "0.2.0",
-        "nano-time": "1.0.0",
-        "oblivious-set": "1.0.0",
-        "rimraf": "3.0.2",
-        "unload": "2.2.0"
       }
     },
     "node_modules/browserslist": {
@@ -3841,6 +3843,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/concurrently": {
@@ -4229,7 +4232,9 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/devlop": {
       "version": "1.1.0",
@@ -5290,6 +5295,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
@@ -5888,6 +5894,7 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -5898,6 +5905,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/inline-style-parser": {
@@ -6111,12 +6119,6 @@
         "@sideway/formula": "^3.0.1",
         "@sideway/pinpoint": "^2.0.0"
       }
-    },
-    "node_modules/js-sha3": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
-      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -6365,16 +6367,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/match-sorter": {
-      "version": "6.3.4",
-      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.4.tgz",
-      "integrity": "sha512-jfZW7cWS5y/1xswZo8VBOdudUiSd9nifYRWphc9M5D/ee4w4AoXLgBEdRbgVaxbMuagBPeUC5y2Hi8DO6o9aDg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.23.8",
-        "remove-accents": "0.5.0"
       }
     },
     "node_modules/matcher": {
@@ -7314,12 +7306,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/microseconds": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
-      "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==",
-      "license": "MIT"
-    },
     "node_modules/mime": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
@@ -7466,15 +7452,6 @@
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
-      }
-    },
-    "node_modules/nano-time": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
-      "integrity": "sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==",
-      "license": "ISC",
-      "dependencies": {
-        "big-integer": "^1.6.16"
       }
     },
     "node_modules/nanoid": {
@@ -7717,16 +7694,11 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/oblivious-set": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
-      "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw==",
-      "license": "MIT"
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -7850,6 +7822,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8377,32 +8350,6 @@
         "react": ">=18"
       }
     },
-    "node_modules/react-query": {
-      "version": "3.39.3",
-      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.39.3.tgz",
-      "integrity": "sha512-nLfLz7GiohKTJDuT4us4X3h/8unOh+00MLb2yJoGTPjxKs2bc1iDhkNx2bd5MKklXnOD3NrVZ+J2UXujA5In4g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "broadcast-channel": "^3.4.1",
-        "match-sorter": "^6.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
@@ -8614,12 +8561,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/remove-accents": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
-      "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
-      "license": "MIT"
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -8722,65 +8663,6 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/rimraf/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/roarr": {
@@ -9955,16 +9837,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/unload": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
-      "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/runtime": "^7.6.2",
-        "detect-node": "^2.0.4"
-      }
-    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -10415,6 +10287,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/xmlbuilder": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@tailwindcss/typography": "^0.5.19",
+    "@tanstack/react-query": "^5.100.14",
     "chokidar": "^3.6.0",
     "glob": "^10.4.1",
     "highlight.js": "^11.11.1",
@@ -46,7 +47,6 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^9.0.1",
-    "react-query": "^3.39.3",
     "recharts": "^3.8.0",
     "rehype-highlight": "^7.0.2",
     "remark-frontmatter": "^5.0.0",

--- a/src/components/project/agents-live/AgentsLiveView.tsx
+++ b/src/components/project/agents-live/AgentsLiveView.tsx
@@ -460,14 +460,14 @@ export function AgentsLiveView({
             </select>
             <button 
               type="submit" 
-              disabled={!prompt.trim() || dispatchBg.isLoading}
+              disabled={!prompt.trim() || dispatchBg.isPending}
               style={{ 
                 padding: '8px 16px', borderRadius: '6px', background: 'var(--cl-ink-1)', color: 'var(--cl-paper)', 
-                fontWeight: 600, cursor: prompt.trim() && !dispatchBg.isLoading ? 'pointer' : 'not-allowed', 
-                opacity: prompt.trim() && !dispatchBg.isLoading ? 1 : 0.5 
+                fontWeight: 600, cursor: prompt.trim() && !dispatchBg.isPending ? 'pointer' : 'not-allowed', 
+                opacity: prompt.trim() && !dispatchBg.isPending ? 1 : 0.5 
               }}
             >
-              {dispatchBg.isLoading ? 'Dispatching...' : 'Dispatch'}
+              {dispatchBg.isPending ? 'Dispatching...' : 'Dispatch'}
             </button>
           </form>
         </div>

--- a/src/components/project/agents/CreateAgentPage.tsx
+++ b/src/components/project/agents/CreateAgentPage.tsx
@@ -76,7 +76,7 @@ export function CreateAgentPage({ project, onBack, onSaved }: {
     await submit()
   }
 
-  useCreateFormKeys({ canSubmit, isLoading: createAgent.isLoading, onSubmit: submit, onCancel: onBack })
+  useCreateFormKeys({ canSubmit, isLoading: createAgent.isPending, onSubmit: submit, onCancel: onBack })
 
   const labelCls = "flex items-center font-mono text-[10px] uppercase tracking-[0.16em] text-[var(--cl-ink-3)] mb-1.5"
   const inputCls = "w-full rounded-none border border-[var(--cl-line)] bg-[var(--cl-paper)] px-3 py-2 text-[13px] text-[var(--cl-ink)] placeholder:text-[var(--cl-ink-4)] outline-none focus:border-[var(--cl-ink)] transition-colors"
@@ -273,11 +273,11 @@ export function CreateAgentPage({ project, onBack, onSaved }: {
             <button type="button" onClick={onBack} className="cl-btn">Cancel</button>
             <button
               type="submit"
-              disabled={!canSubmit || createAgent.isLoading}
+              disabled={!canSubmit || createAgent.isPending}
               className="cl-btn cl-btn--primary"
-              style={{ opacity: (!canSubmit || createAgent.isLoading) ? 0.4 : 1, cursor: (!canSubmit || createAgent.isLoading) ? 'not-allowed' : 'pointer' }}
+              style={{ opacity: (!canSubmit || createAgent.isPending) ? 0.4 : 1, cursor: (!canSubmit || createAgent.isPending) ? 'not-allowed' : 'pointer' }}
             >
-              {createAgent.isLoading ? 'Saving…' : 'Create Agent ↗'}
+              {createAgent.isPending ? 'Saving…' : 'Create Agent ↗'}
             </button>
           </div>
         </form>

--- a/src/components/project/memory/MemoryTopicView.tsx
+++ b/src/components/project/memory/MemoryTopicView.tsx
@@ -226,7 +226,7 @@ export function MemoryTopicView({
   const extraActions = !readOnly && (
     <DeleteControl
       open={confirmDelete}
-      busy={deleteMut.isLoading}
+      busy={deleteMut.isPending}
       onArm={() => setConfirmDelete(true)}
       onCancel={() => setConfirmDelete(false)}
       onConfirm={handleDelete}

--- a/src/components/project/overview/DuplicateProjectsNotice.tsx
+++ b/src/components/project/overview/DuplicateProjectsNotice.tsx
@@ -262,7 +262,7 @@ export function DuplicateProjectsView({ onBack }: { onBack: () => void }) {
           plan={dialog.plan}
           sourceName={dialog.sourceName}
           destName={dialog.destName}
-          isLoading={executeMerge.isLoading}
+          isLoading={executeMerge.isPending}
           canExecute={true}
           onConfirm={confirmMerge}
           onCancel={() => setDialog(null)}

--- a/src/components/project/skills/CreateSkillPage.tsx
+++ b/src/components/project/skills/CreateSkillPage.tsx
@@ -63,7 +63,7 @@ export function CreateSkillPage({ project, onBack, onSaved }: {
     await submit()
   }
 
-  useCreateFormKeys({ canSubmit, isLoading: createSkill.isLoading, onSubmit: submit, onCancel: onBack })
+  useCreateFormKeys({ canSubmit, isLoading: createSkill.isPending, onSubmit: submit, onCancel: onBack })
 
   const labelCls = "flex items-center font-mono text-[10px] uppercase tracking-[0.16em] text-[var(--cl-ink-3)] mb-1.5"
   const inputCls = "w-full rounded-none border border-[var(--cl-line)] bg-[var(--cl-paper)] px-3 py-2 text-[13px] text-[var(--cl-ink)] placeholder:text-[var(--cl-ink-4)] outline-none focus:border-[var(--cl-ink)] transition-colors"
@@ -238,11 +238,11 @@ export function CreateSkillPage({ project, onBack, onSaved }: {
               <button type="button" onClick={onBack} className="cl-btn">Cancel</button>
               <button
                 type="submit"
-                disabled={!canSubmit || createSkill.isLoading}
+                disabled={!canSubmit || createSkill.isPending}
                 className="cl-btn cl-btn--primary"
-                style={{ opacity: (!canSubmit || createSkill.isLoading) ? 0.4 : 1, cursor: (!canSubmit || createSkill.isLoading) ? 'not-allowed' : 'pointer' }}
+                style={{ opacity: (!canSubmit || createSkill.isPending) ? 0.4 : 1, cursor: (!canSubmit || createSkill.isPending) ? 'not-allowed' : 'pointer' }}
               >
-                {createSkill.isLoading ? 'Saving…' : 'Create Skill ↗'}
+                {createSkill.isPending ? 'Saving…' : 'Create Skill ↗'}
               </button>
             </div>
         </form>

--- a/src/hooks/useIPC.ts
+++ b/src/hooks/useIPC.ts
@@ -1,4 +1,4 @@
-import { useQuery, useMutation, useQueryClient } from 'react-query'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useEffect } from 'react'
 
 import type {
@@ -219,15 +219,17 @@ async function unwrap<T>(promise: Promise<IpcResult<T>>): Promise<T> {
 }
 
 export function useMemoryProjects() {
-  return useQuery('memory:projects', () =>
-    unwrap(window.electronAPI.memory.listProjects())
-  )
+  return useQuery({
+    queryKey: ['memory:projects'],
+    queryFn: () => unwrap(window.electronAPI.memory.listProjects()),
+  })
 }
 
 export function useDuplicateProjects() {
-  return useQuery('projects:duplicates', () =>
-    unwrap(window.electronAPI.projects.detectDuplicates())
-  )
+  return useQuery({
+    queryKey: ['projects:duplicates'],
+    queryFn: () => unwrap(window.electronAPI.projects.detectDuplicates()),
+  })
 }
 
 /** Calcola il piano di merge (read-only) per una coppia source → dest. */
@@ -238,109 +240,102 @@ export function planMerge(sourceHash: string, destHash: string): Promise<MergePl
 /** Mutation: esegue il merge e invalida le query sui duplicati/progetti. */
 export function useExecuteMerge() {
   const qc = useQueryClient()
-  return useMutation(
-    ({ sourceHash, destHash }: { sourceHash: string; destHash: string }) =>
+  return useMutation({
+    mutationFn: ({ sourceHash, destHash }: { sourceHash: string; destHash: string }) =>
       unwrap(window.electronAPI.projects.executeMerge(sourceHash, destHash)),
-    {
-      onSuccess: () => {
-        qc.invalidateQueries('projects:duplicates')
-        qc.invalidateQueries('memory:projects')
-        qc.invalidateQueries('cost:summary')
-      },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['projects:duplicates'] })
+      qc.invalidateQueries({ queryKey: ['memory:projects'] })
+      qc.invalidateQueries({ queryKey: ['cost:summary'] })
     },
-  )
+  })
 }
 
 export function useMemoryProject(hash: string | null) {
-  return useQuery(
-    ['memory:project', hash],
-    () => unwrap(window.electronAPI.memory.getProject(hash!)),
-    { enabled: hash !== null }
-  )
+  return useQuery({
+    queryKey: ['memory:project', hash],
+    queryFn: () => unwrap(window.electronAPI.memory.getProject(hash!)),
+    enabled: hash !== null,
+  })
 }
 
 export function useCostSummary() {
-  return useQuery('cost:summary', () =>
-    unwrap(window.electronAPI.cost.getSummary())
-  )
+  return useQuery({
+    queryKey: ['cost:summary'],
+    queryFn: () => unwrap(window.electronAPI.cost.getSummary()),
+  })
 }
 
 export function usePricingMeta() {
-  return useQuery('cost:pricingMeta', () =>
-    unwrap(window.electronAPI.cost.getPricingMeta()),
-    { staleTime: Infinity }
-  )
+  return useQuery({
+    queryKey: ['cost:pricingMeta'],
+    queryFn: () => unwrap(window.electronAPI.cost.getPricingMeta()),
+    staleTime: Infinity,
+  })
 }
 
 export function useClaudeMdHierarchy(realPath: string | null) {
-  return useQuery(
-    ['claudeMd:hierarchy', realPath],
-    () => unwrap(window.electronAPI.claudeMd.getHierarchy(realPath!)),
-    { enabled: realPath !== null }
-  )
+  return useQuery({
+    queryKey: ['claudeMd:hierarchy', realPath],
+    queryFn: () => unwrap(window.electronAPI.claudeMd.getHierarchy(realPath!)),
+    enabled: realPath !== null,
+  })
 }
 
 export function useGlobalClaudeMd() {
-  return useQuery('claudeMd:global', () =>
-    unwrap(window.electronAPI.claudeMd.getGlobal())
-  )
+  return useQuery({
+    queryKey: ['claudeMd:global'],
+    queryFn: () => unwrap(window.electronAPI.claudeMd.getGlobal()),
+  })
 }
 
 export function useWriteGlobalClaudeMd() {
   const qc = useQueryClient()
-  return useMutation(
-    (content: string) => unwrap(window.electronAPI.claudeMd.writeGlobal(content)),
-    {
-      onSuccess: () => {
-        qc.invalidateQueries('claudeMd:global')
-        qc.invalidateQueries('claudeMd:hierarchy')
-      },
-    }
-  )
+  return useMutation({
+    mutationFn: (content: string) => unwrap(window.electronAPI.claudeMd.writeGlobal(content)),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['claudeMd:global'] })
+      qc.invalidateQueries({ queryKey: ['claudeMd:hierarchy'] })
+    },
+  })
 }
 
 export function useWriteMarkdownFile(invalidateKeys: string[] = []) {
   const qc = useQueryClient()
-  return useMutation(
-    ({ filePath, content }: { filePath: string; content: string }) =>
+  return useMutation({
+    mutationFn: ({ filePath, content }: { filePath: string; content: string }) =>
       unwrap(window.electronAPI.markdownFile.write(filePath, content)),
-    {
-      onSuccess: () => {
-        invalidateKeys.forEach(k => qc.invalidateQueries(k))
-      },
-    }
-  )
+    onSuccess: () => {
+      invalidateKeys.forEach(k => qc.invalidateQueries({ queryKey: [k] }))
+    },
+  })
 }
 
 export function useDeleteMarkdownFile(invalidateKeys: string[] = []) {
   const qc = useQueryClient()
-  return useMutation(
-    ({ filePath, pruneEmptyDir }: { filePath: string; pruneEmptyDir?: boolean }) =>
+  return useMutation({
+    mutationFn: ({ filePath, pruneEmptyDir }: { filePath: string; pruneEmptyDir?: boolean }) =>
       unwrap(window.electronAPI.markdownFile.delete(filePath, pruneEmptyDir ? { pruneEmptyDir } : undefined)),
-    {
-      onSuccess: () => {
-        invalidateKeys.forEach(k => qc.invalidateQueries(k))
-      },
-    }
-  )
+    onSuccess: () => {
+      invalidateKeys.forEach(k => qc.invalidateQueries({ queryKey: [k] }))
+    },
+  })
 }
 
 export function useDeleteClaudeMdFile() {
   const qc = useQueryClient()
-  return useMutation(
-    (filePath: string | null) =>
+  return useMutation({
+    mutationFn: (filePath: string | null) =>
       unwrap(
         filePath
           ? window.electronAPI.claudeMd.deleteFile(filePath)
           : window.electronAPI.claudeMd.deleteGlobal()
       ),
-    {
-      onSuccess: () => {
-        qc.invalidateQueries('claudeMd:global')
-        qc.invalidateQueries('claudeMd:hierarchy')
-      },
-    }
-  )
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['claudeMd:global'] })
+      qc.invalidateQueries({ queryKey: ['claudeMd:hierarchy'] })
+    },
+  })
 }
 
 export function saveMarkdownExport(defaultFilename: string, content: string): Promise<ExportSaveResult> {
@@ -353,219 +348,214 @@ export function savePdfExport(defaultFilename: string, html: string): Promise<Ex
 
 export function useWriteClaudeMdFile() {
   const qc = useQueryClient()
-  return useMutation(
-    ({ filePath, content }: { filePath: string; content: string }) =>
+  return useMutation({
+    mutationFn: ({ filePath, content }: { filePath: string; content: string }) =>
       unwrap(window.electronAPI.claudeMd.writeFile(filePath, content)),
-    {
-      onSuccess: () => {
-        qc.invalidateQueries('claudeMd:global')
-        qc.invalidateQueries('claudeMd:hierarchy')
-      },
-    }
-  )
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['claudeMd:global'] })
+      qc.invalidateQueries({ queryKey: ['claudeMd:hierarchy'] })
+    },
+  })
 }
 
 export function useProjectRules(realPath: string | null) {
-  return useQuery(
-    ['rules:project', realPath],
-    () => unwrap(window.electronAPI.rules.getByProject(realPath!)),
-    { enabled: realPath !== null }
-  )
+  return useQuery({
+    queryKey: ['rules:project', realPath],
+    queryFn: () => unwrap(window.electronAPI.rules.getByProject(realPath!)),
+    enabled: realPath !== null,
+  })
 }
 
 export function useSessionList(hash: string | null) {
-  return useQuery(
-    ['sessions:project', hash],
-    () => unwrap(window.electronAPI.sessions.listByProject(hash!)),
-    { enabled: hash !== null }
-  )
+  return useQuery({
+    queryKey: ['sessions:project', hash],
+    queryFn: () => unwrap(window.electronAPI.sessions.listByProject(hash!)),
+    enabled: hash !== null,
+  })
 }
 
 export function useProjectTasks(hash: string | null) {
-  return useQuery(
-    ['tasks:project', hash],
-    () => unwrap(window.electronAPI.tasks.getByProject(hash!)),
-    { enabled: hash !== null }
-  )
+  return useQuery({
+    queryKey: ['tasks:project', hash],
+    queryFn: () => unwrap(window.electronAPI.tasks.getByProject(hash!)),
+    enabled: hash !== null,
+  })
 }
 
 export function useProjectPlans(hash: string | null) {
-  return useQuery(
-    ['plans:project', hash],
-    () => unwrap(window.electronAPI.plans.getByProject(hash!)),
-    { enabled: hash !== null }
-  )
+  return useQuery({
+    queryKey: ['plans:project', hash],
+    queryFn: () => unwrap(window.electronAPI.plans.getByProject(hash!)),
+    enabled: hash !== null,
+  })
 }
 
 export function useCleanupPeriodDays() {
-  return useQuery(
-    'settings:cleanupPeriodDays',
-    () => unwrap(window.electronAPI.settings.getCleanupPeriodDays()),
-    { staleTime: 60_000 }
-  )
+  return useQuery({
+    queryKey: ['settings:cleanupPeriodDays'],
+    queryFn: () => unwrap(window.electronAPI.settings.getCleanupPeriodDays()),
+    staleTime: 60_000,
+  })
 }
 
 export function useProjectCost(hash: string | null) {
-  return useQuery(
-    ['cost:project', hash],
-    () => unwrap(window.electronAPI.cost.getByProject(hash!)),
-    { enabled: hash !== null }
-  )
+  return useQuery({
+    queryKey: ['cost:project', hash],
+    queryFn: () => unwrap(window.electronAPI.cost.getByProject(hash!)),
+    enabled: hash !== null,
+  })
 }
 
 export function useChatSession(hash: string, filename: string | null) {
-  return useQuery(
-    ['sessions:chat', hash, filename],
-    () => unwrap(window.electronAPI.sessions.getChat(hash, filename!)),
-    { enabled: filename !== null }
-  )
+  return useQuery({
+    queryKey: ['sessions:chat', hash, filename],
+    queryFn: () => unwrap(window.electronAPI.sessions.getChat(hash, filename!)),
+    enabled: filename !== null,
+  })
 }
 
 export function useLiveSessions() {
-  return useQuery(
-    'live:sessions',
-    () => unwrap(window.electronAPI.live.getSessions()),
-    { refetchInterval: 4000 }
-  )
+  return useQuery({
+    queryKey: ['live:sessions'],
+    queryFn: () => unwrap(window.electronAPI.live.getSessions()),
+    refetchInterval: 4000,
+  })
 }
 
 export function useCreateTopic(hash: string) {
   const qc = useQueryClient()
-  return useMutation(
-    (input: TopicInput) => unwrap(window.electronAPI.memory.createTopic(hash, input)),
-    { onSuccess: () => qc.invalidateQueries(['memory:project', hash]) }
-  )
+  return useMutation({
+    mutationFn: (input: TopicInput) => unwrap(window.electronAPI.memory.createTopic(hash, input)),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['memory:project', hash] }),
+  })
 }
 
 export function useUpdateTopic(hash: string) {
   const qc = useQueryClient()
-  return useMutation(
-    ({ filename, input }: { filename: string; input: TopicInput }) =>
+  return useMutation({
+    mutationFn: ({ filename, input }: { filename: string; input: TopicInput }) =>
       unwrap(window.electronAPI.memory.updateTopic(hash, filename, input)),
-    { onSuccess: () => qc.invalidateQueries(['memory:project', hash]) }
-  )
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['memory:project', hash] }),
+  })
 }
 
 export function useDeleteTopic(hash: string) {
   const qc = useQueryClient()
-  return useMutation(
-    (filename: string) => unwrap(window.electronAPI.memory.deleteTopic(hash, filename)),
-    { onSuccess: () => qc.invalidateQueries(['memory:project', hash]) }
-  )
+  return useMutation({
+    mutationFn: (filename: string) => unwrap(window.electronAPI.memory.deleteTopic(hash, filename)),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['memory:project', hash] }),
+  })
 }
 
 export function useGlobalSkills() {
-  return useQuery('skills:global', () =>
-    unwrap(window.electronAPI.skills.getGlobal())
-  )
+  return useQuery({
+    queryKey: ['skills:global'],
+    queryFn: () => unwrap(window.electronAPI.skills.getGlobal()),
+  })
 }
 
 export function useAllSkills(realPath: string | null) {
-  return useQuery(
-    ['skills:all', realPath],
-    () => unwrap(window.electronAPI.skills.getAll(realPath!)),
-    { enabled: realPath !== null }
-  )
+  return useQuery({
+    queryKey: ['skills:all', realPath],
+    queryFn: () => unwrap(window.electronAPI.skills.getAll(realPath!)),
+    enabled: realPath !== null,
+  })
 }
 
 export function useGlobalAgents() {
-  return useQuery('agents:global', () =>
-    unwrap(window.electronAPI.agents.getGlobal())
-  )
+  return useQuery({
+    queryKey: ['agents:global'],
+    queryFn: () => unwrap(window.electronAPI.agents.getGlobal()),
+  })
 }
 
 export function useGlobalMcp() {
-  return useQuery('mcp:global', () =>
-    unwrap(window.electronAPI.mcp.getGlobal())
-  )
+  return useQuery({
+    queryKey: ['mcp:global'],
+    queryFn: () => unwrap(window.electronAPI.mcp.getGlobal()),
+  })
 }
 
 export function useProjectAgents(realPath: string | null) {
-  return useQuery(
-    ['agents:project', realPath],
-    () => unwrap(window.electronAPI.agents.getByProject(realPath!)),
-    { enabled: realPath !== null }
-  )
+  return useQuery({
+    queryKey: ['agents:project', realPath],
+    queryFn: () => unwrap(window.electronAPI.agents.getByProject(realPath!)),
+    enabled: realPath !== null,
+  })
 }
 
 export function useCreateSkill() {
   const qc = useQueryClient()
-  return useMutation(
-    ({ input, projectPath }: { input: SkillInput; projectPath?: string }) =>
+  return useMutation({
+    mutationFn: ({ input, projectPath }: { input: SkillInput; projectPath?: string }) =>
       unwrap(window.electronAPI.skills.create(input, projectPath)),
-    {
-      onSuccess: () => {
-        qc.invalidateQueries('skills:global')
-        qc.invalidateQueries('skills:all')
-      },
-    }
-  )
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['skills:global'] })
+      qc.invalidateQueries({ queryKey: ['skills:all'] })
+    },
+  })
 }
 
 export function useCreateAgent() {
   const qc = useQueryClient()
-  return useMutation(
-    ({ input, projectPath }: { input: AgentInput; projectPath?: string }) =>
+  return useMutation({
+    mutationFn: ({ input, projectPath }: { input: AgentInput; projectPath?: string }) =>
       unwrap(window.electronAPI.agents.create(input, projectPath)),
-    {
-      onSuccess: () => {
-        qc.invalidateQueries('agents:global')
-        qc.invalidateQueries('agents:project')
-      },
-    }
-  )
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['agents:global'] })
+      qc.invalidateQueries({ queryKey: ['agents:project'] })
+    },
+  })
 }
 
 export function useDispatchBackgroundAgent() {
   const qc = useQueryClient()
-  return useMutation(
-    ({ cwd, prompt, name, agent, model }: { cwd: string; prompt: string; name?: string; agent?: string; model?: string }) =>
+  return useMutation({
+    mutationFn: ({ cwd, prompt, name, agent, model }: { cwd: string; prompt: string; name?: string; agent?: string; model?: string }) =>
       unwrap(window.electronAPI.agents.dispatchBg(cwd, prompt, name, agent, model)),
-    {
-      onSuccess: () => {
-        qc.invalidateQueries('live:sessions')
-      },
-    }
-  )
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['live:sessions'] })
+    },
+  })
 }
 
 export function useDeleteBackgroundAgent() {
   const qc = useQueryClient()
-  return useMutation(
-    (id: string) => unwrap(window.electronAPI.agents.deleteBg(id)),
-    { onSuccess: () => qc.invalidateQueries('live:sessions') }
-  )
+  return useMutation({
+    mutationFn: (id: string) => unwrap(window.electronAPI.agents.deleteBg(id)),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['live:sessions'] }),
+  })
 }
 
 export function useStopBackgroundAgent() {
   const qc = useQueryClient()
-  return useMutation(
-    (id: string) => unwrap(window.electronAPI.agents.stopBg(id)),
-    { onSuccess: () => qc.invalidateQueries('live:sessions') }
-  )
+  return useMutation({
+    mutationFn: (id: string) => unwrap(window.electronAPI.agents.stopBg(id)),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['live:sessions'] }),
+  })
 }
 
 export function useRespawnBackgroundAgent() {
   const qc = useQueryClient()
-  return useMutation(
-    (id: string) => unwrap(window.electronAPI.agents.respawnBg(id)),
-    { onSuccess: () => qc.invalidateQueries('live:sessions') }
-  )
+  return useMutation({
+    mutationFn: (id: string) => unwrap(window.electronAPI.agents.respawnBg(id)),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['live:sessions'] }),
+  })
 }
 
 export function useAttachBackgroundAgent() {
-  return useMutation(
-    ({ cwd, id }: { cwd: string; id: string }) =>
-      unwrap(window.electronAPI.agents.attachBg(cwd, id))
-  )
+  return useMutation({
+    mutationFn: ({ cwd, id }: { cwd: string; id: string }) =>
+      unwrap(window.electronAPI.agents.attachBg(cwd, id)),
+  })
 }
 
 export function useDeleteProject() {
   const qc = useQueryClient()
-  return useMutation(
-    (hash: string) => unwrap(window.electronAPI.projects.delete(hash)),
-    { onSuccess: () => qc.invalidateQueries('memory:projects') }
-  )
+  return useMutation({
+    mutationFn: (hash: string) => unwrap(window.electronAPI.projects.delete(hash)),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['memory:projects'] }),
+  })
 }
 
 export function useDataChangedRefetch() {
@@ -573,22 +563,22 @@ export function useDataChangedRefetch() {
 
   useEffect(() => {
     const unsubscribe = window.electronAPI.onDataChanged(() => {
-      qc.invalidateQueries('memory:projects')
-      qc.invalidateQueries('memory:project')
-      qc.invalidateQueries('cost:summary')
-      qc.invalidateQueries('cost:project')
-      qc.invalidateQueries('sessions:project')
-      qc.invalidateQueries('sessions:chat')
-      qc.invalidateQueries('claudeMd:hierarchy')
-      qc.invalidateQueries('claudeMd:global')
-      qc.invalidateQueries('rules:project')
-      qc.invalidateQueries('tasks:project')
-      qc.invalidateQueries('plans:project')
-      qc.invalidateQueries('skills:global')
-      qc.invalidateQueries('skills:all')
-      qc.invalidateQueries('agents:global')
-      qc.invalidateQueries('agents:project')
-      qc.invalidateQueries('mcp:global')
+      qc.invalidateQueries({ queryKey: ['memory:projects'] })
+      qc.invalidateQueries({ queryKey: ['memory:project'] })
+      qc.invalidateQueries({ queryKey: ['cost:summary'] })
+      qc.invalidateQueries({ queryKey: ['cost:project'] })
+      qc.invalidateQueries({ queryKey: ['sessions:project'] })
+      qc.invalidateQueries({ queryKey: ['sessions:chat'] })
+      qc.invalidateQueries({ queryKey: ['claudeMd:hierarchy'] })
+      qc.invalidateQueries({ queryKey: ['claudeMd:global'] })
+      qc.invalidateQueries({ queryKey: ['rules:project'] })
+      qc.invalidateQueries({ queryKey: ['tasks:project'] })
+      qc.invalidateQueries({ queryKey: ['plans:project'] })
+      qc.invalidateQueries({ queryKey: ['skills:global'] })
+      qc.invalidateQueries({ queryKey: ['skills:all'] })
+      qc.invalidateQueries({ queryKey: ['agents:global'] })
+      qc.invalidateQueries({ queryKey: ['agents:project'] })
+      qc.invalidateQueries({ queryKey: ['mcp:global'] })
     })
     return unsubscribe
   }, [qc])

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import { QueryClient, QueryClientProvider } from 'react-query'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import App from './App'
 import './index.css'
 

--- a/src/tabs/ProjectOverview.tsx
+++ b/src/tabs/ProjectOverview.tsx
@@ -388,7 +388,7 @@ export default function ProjectOverview() {
         {projectToDelete && (
           <DeleteProjectDialog
             project={projectToDelete}
-            isLoading={deleteProjectMutation.isLoading}
+            isLoading={deleteProjectMutation.isPending}
             onConfirm={() => handleConfirmDelete(projectToDelete)}
             onCancel={() => setProjectToDelete(null)}
           />
@@ -477,7 +477,7 @@ export default function ProjectOverview() {
       {projectToDelete && (
         <DeleteProjectDialog
           project={projectToDelete}
-          isLoading={deleteProjectMutation.isLoading}
+          isLoading={deleteProjectMutation.isPending}
           onConfirm={() => handleConfirmDelete(projectToDelete)}
           onCancel={() => setProjectToDelete(null)}
         />


### PR DESCRIPTION
Part of #26 (migrate react-query v3 → @tanstack/react-query v5).

The `react-query` v3 package is unmaintained; this migrates to the actively maintained `@tanstack/react-query` v5.

## Changes
- **package.json / package-lock.json**: removed `react-query`, added `@tanstack/react-query` ^5
- **src/main.tsx**: import the provider from the new package
- **src/hooks/useIPC.ts**: converted every hook to the v5 object API — `useQuery({ queryKey, queryFn, ... })`, `useMutation({ mutationFn, onSuccess })`, query keys always as arrays, `invalidateQueries({ queryKey: [...] })`
- **6 components**: renamed mutation `.isLoading` → `.isPending` (v5 rename) in `tabs/ProjectOverview.tsx`, `components/project/memory/MemoryTopicView.tsx`, `components/project/agents/CreateAgentPage.tsx`, `components/project/agents-live/AgentsLiveView.tsx`, `components/project/skills/CreateSkillPage.tsx`, `components/project/overview/DuplicateProjectsNotice.tsx`

## Verification
All passing: typecheck (v5 enforces stronger typing), lint (0 errors), 71 tests, build, and a runtime launch of the app (no React Query errors — only the benign DevTools Autofill warnings).