### PR TITLE
chore: release v1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claudelens-app",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claudelens-app",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/typography": "^0.5.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claudelens-app",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "ClaudeLens — GUI for Claude Code data",
   "author": "Giulio Di Giamberardino",
   "license": "MIT",


### PR DESCRIPTION
Version bump to 1.6.0 for the v1.6.0 release.

Highlights since v1.5.0:
- Experimental **Linux** support (AppImage) — #48
- Experimental **Windows** support (nsis) — #51
- Cross-platform CI packaging jobs

Per-platform limitations are documented in the README. Follow-up gaps tracked in #50.