### PR TITLE
Sessions: sezione "Pinned sessions" al posto del toggle PINNED/ALL

### DIFF
--- a/src/components/project/overview/ProjectOverviewContent.tsx
+++ b/src/components/project/overview/ProjectOverviewContent.tsx
@@ -395,15 +395,12 @@ export function ProjectView({
             </div>
           </section>
 
-          {hasPinnedSession && (
-            <section className="cl-section">
-              <div className="cl-sec-head">
-                <h2>Pinned sessions</h2>
-                <span className="ct">{pinnedSessions.length} pinned</span>
-              </div>
-              <SessionRows sessions={pinnedSessions} projectHash={project.hash} cleanupDays={cleanupDays} onOpen={s => onNavigate({ type: 'chat', project, session: s })} />
-            </section>
-          )}
+          <PinnedSessionsSection
+            sessions={pinnedSessions}
+            projectHash={project.hash}
+            cleanupDays={cleanupDays}
+            onOpen={s => onNavigate({ type: 'chat', project, session: s })}
+          />
 
           <section className="cl-section">
             <div className="cl-sec-head">
@@ -479,15 +476,13 @@ export function ProjectView({
 
       {section === 'sessions' && (
         <>
-          {hasPinnedSession && (
-            <section className="cl-section" style={{ paddingTop: 38 }}>
-              <div className="cl-sec-head">
-                <h2>Pinned sessions</h2>
-                <span className="ct">{pinnedSessions.length} pinned</span>
-              </div>
-              <SessionRows sessions={pinnedSessions} projectHash={project.hash} cleanupDays={cleanupDays} onOpen={s => onNavigate({ type: 'chat', project, session: s })} />
-            </section>
-          )}
+          <PinnedSessionsSection
+            sessions={pinnedSessions}
+            projectHash={project.hash}
+            cleanupDays={cleanupDays}
+            onOpen={s => onNavigate({ type: 'chat', project, session: s })}
+            style={{ paddingTop: 38 }}
+          />
           <section className="cl-section" style={{ paddingTop: hasPinnedSession ? undefined : 38 }}>
             <div className="cl-sec-head">
               <h2>Sessions</h2>
@@ -746,6 +741,19 @@ function ExpiryTag({ date, cleanupDays }: { date: string; cleanupDays: number })
       <svg width="7" height="7" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5"><circle cx="12" cy="12" r="10" /><polyline points="12 6 12 12 16 14" /></svg>
       {label}
     </span>
+  )
+}
+
+function PinnedSessionsSection({ sessions, projectHash, cleanupDays, onOpen, style }: { sessions: SessionSummary[]; projectHash: string; cleanupDays: number; onOpen: (s: SessionSummary) => void; style?: CSSProperties }) {
+  if (sessions.length === 0) return null
+  return (
+    <section className="cl-section" style={style}>
+      <div className="cl-sec-head">
+        <h2>Pinned sessions</h2>
+        <span className="ct">{sessions.length} pinned</span>
+      </div>
+      <SessionRows sessions={sessions} projectHash={projectHash} cleanupDays={cleanupDays} onOpen={onOpen} />
+    </section>
   )
 }
 

--- a/src/components/project/overview/ProjectOverviewContent.tsx
+++ b/src/components/project/overview/ProjectOverviewContent.tsx
@@ -214,7 +214,6 @@ export function ProjectView({
   const pinnedNow = isPinned(project.hash)
   const { isPinned: isSessionPinned } = usePinnedSessions()
   const { tags: projectTags, tagCounts, tagsForSession } = useSessionTags(project.hash)
-  const [sessionsFilter, setSessionsFilter] = useState<'pinned' | 'all'>('all')
   const [tagFilter, setTagFilter] = useState<string | null>(null)
   const { data: memory } = useMemoryProject(project.hash)
   const { data: sessions = [] } = useSessionList(project.hash)
@@ -278,12 +277,10 @@ export function ProjectView({
     [sessions, project.hash, isSessionPinned],
   )
   const hasPinnedSession = pinnedSessions.length > 0
-  const effectiveSessionsFilter: 'pinned' | 'all' = hasPinnedSession ? sessionsFilter : 'all'
   const visibleSessions = useMemo(() => {
-    const base = effectiveSessionsFilter === 'pinned' ? pinnedSessions : sessions
-    if (!tagFilter) return base
-    return base.filter(s => tagsForSession(s.filename).includes(tagFilter))
-  }, [effectiveSessionsFilter, pinnedSessions, sessions, tagFilter, tagsForSession])
+    if (!tagFilter) return sessions
+    return sessions.filter(s => tagsForSession(s.filename).includes(tagFilter))
+  }, [sessions, tagFilter, tagsForSession])
   useEffect(() => {
     if (tagFilter && !projectTags.some(t => t.name === tagFilter)) setTagFilter(null)
   }, [tagFilter, projectTags])
@@ -481,51 +478,41 @@ export function ProjectView({
       )}
 
       {section === 'sessions' && (
-        <section className="cl-section" style={{ paddingTop: 38 }}>
-          <div className="cl-sec-head">
-            <h2>{effectiveSessionsFilter === 'pinned' ? 'Pinned sessions' : 'Sessions'}</h2>
-            <span className="ct">
-              {tagFilter
-                ? `${visibleSessions.length} tagged #${tagFilter}`
-                : effectiveSessionsFilter === 'pinned'
-                  ? `${visibleSessions.length} pinned`
-                  : `${sessions.length} total · sorted by last activity`}
-            </span>
-            {hasPinnedSession && (
-              <span className="cl-pinfilter">
-                <button
-                  type="button"
-                  className={sessionsFilter === 'pinned' ? 'on' : ''}
-                  onClick={() => setSessionsFilter('pinned')}
-                >Pinned</button>
-                <span className="sep">·</span>
-                <button
-                  type="button"
-                  className={sessionsFilter === 'all' ? 'on' : ''}
-                  onClick={() => setSessionsFilter('all')}
-                >All</button>
-              </span>
-            )}
-          </div>
-          <TagBar
-            tags={projectTags}
-            counts={tagCounts}
-            activeTag={tagFilter}
-            totalCount={effectiveSessionsFilter === 'pinned' ? pinnedSessions.length : sessions.length}
-            onSelect={setTagFilter}
-          />
-          {visibleSessions.length === 0 ? (
-            <div className="cl-empty">
-              {tagFilter
-                ? `No sessions tagged #${tagFilter}.`
-                : effectiveSessionsFilter === 'pinned'
-                  ? 'No pinned sessions. Hover a session row to pin it.'
-                  : 'No sessions yet.'}
-            </div>
-          ) : (
-            <SessionRows sessions={visibleSessions} projectHash={project.hash} cleanupDays={cleanupDays} onOpen={s => onNavigate({ type: 'chat', project, session: s })} />
+        <>
+          {hasPinnedSession && (
+            <section className="cl-section" style={{ paddingTop: 38 }}>
+              <div className="cl-sec-head">
+                <h2>Pinned sessions</h2>
+                <span className="ct">{pinnedSessions.length} pinned</span>
+              </div>
+              <SessionRows sessions={pinnedSessions} projectHash={project.hash} cleanupDays={cleanupDays} onOpen={s => onNavigate({ type: 'chat', project, session: s })} />
+            </section>
           )}
-        </section>
+          <section className="cl-section" style={{ paddingTop: hasPinnedSession ? undefined : 38 }}>
+            <div className="cl-sec-head">
+              <h2>Sessions</h2>
+              <span className="ct">
+                {tagFilter
+                  ? `${visibleSessions.length} tagged #${tagFilter}`
+                  : `${sessions.length} total · sorted by last activity`}
+              </span>
+            </div>
+            <TagBar
+              tags={projectTags}
+              counts={tagCounts}
+              activeTag={tagFilter}
+              totalCount={sessions.length}
+              onSelect={setTagFilter}
+            />
+            {visibleSessions.length === 0 ? (
+              <div className="cl-empty">
+                {tagFilter ? `No sessions tagged #${tagFilter}.` : 'No sessions yet.'}
+              </div>
+            ) : (
+              <SessionRows sessions={visibleSessions} projectHash={project.hash} cleanupDays={cleanupDays} onOpen={s => onNavigate({ type: 'chat', project, session: s })} />
+            )}
+          </section>
+        </>
       )}
 
       {section === 'memory' && (


### PR DESCRIPTION
## Problema

Nella sezione **Progetto → Sessions**, pinnare una sessione non mostrava una sezione "Pinned Sessions" come avviene correttamente nella **Overview**. Compariva invece un toggle `PINNED / ALL` in alto, con un'esperienza incoerente tra le due viste.

## Soluzione

Allineata la tab **Sessions** al comportamento della **Overview**:

- ❌ Rimosso il toggle `PINNED / ALL` (`cl-pinfilter`).
- ✅ Aggiunta una sezione dedicata **"Pinned sessions"** sopra la lista completa delle sessioni, identica a quella della Overview (`SessionRows` con i pin in cima).
- 🧹 Rimossi lo state `sessionsFilter` e la variabile `effectiveSessionsFilter` ora inutilizzati; `visibleSessions` filtra solo per tag.

La lista principale "Sessions" continua a mostrare tutte le sessioni con la `TagBar` per il filtro per tag.

## Note

- La classe CSS `cl-pinfilter` resta in `index.css` perché ancora usata da `GlobalHomeView.tsx`.
- `npm run typecheck` ✅ e `npm run lint` ✅ (0 errori; restano solo warning preesistenti non correlati).

https://claude.ai/code/session_01AGMBsyVB771PHGY86SHTwm

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGMBsyVB771PHGY86SHTwm)_