### PR TITLE
fix: Windows path compatibility for memory detection and project name extraction

### DIFF
--- a/electron/modules/bg-sessions-reader.ts
+++ b/electron/modules/bg-sessions-reader.ts
@@ -1,5 +1,5 @@
 import { readFileSync, existsSync, readdirSync } from 'fs';
-import { join } from 'path';
+import { join, basename } from 'path';
 import os from 'os';
 
 const CLAUDE_DIR = join(os.homedir(), '.claude');
@@ -118,7 +118,7 @@ export function getBgSessions(): BgSession[] {
       intent: (state.intent as string) ?? '',
       result: readResult(state.output),
       cwd,
-      projectName: cwd ? cwd.split('/').filter(Boolean).pop() ?? cwd : '',
+      projectName: cwd ? (basename(cwd) || cwd) : '',
       template: (state.template as string) ?? '',
       inFlightTasks:
         state.inFlight && typeof state.inFlight === 'object'

--- a/electron/modules/claude-md-reader.ts
+++ b/electron/modules/claude-md-reader.ts
@@ -1,5 +1,5 @@
 import { readFileSync, existsSync, readdirSync, writeFileSync, mkdirSync } from 'fs';
-import { dirname, join } from 'path';
+import { basename, dirname, join } from 'path';
 import os from 'os';
 
 export interface ClaudeMdLayer {
@@ -88,7 +88,7 @@ function findAllClaudeMd(dir: string, maxDepth: number = 5, currentDepth: number
 
 export function writeClaudeMdFile(filePath: string, content: string): void {
   const allowedBasenames = new Set(['CLAUDE.md', 'CLAUDE.local.md']);
-  const base = filePath.split('/').pop() ?? '';
+  const base = basename(filePath);
   if (!allowedBasenames.has(base)) {
     throw new Error(`Refusing to write non-CLAUDE.md file: ${filePath}`);
   }

--- a/electron/modules/cost-tracker.ts
+++ b/electron/modules/cost-tracker.ts
@@ -326,7 +326,7 @@ export async function calculateCostSummary(claudeDir: string): Promise<ProjectCo
         if (a.totalTokens === 0) continue;
 
         costs.push({
-          project: projectPath.split('/').pop() || 'unknown',
+          project: basename(projectPath) || 'unknown',
           inputTokens: a.inputTokens,
           outputTokens: a.outputTokens,
           totalTokens: a.totalTokens,

--- a/src/components/project/chat/graph/buildGraph.ts
+++ b/src/components/project/chat/graph/buildGraph.ts
@@ -75,7 +75,9 @@ function classifyTool(name: string, input: Record<string, unknown>): { kind: Lan
   if (name === 'Read' || name === 'Write' || name === 'Edit') {
     const path = typeof input.file_path === 'string' ? input.file_path : null
     if (path) {
-      const isMemory = path.includes('/.claude/') && path.includes('/memory/')
+      // Normalize backslashes so the check works on Windows paths too
+      const normalizedPath = path.replace(/\\/g, '/')
+      const isMemory = normalizedPath.includes('/.claude/') && normalizedPath.includes('/memory/')
       return {
         kind: isMemory ? 'memory' : 'file',
         laneId: isMemory ? `memory:${path}` : `file:${path}`,

--- a/src/components/project/chat/utils.ts
+++ b/src/components/project/chat/utils.ts
@@ -324,7 +324,9 @@ export function parseMemoryFrontmatter(content: string): ParsedMemory | null {
 export function isMemoryFile(input: Record<string, unknown>): boolean {
   const path = input.file_path as string | undefined
   if (!path) return false
-  return path.includes('/.claude/') && path.includes('/memory/')
+  // Normalize backslashes so the check works on Windows paths too
+  const normalized = path.replace(/\\/g, '/')
+  return normalized.includes('/.claude/') && normalized.includes('/memory/')
 }
 
 export function resolveToolIcon(name: string, input: Record<string, unknown>): string {


### PR DESCRIPTION
## Problem

On Windows, paths use `\` as separator (e.g. `C:\Users\alice\.claude\memory\topic.md`), while the code always assumed `/`. This caused two issues:

- Memory files were not recognized as such → the 🧠 icon did not appear in the chat view
- Project/file names extracted from paths came out empty or contained the full path string

## Changes

### Frontend — memory file detection
**`src/components/project/chat/utils.ts`** (`isMemoryFile`)  
**`src/components/project/chat/graph/buildGraph.ts`** (lane classification)

Normalize `\` → `/` before checking for `/.claude/` and `/memory/`, making the check work on both platforms:
```ts
const normalized = path.replace(/\\/g, '/')
return normalized.includes('/.claude/') && normalized.includes('/memory/')
```

### Backend (Electron main process) — basename extraction
**`electron/modules/bg-sessions-reader.ts`** — `cwd.split('/').pop()` → `basename(cwd)`  
**`electron/modules/claude-md-reader.ts`** — `filePath.split('/').pop()` → `basename(filePath)`  
**`electron/modules/cost-tracker.ts`** — `projectPath.split('/').pop()` → `basename(projectPath)`

## Testing

- `tsc -p tsconfig.electron.json --noEmit` → no errors
- `npm test` → 75/75 tests passed

## Out of scope

- Live Monitor on Windows (requires native bindings to enumerate processes — separate effort)
- Windows-specific CI test jobs

https://claude.ai/code/session_019C4xC7cN8nQJDiYUEyCpKo