### PR TITLE
build: multi-arch packages (x64 + arm64)

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,20 +90,41 @@
       "icon4.icns",
       "icon.png"
     ],
+    "artifactName": "${productName}-${version}-${arch}.${ext}",
     "mac": {
-      "target": "dmg",
+      "target": [
+        {
+          "target": "dmg",
+          "arch": [
+            "x64",
+            "arm64"
+          ]
+        }
+      ],
       "icon": "./icon4.icns"
     },
     "linux": {
       "target": [
-        "AppImage"
+        {
+          "target": "AppImage",
+          "arch": [
+            "x64",
+            "arm64"
+          ]
+        }
       ],
       "icon": "./icon.png",
       "category": "Development"
     },
     "win": {
       "target": [
-        "nsis"
+        {
+          "target": "nsis",
+          "arch": [
+            "x64",
+            "arm64"
+          ]
+        }
       ],
       "icon": "./icon.png"
     }


### PR DESCRIPTION
Extends electron-builder to build both **x64** and **arm64** for macOS (dmg), Linux (AppImage) and Windows (nsis). Adds a global `artifactName` with `${arch}` so per-arch outputs don't collide.

No release change here — the additional architecture binaries are attached to the existing v1.6.0 release.