### PR TITLE
fix(security): path-traversal guards and resume command injection hardening

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -35,7 +35,7 @@ import { startLiveMonitor, stopLiveMonitor } from './modules/live-monitor';
 import { detectDuplicateProjects } from './modules/duplicate-detector';
 import { computeMergePlan } from './modules/duplicate-merger';
 import { executeMerge } from './modules/duplicate-merge-executor';
-import { hashToPath, resolveRealPath, invalidateCwdCache, CLAUDE_DIR } from './utils';
+import { hashToPath, resolveRealPath, invalidateCwdCache, CLAUDE_DIR, isValidSessionId } from './utils';
 import { registerScreenshotHandlers } from './screenshotFixtures';
 const PROJECTS_DIR = join(CLAUDE_DIR, 'projects');
 const TASKS_DIR = join(CLAUDE_DIR, 'tasks');
@@ -930,10 +930,15 @@ function openInTerminal(cwd: string, command: string): void {
   const dir = cwd || os.homedir();
 
   if (process.platform === 'darwin') {
-    const escapedCwd = dir.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+    // Both values are embedded in an AppleScript double-quoted string, so
+    // backslashes and quotes must be escaped or a crafted path/command could
+    // break out of the string literal.
+    const escapeAppleScript = (s: string): string => s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+    const escapedCwd = escapeAppleScript(dir);
+    const escapedCommand = escapeAppleScript(command);
     const script = [
       'tell application "Terminal"',
-      `do script "cd \\"${escapedCwd}\\" && ${command}"`,
+      `do script "cd \\"${escapedCwd}\\" && ${escapedCommand}"`,
       'activate',
       'end tell',
     ].join('\n');
@@ -989,7 +994,9 @@ function openInTerminal(cwd: string, command: string): void {
 function buildResumeCommand(sessionId: string): string {
   try {
     const bg = getBgSessions().find(s => s.sessionId === sessionId);
-    if (bg) return `claude attach ${bg.id}`;
+    // bg.id is read from disk; only use it if it's a clean session id, else
+    // fall back to the validated --resume form below.
+    if (bg && isValidSessionId(bg.id)) return `claude attach ${bg.id}`;
   } catch {
     // fall through to default
   }
@@ -998,6 +1005,9 @@ function buildResumeCommand(sessionId: string): string {
 
 ipcMain.handle('sessions:openInTerminal', async (_event, realPath: string, sessionId: string) => {
   try {
+    if (!isValidSessionId(sessionId)) {
+      return err(new Error(`Invalid session id: ${sessionId}`));
+    }
     openInTerminal(realPath, buildResumeCommand(sessionId));
     return ok(null);
   } catch (e) {

--- a/electron/modules/agents-writer.ts
+++ b/electron/modules/agents-writer.ts
@@ -1,6 +1,6 @@
 import { writeFileSync, mkdirSync, existsSync } from 'fs';
 import { join } from 'path';
-import { CLAUDE_DIR } from '../utils';
+import { CLAUDE_DIR, validateEntityName, assertWithin } from '../utils';
 
 export interface AgentInput {
   name: string;
@@ -48,12 +48,16 @@ function buildAgentMarkdown(input: AgentInput): string {
 }
 
 export function createAgent(input: AgentInput, projectPath?: string): string {
-  const baseDir = projectPath ? join(projectPath, '.claude') : CLAUDE_DIR;
-  const agentsDir = join(baseDir, 'agents');
+  const name = validateEntityName(input.name);
+  const agentsDir = join(projectPath ? join(projectPath, '.claude') : CLAUDE_DIR, 'agents');
+  const filePath = join(agentsDir, `${name}.md`);
+  assertWithin(agentsDir, filePath);
+  if (existsSync(filePath)) {
+    throw new Error(`An agent named "${name}" already exists.`);
+  }
   if (!existsSync(agentsDir)) {
     mkdirSync(agentsDir, { recursive: true });
   }
-  const filePath = join(agentsDir, `${input.name}.md`);
-  writeFileSync(filePath, buildAgentMarkdown(input), 'utf-8');
+  writeFileSync(filePath, buildAgentMarkdown({ ...input, name }), 'utf-8');
   return filePath;
 }

--- a/electron/modules/memory-writer.ts
+++ b/electron/modules/memory-writer.ts
@@ -1,5 +1,8 @@
 import { writeFileSync, existsSync, unlinkSync, readFileSync, mkdirSync } from 'fs';
 import { join } from 'path';
+import { assertWithin } from '../utils';
+
+const VALID_TOPIC_TYPES = ['user', 'feedback', 'project', 'reference'] as const;
 
 export interface TopicInput {
   name: string;
@@ -90,10 +93,26 @@ function uniqueFilename(memoryDir: string, base: string): string {
   return `${stem}_${n}.md`;
 }
 
+// The slug only keeps [a-z0-9_], so the name can't traverse; but `type` is
+// interpolated into the filename, and a name that slugs to empty would yield a
+// bare "type_.md". Guard both before touching the filesystem.
+function validateTopicInput(input: TopicInput): void {
+  if (!VALID_TOPIC_TYPES.includes(input.type)) {
+    throw new Error(`Invalid topic type "${input.type}".`);
+  }
+  const slug = nameToFilename(input.type, input.name).replace(`${input.type}_`, '').replace(/\.md$/, '');
+  if (!slug) {
+    throw new Error(`Invalid topic name "${input.name}": produces an empty slug.`);
+  }
+}
+
 export function createTopic(memoryDir: string, input: TopicInput): string {
+  validateTopicInput(input);
   if (!existsSync(memoryDir)) mkdirSync(memoryDir, { recursive: true });
   const filename = uniqueFilename(memoryDir, nameToFilename(input.type, input.name));
-  writeFileSync(join(memoryDir, filename), buildTopicFileContent(input), 'utf-8');
+  const target = join(memoryDir, filename);
+  assertWithin(memoryDir, target);
+  writeFileSync(target, buildTopicFileContent(input), 'utf-8');
   addLineToMemoryMd(join(memoryDir, 'MEMORY.md'), filename, input.description);
   return filename;
 }

--- a/electron/modules/skills-writer.ts
+++ b/electron/modules/skills-writer.ts
@@ -1,6 +1,6 @@
 import { writeFileSync, mkdirSync, existsSync } from 'fs';
 import { join } from 'path';
-import { CLAUDE_DIR } from '../utils';
+import { CLAUDE_DIR, validateEntityName, assertWithin } from '../utils';
 
 export interface SkillInput {
   name: string;
@@ -35,8 +35,13 @@ function buildSkillMarkdown(input: SkillInput): string {
 }
 
 export function createSkill(input: SkillInput, projectPath?: string): string {
-  const baseDir = projectPath ? join(projectPath, '.claude') : CLAUDE_DIR;
-  const skillDir = join(baseDir, 'skills', input.name);
+  const name = validateEntityName(input.name);
+  const skillsDir = join(projectPath ? join(projectPath, '.claude') : CLAUDE_DIR, 'skills');
+  const skillDir = join(skillsDir, name);
+  assertWithin(skillsDir, skillDir);
+  if (existsSync(join(skillDir, 'SKILL.md'))) {
+    throw new Error(`A skill named "${name}" already exists.`);
+  }
   if (!existsSync(skillDir)) {
     mkdirSync(skillDir, { recursive: true });
   }

--- a/electron/utils.ts
+++ b/electron/utils.ts
@@ -1,9 +1,49 @@
 import { readdirSync, readFileSync, statSync } from 'fs';
-import { join } from 'path';
+import { join, resolve, sep } from 'path';
 import os from 'os';
 
 // Respect CLAUDE_CONFIG_DIR if the user has relocated their Claude data dir.
 export const CLAUDE_DIR = process.env.CLAUDE_CONFIG_DIR ?? join(os.homedir(), '.claude');
+
+// Allowed charset for user-created entity names (skills, agents). It rejects
+// path separators, so a crafted name like "../../tmp/x" can't escape the
+// target directory; '.' and '..' are excluded explicitly since they'd pass the
+// charset but still traverse.
+const ENTITY_NAME_RE = /^[A-Za-z0-9._ -]{1,80}$/;
+
+/**
+ * Validate a renderer-supplied entity name before it is interpolated into a
+ * write path. Returns the trimmed name, or throws for anything unsafe.
+ */
+export function validateEntityName(name: string): string {
+  const trimmed = (name ?? '').trim();
+  if (trimmed === '.' || trimmed === '..' || !ENTITY_NAME_RE.test(trimmed)) {
+    throw new Error(
+      `Invalid name "${name}": use only letters, numbers, spaces, '.', '_' or '-' (max 80 chars), and not '.'/'..'.`
+    );
+  }
+  return trimmed;
+}
+
+/**
+ * Defense in depth: assert a built target path stays inside `baseDir` after
+ * resolution. Throws otherwise. Pair with validateEntityName at write sites.
+ */
+export function assertWithin(baseDir: string, target: string): void {
+  const base = resolve(baseDir);
+  const resolved = resolve(target);
+  if (resolved !== base && !resolved.startsWith(base + sep)) {
+    throw new Error(`Refusing to write outside ${base}: ${resolved}`);
+  }
+}
+
+// Claude Code session ids are UUIDs. Validate before interpolating an id into a
+// shell command (resume/attach) so metacharacters can't break out.
+const SESSION_ID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+export function isValidSessionId(id: unknown): id is string {
+  return typeof id === 'string' && SESSION_ID_RE.test(id);
+}
 
 export function hashToPath(hash: string): string {
   // Fallback ingenuo: Claude Code converte sia '/' sia '.' in '-' nel nome cartella,

--- a/test/entity-writers.test.ts
+++ b/test/entity-writers.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, readFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { createSkill } from '../electron/modules/skills-writer';
+import { createAgent } from '../electron/modules/agents-writer';
+
+// createSkill/createAgent honor a projectPath by writing under
+// {projectPath}/.claude/(skills|agents), which keeps the test sandboxed.
+let proj: string;
+
+beforeEach(() => {
+  proj = mkdtempSync(join(tmpdir(), 'cl-entity-'));
+});
+
+afterEach(() => {
+  rmSync(proj, { recursive: true, force: true });
+});
+
+describe('createSkill (issue #58)', () => {
+  it('writes SKILL.md under .claude/skills/<name>', () => {
+    const filePath = createSkill({ name: 'my-skill', content: 'Body' }, proj);
+    expect(filePath).toBe(join(proj, '.claude', 'skills', 'my-skill', 'SKILL.md'));
+    expect(readFileSync(filePath, 'utf-8')).toContain('Body');
+  });
+
+  it('rejects a traversal name instead of escaping the skills dir', () => {
+    expect(() => createSkill({ name: '../../../../tmp/x', content: 'x' }, proj)).toThrow(
+      /Invalid name/
+    );
+    expect(existsSync(join(proj, '.claude', 'skills'))).toBe(false);
+  });
+
+  it('refuses to overwrite an existing skill', () => {
+    createSkill({ name: 'dup', content: 'first' }, proj);
+    expect(() => createSkill({ name: 'dup', content: 'second' }, proj)).toThrow(/already exists/);
+    expect(readFileSync(join(proj, '.claude', 'skills', 'dup', 'SKILL.md'), 'utf-8')).toContain(
+      'first'
+    );
+  });
+});
+
+describe('createAgent (issue #58)', () => {
+  it('writes <name>.md under .claude/agents', () => {
+    const filePath = createAgent({ name: 'reviewer', content: 'Body' }, proj);
+    expect(filePath).toBe(join(proj, '.claude', 'agents', 'reviewer.md'));
+    expect(readFileSync(filePath, 'utf-8')).toContain('name: reviewer');
+  });
+
+  it('rejects a traversal name instead of escaping the agents dir', () => {
+    expect(() => createAgent({ name: '../../evil', content: 'x' }, proj)).toThrow(/Invalid name/);
+    expect(existsSync(join(proj, '.claude', 'agents'))).toBe(false);
+  });
+
+  it('refuses to overwrite an existing agent', () => {
+    createAgent({ name: 'dup', content: 'first' }, proj);
+    expect(() => createAgent({ name: 'dup', content: 'second' }, proj)).toThrow(/already exists/);
+  });
+});

--- a/test/memory.test.ts
+++ b/test/memory.test.ts
@@ -209,6 +209,24 @@ describe('createTopic', () => {
     expect(indexContent.startsWith('# Memory Index')).toBe(true);
   });
 
+  it('rejects an invalid topic type (issue #58)', () => {
+    expect(() =>
+      createTopic(memoryDir, {
+        name: 'Evil',
+        description: 'd',
+        // @ts-expect-error — exercising the runtime guard for an out-of-union type
+        type: '../../../etc',
+        content: 'x',
+      })
+    ).toThrow(/Invalid topic type/);
+  });
+
+  it('rejects a name that slugs to empty (issue #58)', () => {
+    expect(() =>
+      createTopic(memoryDir, { name: '../../', description: 'd', type: 'user', content: 'x' })
+    ).toThrow(/empty slug/);
+  });
+
   it('appends to an existing MEMORY.md without clobbering existing lines', () => {
     writeFileSync(
       join(memoryDir, 'MEMORY.md'),

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { isAbsolutePath } from '../electron/utils';
+import { join } from 'path';
+import { isAbsolutePath, validateEntityName, assertWithin, isValidSessionId } from '../electron/utils';
 
 describe('isAbsolutePath', () => {
   it('accepts POSIX absolute paths', () => {
@@ -22,5 +23,55 @@ describe('isAbsolutePath', () => {
     expect(isAbsolutePath('./foo')).toBe(false);
     expect(isAbsolutePath('C:')).toBe(false);
     expect(isAbsolutePath('')).toBe(false);
+  });
+});
+
+describe('validateEntityName (issue #58)', () => {
+  it('accepts safe names and returns them trimmed', () => {
+    expect(validateEntityName('my-skill')).toBe('my-skill');
+    expect(validateEntityName('  Code Reviewer  ')).toBe('Code Reviewer');
+    expect(validateEntityName('agent_v1.2')).toBe('agent_v1.2');
+  });
+
+  it('rejects path-traversal and separator-bearing names', () => {
+    expect(() => validateEntityName('../../../tmp/x')).toThrow(/Invalid name/);
+    expect(() => validateEntityName('a/b')).toThrow(/Invalid name/);
+    expect(() => validateEntityName('a\\b')).toThrow(/Invalid name/);
+    expect(() => validateEntityName('.')).toThrow(/Invalid name/);
+    expect(() => validateEntityName('..')).toThrow(/Invalid name/);
+  });
+
+  it('rejects empty and over-long names', () => {
+    expect(() => validateEntityName('')).toThrow(/Invalid name/);
+    expect(() => validateEntityName('   ')).toThrow(/Invalid name/);
+    expect(() => validateEntityName('x'.repeat(81))).toThrow(/Invalid name/);
+  });
+});
+
+describe('assertWithin (issue #58)', () => {
+  const base = '/Users/foo/.claude/skills';
+
+  it('allows the base dir and paths inside it', () => {
+    expect(() => assertWithin(base, base)).not.toThrow();
+    expect(() => assertWithin(base, join(base, 'my-skill', 'SKILL.md'))).not.toThrow();
+  });
+
+  it('throws for resolved paths that escape the base dir', () => {
+    expect(() => assertWithin(base, join(base, '..', '..', 'evil'))).toThrow(/outside/);
+    expect(() => assertWithin(base, '/etc/passwd')).toThrow(/outside/);
+  });
+});
+
+describe('isValidSessionId (issue #57)', () => {
+  it('accepts canonical UUIDs', () => {
+    expect(isValidSessionId('123e4567-e89b-12d3-a456-426614174000')).toBe(true);
+  });
+
+  it('rejects ids carrying shell metacharacters or wrong shape', () => {
+    expect(isValidSessionId('x"; rm -rf ~; echo "')).toBe(false);
+    expect(isValidSessionId('x & calc')).toBe(false);
+    expect(isValidSessionId('not-a-uuid')).toBe(false);
+    expect(isValidSessionId('')).toBe(false);
+    expect(isValidSessionId(undefined)).toBe(false);
   });
 });


### PR DESCRIPTION
## Highlights

- Closes two security issues: directory traversal via user-supplied entity names (#58) and shell/AppleScript command injection in the session resume flow (#57).
- New reusable guards in `electron/utils.ts`: `validateEntityName()`, `assertWithin()` (path-traversal defense in depth), and `isValidSessionId()` (UUID validation).
- All entity writers (skills, agents, memory) now validate input, assert the resolved path stays inside the target directory, and refuse to overwrite existing files.
- The `sessions:openInTerminal` handler rejects non-UUID session ids and escapes the resume command for the macOS AppleScript string literal.
- Full unit coverage for the new helpers and writer guards; `npm run typecheck` and `npm test` (111 tests) pass.

## Path traversal (#58)

Renderer-supplied skill/agent names and memory topic slugs/types were interpolated directly into write paths, so a crafted name (e.g. `../../tmp/x`) could escape the intended target directory.

- `electron/utils.ts` — adds `validateEntityName()` (strict charset, rejects path separators and `.`/`..`) and `assertWithin()` (asserts the resolved path stays inside the base dir).
- `electron/modules/skills-writer.ts` — validates the skill name, `assertWithin` on the skill dir, refuses overwrite.
- `electron/modules/agents-writer.ts` — validates the agent name, `assertWithin`, refuses overwrite.
- `electron/modules/memory-writer.ts` — validates the topic `type`, rejects empty slugs, `assertWithin`.

## Command injection (#57)

Session ids and background-agent ids were interpolated into the shell/AppleScript resume command without validation.

- `electron/utils.ts` — adds `isValidSessionId()` (UUID format check).
- `electron/main.ts` — `sessions:openInTerminal` rejects non-UUID session ids; `buildResumeCommand` only uses `bg.id` when it is a valid id; the macOS branch escapes the `command` for the AppleScript double-quoted string.

## Tests

- `test/utils.test.ts` — cases for `validateEntityName`, `assertWithin`, `isValidSessionId`.
- `test/entity-writers.test.ts` (new) — skill/agent writers reject traversal and refuse overwrite.
- `test/memory.test.ts` — traversal/type cases for `createTopic`.

## Verification

- `npm run typecheck` — passes.
- `npm test` — 111 tests passing across 7 files.

Closes #57
Closes #58