### PR TITLE
feat: experimental Windows support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,3 +67,32 @@ jobs:
           name: claudelens-linux
           path: release/*.AppImage
           if-no-files-found: error
+
+  package-windows:
+    name: Package Windows (nsis)
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build renderer + electron
+        run: npm run build
+
+      - name: Package Windows artifacts
+        run: npx electron-builder --win --publish never
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: claudelens-windows
+          path: release/*.exe
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ClaudeLens
 
-A desktop app (macOS, with experimental Linux support) to visually explore and manage your local [Claude Code](https://claude.ai/code) data.
+A desktop app (macOS, with experimental Linux and Windows support) to visually explore and manage your local [Claude Code](https://claude.ai/code) data.
 
 If you use Claude Code heavily, you know how opaque `~/.claude/` is — ClaudeLens makes it navigable. Browse chat sessions, manage memory topics, inspect tool calls, view your full CLAUDE.md hierarchy, and monitor active Claude processes, all in one place and updated in real time.
 
@@ -153,7 +153,7 @@ Requires `claude` CLI in `PATH`.
 
 ## Requirements
 
-- macOS 12 Monterey or later, or Linux (experimental)
+- macOS 12 Monterey or later, or Linux / Windows (experimental)
 - [Claude Code](https://claude.ai/code) installed and used at least once (so `~/.claude/` exists)
 
 ---
@@ -163,6 +163,8 @@ Requires `claude` CLI in `PATH`.
 **macOS** — download the `.dmg` from the [Releases](https://github.com/giulio333/ClaudeLens/releases) page, open it, and drag ClaudeLens to Applications.
 
 **Linux (experimental)** — download the `.AppImage` from the [Releases](https://github.com/giulio333/ClaudeLens/releases) page and make it executable with `chmod +x`. Opening a session in a terminal relies on a common terminal emulator being installed (`gnome-terminal`, `konsole`, `xfce4-terminal`, or `xterm`).
+
+**Windows (experimental)** — download and run the `.exe` installer from the [Releases](https://github.com/giulio333/ClaudeLens/releases) page. Opening a session launches it in a new `cmd` window.
 
 > **First launch — Gatekeeper warning**
 >
@@ -193,6 +195,7 @@ npm run electron:build   # Generate distributable DMG
 - Session list is not paginated — may be slow with very large histories (500+ sessions)
 - No automatic updates
 - App is not code-signed (see installation note above)
+- On Windows, the Live Monitor and the in-app AI Assistant / background agents are not yet supported (they rely on Unix process tooling and direct CLI spawning); browsing sessions, memory, CLAUDE.md, and opening sessions in a terminal all work
 
 ---
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,5 +1,5 @@
 import { app, BrowserWindow, dialog, ipcMain, session, shell } from 'electron';
-import { basename, isAbsolute, join, resolve, sep } from 'path';
+import { basename, delimiter, isAbsolute, join, resolve, sep } from 'path';
 import os from 'os';
 import { mkdtempSync, rmSync, writeFileSync } from 'fs';
 import chokidar from 'chokidar';
@@ -120,6 +120,19 @@ function ok<T>(data: T): IpcResult<T> {
 
 function err<T>(e: unknown): IpcResult<T> {
   return { data: null, error: e instanceof Error ? e.message : String(e) };
+}
+
+// Build the env for spawning the `claude` CLI. A GUI-launched app may not inherit
+// the user's interactive-shell PATH, so we prepend common install locations using
+// the platform path delimiter (':' on Unix, ';' on Windows). On Windows the CLI
+// is on the user PATH as claude.cmd, so the Unix-only dirs are skipped.
+function claudeEnv(): NodeJS.ProcessEnv {
+  const extra =
+    process.platform === 'win32'
+      ? []
+      : [join(os.homedir(), '.local', 'bin'), '/usr/local/bin', '/opt/homebrew/bin'];
+  const PATH = [...extra, process.env.PATH || ''].filter(Boolean).join(delimiter);
+  return { ...process.env, PATH };
 }
 
 function cleanDefaultFilename(filename: string, extension: string): string {
@@ -630,13 +643,7 @@ ipcMain.handle(
       const { promisify } = await import('util');
       const execFileAsync = promisify(execFile);
 
-      const localBinPath = join(os.homedir(), '.local', 'bin');
-      const env = {
-        ...process.env,
-        PATH: `${localBinPath}:/usr/local/bin:/opt/homebrew/bin:${process.env.PATH || ''}`,
-      };
-
-      await execFileAsync('claude', args, { cwd, env });
+      await execFileAsync('claude', args, { cwd, env: claudeEnv() });
 
       return ok(null);
     } catch (e: any) {
@@ -674,12 +681,10 @@ async function runClaudeCommand(args: string[]): Promise<IpcResult<string>> {
     const { execFile } = await import('child_process');
     const { promisify } = await import('util');
     const execFileAsync = promisify(execFile);
-    const localBinPath = join(os.homedir(), '.local', 'bin');
-    const env = {
-      ...process.env,
-      PATH: `${localBinPath}:/usr/local/bin:/opt/homebrew/bin:${process.env.PATH || ''}`,
-    };
-    const { stdout } = await execFileAsync('claude', args, { env, maxBuffer: 4 * 1024 * 1024 });
+    const { stdout } = await execFileAsync('claude', args, {
+      env: claudeEnv(),
+      maxBuffer: 4 * 1024 * 1024,
+    });
     return ok(stdout);
   } catch (e: any) {
     return err(e.stderr || e.message || String(e));
@@ -775,10 +780,9 @@ ipcMain.handle(
         'Read,Glob,Grep,WebSearch,WebFetch',
         '--no-session-persistence',
       ];
-      const localBinPath = join(os.homedir(), '.local', 'bin');
       const proc = spawn('claude', args, {
         cwd: projectPath,
-        env: { ...process.env, PATH: `${localBinPath}:/usr/local/bin:${process.env.PATH || ''}` },
+        env: claudeEnv(),
       });
       currentAiProcess = proc;
 
@@ -874,6 +878,14 @@ function openInTerminal(cwd: string, command: string): void {
       'end tell',
     ].join('\n');
     execFile('osascript', ['-e', script]);
+    return;
+  }
+
+  if (process.platform === 'win32') {
+    // `start` is a cmd builtin (hence `cmd /c start`); the empty "" is the
+    // window title. `cmd /k` runs the command and keeps the window open.
+    // `cd /d` switches drive and directory in one go.
+    execFile('cmd.exe', ['/c', 'start', '', 'cmd', '/k', `cd /d "${dir}" && ${command}`]);
     return;
   }
 

--- a/electron/modules/duplicate-merger.ts
+++ b/electron/modules/duplicate-merger.ts
@@ -1,6 +1,6 @@
 import { readdirSync, readFileSync, existsSync, statSync } from 'fs';
 import { join } from 'path';
-import { resolveRealPath } from '../utils';
+import { resolveRealPath, isAbsolutePath } from '../utils';
 
 /** Spostamento di un file di sessione dalla source alla dest. */
 export interface SessionMove {
@@ -12,8 +12,8 @@ export interface SessionMove {
 }
 
 export type MemoryActionKind =
-  | 'copy'             // nessun file con lo stesso nome nella dest → copia diretta
-  | 'identical'        // file con lo stesso nome e contenuto identico → skip
+  | 'copy' // nessun file con lo stesso nome nella dest → copia diretta
+  | 'identical' // file con lo stesso nome e contenuto identico → skip
   | 'conflict-rename'; // stesso nome, contenuto diverso → copia rinominata
 
 export interface MemoryAction {
@@ -78,7 +78,7 @@ function readCwdSet(filePath: string): Set<string> {
       if (!line || line.indexOf('"cwd"') === -1) continue;
       try {
         const obj = JSON.parse(line);
-        if (typeof obj.cwd === 'string' && obj.cwd.startsWith('/')) out.add(obj.cwd);
+        if (typeof obj.cwd === 'string' && isAbsolutePath(obj.cwd)) out.add(obj.cwd);
       } catch {
         // riga malformata
       }
@@ -108,7 +108,11 @@ function uniqueRenameTarget(baseName: string, taken: Set<string>): string {
  * dentro `destHash`. Non scrive nulla: produce il piano che alimenta il dialog di
  * conferma e, successivamente, l'esecuzione.
  */
-export function computeMergePlan(projectsDir: string, sourceHash: string, destHash: string): MergePlan {
+export function computeMergePlan(
+  projectsDir: string,
+  sourceHash: string,
+  destHash: string
+): MergePlan {
   const sourceDir = join(projectsDir, sourceHash);
   const destDir = join(projectsDir, destHash);
 
@@ -150,7 +154,7 @@ export function computeMergePlan(projectsDir: string, sourceHash: string, destHa
     if (!destAuthoritative) {
       // Senza sessioni nella dest il cwd nuovo non è ricavabile in modo affidabile.
       blockers.push(
-        'Cannot determine the destination cwd reliably: the destination folder has no sessions to read it from.',
+        'Cannot determine the destination cwd reliably: the destination folder has no sessions to read it from.'
       );
     } else if (sourceReal !== destReal) {
       cwdRewrite = { from: sourceReal, to: destReal };
@@ -159,7 +163,9 @@ export function computeMergePlan(projectsDir: string, sourceHash: string, destHa
         .map(f => readCwdSet(join(sourceDir, f)))
         .find(set => set.size > 0);
       if (sample && !sample.has(sourceReal)) {
-        warnings.push('Source sessions reference a cwd different from the resolved source path; rewrite will target the destination cwd anyway.');
+        warnings.push(
+          'Source sessions reference a cwd different from the resolved source path; rewrite will target the destination cwd anyway.'
+        );
       }
     }
   }
@@ -193,7 +199,9 @@ export function computeMergePlan(projectsDir: string, sourceHash: string, destHa
       const targetName = uniqueRenameTarget(filename, takenTargets);
       takenTargets.add(targetName);
       memory.push({ filename, kind: 'conflict-rename', targetName });
-      warnings.push(`Memory "${filename}" exists in both with different content → kept as "${targetName}". Wikilinks to its slug may become ambiguous.`);
+      warnings.push(
+        `Memory "${filename}" exists in both with different content → kept as "${targetName}". Wikilinks to its slug may become ambiguous.`
+      );
     }
   }
 
@@ -210,7 +218,9 @@ export function computeMergePlan(projectsDir: string, sourceHash: string, destHa
     .map(name => {
       const collides = destSubdirSet.has(name);
       if (collides) {
-        warnings.push(`Session folder "${name}" already exists in the destination → left in place (not overwritten).`);
+        warnings.push(
+          `Session folder "${name}" already exists in the destination → left in place (not overwritten).`
+        );
       }
       return { name, collides };
     });
@@ -226,7 +236,7 @@ export function computeMergePlan(projectsDir: string, sourceHash: string, destHa
     /* ignore */
   }
   const leftovers = sourceEntries.filter(
-    n => n !== 'memory' && n !== '.DS_Store' && !n.endsWith('.jsonl') && !movableSidecars.has(n),
+    n => n !== 'memory' && n !== '.DS_Store' && !n.endsWith('.jsonl') && !movableSidecars.has(n)
   );
   const sourceEmptyAfter = leftovers.length === 0;
 

--- a/electron/modules/process-scanner.ts
+++ b/electron/modules/process-scanner.ts
@@ -36,6 +36,11 @@ async function getProcessCwd(pid: number): Promise<string | null> {
 }
 
 export async function findClaudeProcesses(): Promise<ClaudeProcess[]> {
+  // Windows has no `ps`/`lsof`/`/proc`, and resolving an arbitrary process'
+  // working directory requires native APIs (NtQueryInformationProcess). The
+  // Live Monitor degrades to empty here; the rest of the app is unaffected.
+  if (process.platform === 'win32') return [];
+
   try {
     // Cattura anche il bare command "claude" (senza path), esclude Claude.app desktop, ClaudeLens
     // e il plumbing del daemon background agent (--bg-pty-host / --bg-spare): non sono sessioni utente.

--- a/electron/utils.ts
+++ b/electron/utils.ts
@@ -1,64 +1,73 @@
-import { readdirSync, readFileSync, statSync } from 'fs'
-import { join } from 'path'
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join } from 'path';
 
 export function hashToPath(hash: string): string {
   // Fallback ingenuo: Claude Code converte sia '/' sia '.' in '-' nel nome cartella,
   // quindi questa inversione è lossy (es. SARA2.0 → SARA2-0 → SARA2/0).
   // Usa resolveRealPath quando possibile per leggere il cwd autoritativo dai .jsonl.
-  return '/' + hash.replace(/^-/, '').replace(/-/g, '/')
+  return '/' + hash.replace(/^-/, '').replace(/-/g, '/');
 }
 
 export function pathToHash(realPath: string): string {
-  return realPath.replace(/\//g, '-')
+  return realPath.replace(/\//g, '-');
+}
+
+/**
+ * True if `p` looks like an absolute path on any platform. Used to validate the
+ * `cwd` read from .jsonl files: POSIX paths start with '/', Windows paths start
+ * with a drive letter ('C:\...' / 'C:/...') or a UNC prefix ('\\server\share').
+ */
+export function isAbsolutePath(p: string): boolean {
+  return p.startsWith('/') || /^[a-zA-Z]:[\\/]/.test(p) || p.startsWith('\\\\');
 }
 
 // Cache per evitare di rileggere lo stesso jsonl più volte nella stessa sessione.
-const cwdCache = new Map<string, string>()
+const cwdCache = new Map<string, string>();
 
 /** Invalida la cache del cwd dopo che il contenuto di una cartella è cambiato (es. merge). */
 export function invalidateCwdCache(hash?: string): void {
-  if (hash) cwdCache.delete(hash)
-  else cwdCache.clear()
+  if (hash) cwdCache.delete(hash);
+  else cwdCache.clear();
 }
 
 export function resolveRealPath(projectsDir: string, hash: string): string {
-  const cached = cwdCache.get(hash)
-  if (cached) return cached
+  const cached = cwdCache.get(hash);
+  if (cached) return cached;
 
-  const projectDir = join(projectsDir, hash)
+  const projectDir = join(projectsDir, hash);
   try {
     const files = readdirSync(projectDir)
       .filter(f => f.endsWith('.jsonl'))
       .map(f => {
-        const full = join(projectDir, f)
-        return { full, mtime: statSync(full).mtimeMs }
+        const full = join(projectDir, f);
+        return { full, mtime: statSync(full).mtimeMs };
       })
-      .sort((a, b) => b.mtime - a.mtime)
+      .sort((a, b) => b.mtime - a.mtime);
 
     for (const { full } of files) {
-      const cwd = readCwdFromJsonl(full)
+      const cwd = readCwdFromJsonl(full);
       if (cwd) {
-        cwdCache.set(hash, cwd)
-        return cwd
+        cwdCache.set(hash, cwd);
+        return cwd;
       }
     }
   } catch {
     // ignore, ricade nel fallback
   }
 
-  return hashToPath(hash)
+  return hashToPath(hash);
 }
 
 function readCwdFromJsonl(filePath: string): string | null {
   try {
-    const content = readFileSync(filePath, 'utf-8')
+    const content = readFileSync(filePath, 'utf-8');
     for (const line of content.split('\n')) {
-      if (!line) continue
-      const idx = line.indexOf('"cwd"')
-      if (idx === -1) continue
+      if (!line) continue;
+      const idx = line.indexOf('"cwd"');
+      if (idx === -1) continue;
       try {
-        const obj = JSON.parse(line)
-        if (typeof obj.cwd === 'string' && obj.cwd.startsWith('/')) return obj.cwd
+        const obj = JSON.parse(line);
+        if (typeof obj.cwd === 'string' && isAbsolutePath(obj.cwd)) return obj.cwd;
       } catch {
         // riga malformata, continua
       }
@@ -66,5 +75,5 @@ function readCwdFromJsonl(filePath: string): string | null {
   } catch {
     // file illeggibile
   }
-  return null
+  return null;
 }

--- a/package.json
+++ b/package.json
@@ -100,6 +100,12 @@
       ],
       "icon": "./icon.png",
       "category": "Development"
+    },
+    "win": {
+      "target": [
+        "nsis"
+      ],
+      "icon": "./icon.png"
     }
   }
 }

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { isAbsolutePath } from '../electron/utils';
+
+describe('isAbsolutePath', () => {
+  it('accepts POSIX absolute paths', () => {
+    expect(isAbsolutePath('/Users/foo/bar')).toBe(true);
+    expect(isAbsolutePath('/')).toBe(true);
+  });
+
+  it('accepts Windows drive-letter paths (backslash and forward slash)', () => {
+    expect(isAbsolutePath('C:\\Users\\foo\\bar')).toBe(true);
+    expect(isAbsolutePath('C:/Users/foo/bar')).toBe(true);
+    expect(isAbsolutePath('d:\\projects')).toBe(true);
+  });
+
+  it('accepts Windows UNC paths', () => {
+    expect(isAbsolutePath('\\\\server\\share\\dir')).toBe(true);
+  });
+
+  it('rejects relative and non-path strings', () => {
+    expect(isAbsolutePath('foo/bar')).toBe(false);
+    expect(isAbsolutePath('./foo')).toBe(false);
+    expect(isAbsolutePath('C:')).toBe(false);
+    expect(isAbsolutePath('')).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #47. Based on #48 (Linux support) — review/merge that first; this PR targets the Linux branch so the diff shows only the Windows-specific work.

Adds **experimental Windows support**. The investigation phase (required by #47) found the impact is much smaller than expected: ClaudeLens never reconstructs paths from the folder hash (`pathToHash` is unused) — the real path always comes from the authoritative `cwd` in the `.jsonl`. The core bug was a single POSIX-only assumption.

## Changes
- **`utils.ts`** — new `isAbsolutePath()` (POSIX `/`, Windows `C:\`/`C:/`, UNC `\\`). Replaces the hardcoded `startsWith('/')` that silently rejected Windows cwds and forced the lossy hash fallback. Same fix in **`duplicate-merger.ts`**.
- **`main.ts`** — `openInTerminal` gets a Windows branch (`cmd /k` in a new window); `claude` CLI PATH building centralized into a cross-platform `claudeEnv()` using `path.delimiter`.
- **`process-scanner.ts`** — returns `[]` on Windows (no `ps`/`lsof`/`/proc`; resolving an arbitrary process' cwd needs native APIs). Live Monitor degrades gracefully.
- **`package.json`** — `win` nsis target (reuses `icon.png`).
- **CI** — new `package-windows` job (windows-latest).
- **Tests** — unit coverage for `isAbsolutePath`.

## What works vs. what's limited on Windows
- ✅ Browsing sessions, memory, CLAUDE.md, tasks, plans; opening a session in a terminal
- ⚠️ **Not supported**: Live Monitor and in-app AI Assistant / background agents. The latter would need `shell: true` to resolve `claude.cmd`, which introduces untested quoting/escaping of user input — deliberately deferred.

## Validation
- ✅ typecheck, lint, prettier, tests (75 passing)
- ⚠️ **Not validated on real Windows**: terminal launch and the actual nsis build need on-device testing. The CI `package-windows` job validates that it builds/packages.
