### PR TITLE
fix: cost usage dedup (#56) and graph timeline RangeError (#62)

### DIFF
--- a/electron/modules/cost-tracker.ts
+++ b/electron/modules/cost-tracker.ts
@@ -147,6 +147,8 @@ interface LineData {
   cacheWriteTokens: number;
   cacheReadTokens: number;
   model: string | undefined;
+  // Stable identity of the message-level usage, used to dedup repeated lines.
+  usageKey: string | undefined;
 }
 
 function extractFirstUserText(json: Record<string, unknown>): string | undefined {
@@ -190,6 +192,15 @@ function extractLineData(json: any): LineData | null {
   if (!usage && !date && !customTitle && !aiTitle && !firstUserMessage) return null;
 
   const model: string | undefined = json.message?.model;
+  // Claude Code writes one JSONL line per content block of an assistant turn
+  // (text + tool_use, …) and each repeats the same message-level usage, tagged
+  // with the same message.id / requestId. Build a stable key so the caller can
+  // count each unique turn once instead of inflating tokens/cost (issue #56).
+  const messageId: string | undefined = json.message?.id;
+  const requestId: string | undefined = json.requestId;
+  const usageKey = usage && (messageId || requestId)
+    ? `${messageId ?? ''}:${requestId ?? ''}`
+    : undefined;
   return {
     date,
     customTitle,
@@ -200,6 +211,7 @@ function extractLineData(json: any): LineData | null {
     cacheWriteTokens: usage?.cache_creation_input_tokens   ?? 0,
     cacheReadTokens:  usage?.cache_read_input_tokens       ?? 0,
     model:            model && model !== '<synthetic>' ? model : undefined,
+    usageKey,
   };
 }
 
@@ -215,6 +227,7 @@ function parseJsonlSession(filePath: string): ParsedSession {
   try {
     const lines = readFileSync(filePath, 'utf-8').split('\n').filter(l => l.trim());
     const modelCounts: Record<string, number> = {};
+    const seenUsage = new Set<string>();
     let dropped = 0;
 
     for (const line of lines) {
@@ -234,6 +247,11 @@ function parseJsonlSession(filePath: string): ParsedSession {
       if (parsed.date) result.date = parsed.date;
 
       if (parsed.inputTokens || parsed.outputTokens) {
+        // Skip lines that repeat a usage we've already counted for this turn.
+        if (parsed.usageKey) {
+          if (seenUsage.has(parsed.usageKey)) continue;
+          seenUsage.add(parsed.usageKey);
+        }
         result.messageCount++;
         if (parsed.model) modelCounts[parsed.model] = (modelCounts[parsed.model] ?? 0) + 1;
         result.inputTokens      += parsed.inputTokens;

--- a/src/components/project/chat/graph/buildGraph.ts
+++ b/src/components/project/chat/graph/buildGraph.ts
@@ -136,8 +136,16 @@ export function buildTimeline(processed: ProcessedMessage[]): TimelineModel {
     }
   }
 
-  const start = Math.min(...stamps)
-  const end = Math.max(...stamps)
+  // Compute min/max in a single linear pass. Spreading `stamps` into
+  // Math.min/max would pass each element as an argument, and engines cap the
+  // argument count — very long sessions throw a RangeError and the graph fails
+  // to render (issue #62).
+  let start = stamps[0]
+  let end = stamps[0]
+  for (const t of stamps) {
+    if (t < start) start = t
+    if (t > end) end = t
+  }
   // Pad domain by 2% on each side so first/last events aren't flush with edge.
   const span = Math.max(end - start, 1000)
   const padded = { start: start - span * 0.02, end: end + span * 0.02 }

--- a/test/cost-tracker.test.ts
+++ b/test/cost-tracker.test.ts
@@ -38,11 +38,15 @@ function assistantLine(opts: {
   cacheWrite?: number;
   cacheRead?: number;
   timestamp?: string;
+  id?: string;
+  requestId?: string;
 }): string {
   return JSON.stringify({
     type: 'assistant',
     timestamp: opts.timestamp ?? '2026-05-01T10:00:00.000Z',
+    requestId: opts.requestId,
     message: {
+      id: opts.id,
       model: opts.model,
       usage: {
         input_tokens: opts.input ?? 0,
@@ -118,6 +122,67 @@ describe('getProjectUsage — token summation & known-model cost', () => {
     expect(usage.outputTokens).toBe(200);
     expect(sessionCount).toBe(2);
     expect(cost).toBeCloseTo(expectedCost(PRICE.opus, { input: 400, output: 200 }), 10);
+  });
+});
+
+describe('usage dedup by message.id / requestId (issue #56)', () => {
+  it('counts a usage carried by repeated message.id+requestId lines only once', async () => {
+    // Claude Code emits one line per content block of an assistant turn, each
+    // repeating the same message-level usage tagged with the same ids.
+    writeSession(tmp, 'dup.jsonl', [
+      assistantLine({
+        model: 'claude-sonnet-4-5',
+        input: 6,
+        output: 185,
+        cacheRead: 16906,
+        id: 'msg_01XHZ',
+        requestId: 'req_011Cb',
+      }),
+      assistantLine({
+        model: 'claude-sonnet-4-5',
+        input: 6,
+        output: 185,
+        cacheRead: 16906,
+        id: 'msg_01XHZ',
+        requestId: 'req_011Cb',
+      }),
+    ]);
+
+    const [s] = await getSessionList(tmp);
+
+    expect(s.inputTokens).toBe(6);
+    expect(s.outputTokens).toBe(185);
+    expect(s.cacheReadTokens).toBe(16906);
+    expect(s.messageCount).toBe(1);
+  });
+
+  it('counts distinct ids separately and reports unique messageCount', async () => {
+    writeSession(tmp, 'mixed.jsonl', [
+      // turn A — two duplicated content-block lines
+      assistantLine({ model: 'claude-sonnet-4-5', input: 1, output: 10, id: 'a', requestId: 'r1' }),
+      assistantLine({ model: 'claude-sonnet-4-5', input: 1, output: 10, id: 'a', requestId: 'r1' }),
+      // turn B — single line, different ids
+      assistantLine({ model: 'claude-sonnet-4-5', input: 2, output: 20, id: 'b', requestId: 'r2' }),
+    ]);
+
+    const [s] = await getSessionList(tmp);
+
+    expect(s.inputTokens).toBe(3); // 1 (A, once) + 2 (B)
+    expect(s.outputTokens).toBe(30); // 10 + 20
+    expect(s.messageCount).toBe(2); // two unique turns, not three lines
+  });
+
+  it('does not dedup lines that lack both message.id and requestId', async () => {
+    // Without a stable key we cannot tell duplicates apart, so keep summing.
+    writeSession(tmp, 'nokey.jsonl', [
+      assistantLine({ model: 'claude-sonnet-4-5', input: 5, output: 5 }),
+      assistantLine({ model: 'claude-sonnet-4-5', input: 5, output: 5 }),
+    ]);
+
+    const { usage } = await getProjectUsage(tmp);
+
+    expect(usage.inputTokens).toBe(10);
+    expect(usage.outputTokens).toBe(10);
   });
 });
 


### PR DESCRIPTION
## Highlights

- Cost tracker no longer double-counts streamed assistant usage — tokens and cost are now accurate per turn.
- Session graph timeline renders on very large sessions instead of crashing with a `RangeError`.

## Details

### Cost dedup (#56)
Claude Code writes one JSONL line per content block of an assistant turn (text + `tool_use`, …), and each repeats the same message-level usage tagged with the same `message.id` / `requestId`. The tracker counted every line, inflating tokens and cost. We now build a stable `usageKey` and count each unique turn once; `messageCount` reflects unique turns rather than raw lines. Covered by new unit tests (dedup, distinct ids, and the no-key fallback).

### Graph RangeError (#62)
`Math.min(...stamps)` / `Math.max(...stamps)` spread the timestamp array into call arguments; JS engines cap the argument count, so very long sessions threw a `RangeError` and the timeline failed to render. Replaced with a single linear scan.

## Testing
- `npm run typecheck` — clean
- `npm test` — 99 passed

Closes #56
Closes #62
