### PR TITLE
fix(lint): resolve react-hooks v7 and ESLint errors that broke CI

### DIFF
--- a/electron/modules/duplicate-merge-executor.ts
+++ b/electron/modules/duplicate-merge-executor.ts
@@ -277,6 +277,8 @@ export function executeMerge(projectsDir: string, sourceHash: string, destHash: 
   } catch (e) {
     rollback();
     const msg = e instanceof Error ? e.message : String(e);
-    throw new Error(`Merge failed and was rolled back (backup at ${backupPath}): ${msg}`);
+    throw new Error(`Merge failed and was rolled back (backup at ${backupPath}): ${msg}`, {
+      cause: e,
+    });
   }
 }

--- a/src/components/project/chat/ChatView.tsx
+++ b/src/components/project/chat/ChatView.tsx
@@ -423,6 +423,25 @@ function TurnMinimap({
   )
 }
 
+function ChatFilterChip({
+  label,
+  c,
+  active,
+  onToggle,
+}: {
+  label: string
+  c: number
+  active: boolean
+  onToggle: () => void
+}) {
+  return (
+    <button type="button" className="cl-filter" data-on={active || undefined} onClick={onToggle}>
+      {label}
+      <span className="c">{c}</span>
+    </button>
+  )
+}
+
 function ChatTypeFilters({
   filter,
   setFilter,
@@ -434,24 +453,32 @@ function ChatTypeFilters({
   counts: { all: number; tools: number; thinking: number; questions: number; plan: number }
   showThinking: boolean
 }) {
-  const Chip = ({ id, label, c }: { id: TurnFilter; label: string; c: number }) => (
-    <button
-      type="button"
-      className="cl-filter"
-      data-on={filter === id || undefined}
-      onClick={() => setFilter(filter === id ? 'all' : id)}
-    >
-      {label}
-      <span className="c">{c}</span>
-    </button>
-  )
+  const toggle = (id: TurnFilter) => () => setFilter(filter === id ? 'all' : id)
   return (
     <div className="cl-chat-filters" role="group" aria-label="Filter turns by type">
-      <Chip id="all" label="All" c={counts.all} />
-      {counts.tools > 0 && <Chip id="tools" label="Tools" c={counts.tools} />}
-      {showThinking && counts.thinking > 0 && <Chip id="thinking" label="Thinking" c={counts.thinking} />}
-      {counts.questions > 0 && <Chip id="questions" label="Questions" c={counts.questions} />}
-      {counts.plan > 0 && <Chip id="plan" label="Plan" c={counts.plan} />}
+      <ChatFilterChip label="All" c={counts.all} active={filter === 'all'} onToggle={toggle('all')} />
+      {counts.tools > 0 && (
+        <ChatFilterChip label="Tools" c={counts.tools} active={filter === 'tools'} onToggle={toggle('tools')} />
+      )}
+      {showThinking && counts.thinking > 0 && (
+        <ChatFilterChip
+          label="Thinking"
+          c={counts.thinking}
+          active={filter === 'thinking'}
+          onToggle={toggle('thinking')}
+        />
+      )}
+      {counts.questions > 0 && (
+        <ChatFilterChip
+          label="Questions"
+          c={counts.questions}
+          active={filter === 'questions'}
+          onToggle={toggle('questions')}
+        />
+      )}
+      {counts.plan > 0 && (
+        <ChatFilterChip label="Plan" c={counts.plan} active={filter === 'plan'} onToggle={toggle('plan')} />
+      )}
     </div>
   )
 }
@@ -571,20 +598,6 @@ export function ChatView({
     return items
   }, [processed, descriptors])
 
-  // Per-turn match against the active type filter (non-matching turns are dimmed,
-  // never removed, so the conversation thread stays continuous).
-  const matchesFilter = useCallback(
-    (d: TurnDescriptor) => {
-      switch (turnFilter) {
-        case 'tools': return d.hasTools
-        case 'thinking': return d.hasThinking && detailsFilter === 'all'
-        case 'questions': return d.hasQuestion
-        case 'plan': return d.hasPlan
-        default: return true
-      }
-    },
-    [turnFilter, detailsFilter]
-  )
   const filterCounts = useMemo(
     () => ({
       all: visibleItems.length,
@@ -594,6 +607,31 @@ export function ChatView({
       plan: visibleItems.filter(d => d.hasPlan).length,
     }),
     [visibleItems]
+  )
+
+  // Derived (not stored) so it can never get stuck: the active filter falls back
+  // to "All" when it no longer has matching turns — e.g. Thinking in minimal
+  // mode, or any chip that just dropped to 0 (and is now hidden) — otherwise the
+  // transcript would stay fully dimmed with no way back.
+  const activeFilter: TurnFilter =
+    turnFilter !== 'all' &&
+    ((turnFilter === 'thinking' && detailsFilter === 'minimal') || filterCounts[turnFilter] === 0)
+      ? 'all'
+      : turnFilter
+
+  // Per-turn match against the active type filter (non-matching turns are dimmed,
+  // never removed, so the conversation thread stays continuous).
+  const matchesFilter = useCallback(
+    (d: TurnDescriptor) => {
+      switch (activeFilter) {
+        case 'tools': return d.hasTools
+        case 'thinking': return d.hasThinking && detailsFilter === 'all'
+        case 'questions': return d.hasQuestion
+        case 'plan': return d.hasPlan
+        default: return true
+      }
+    },
+    [activeFilter, detailsFilter]
   )
   // Model token distribution (descending), excluding the synthetic bucket.
   const modelEntries = useMemo<[string, number][]>(
@@ -625,15 +663,6 @@ export function ChatView({
     Object.values(turnRefs.current).forEach(el => el && io.observe(el))
     return () => io.disconnect()
   }, [minimapItems, viewMode])
-
-  // Reset to "All" when the active filter no longer has matching turns — e.g.
-  // Thinking in minimal mode, or any chip that just dropped to 0 (and is now
-  // hidden), so the transcript never gets stuck fully dimmed with no way back.
-  useEffect(() => {
-    if (turnFilter === 'all') return
-    if (turnFilter === 'thinking' && detailsFilter === 'minimal') { setTurnFilter('all'); return }
-    if (filterCounts[turnFilter] === 0) setTurnFilter('all')
-  }, [detailsFilter, turnFilter, filterCounts])
 
   const jumpToTurn = useCallback((n: number) => {
     const el = turnRefs.current[n]
@@ -824,7 +853,7 @@ export function ChatView({
 
             {processed.length > 0 && (
               <ChatTypeFilters
-                filter={turnFilter}
+                filter={activeFilter}
                 setFilter={setTurnFilter}
                 counts={filterCounts}
                 showThinking={detailsFilter === 'all'}
@@ -859,14 +888,14 @@ export function ChatView({
                         detailsFilter={detailsFilter}
                         onOpenToolDetail={setSelectedTool}
                         turnIndex={item.idx + 1}
-                        dimmed={turnFilter !== 'all' && descriptors[item.idx]?.visible && !matchesFilter(descriptors[item.idx])}
+                        dimmed={activeFilter !== 'all' && descriptors[item.idx]?.visible && !matchesFilter(descriptors[item.idx])}
                         innerRef={setTurnRef}
                       />
                     ) : (
                       <ToolsHiddenBadge
                         key={item.key}
                         count={item.count}
-                        dimmed={turnFilter !== 'all' && turnFilter !== 'tools'}
+                        dimmed={activeFilter !== 'all' && activeFilter !== 'tools'}
                       />
                     )
                   )}

--- a/src/components/project/chat/ToolDetailPanel.tsx
+++ b/src/components/project/chat/ToolDetailPanel.tsx
@@ -534,8 +534,15 @@ function ToolOutput({ name, input, result }: {
   }
 
   if (name.startsWith('memory:')) {
+    // Parse inside try/catch, but keep JSX returns outside it so a render-time
+    // throw propagates to the error boundary instead of being swallowed.
+    let json: { data?: { filename?: string }; filename?: string } | null = null
     try {
-      const json = JSON.parse(raw)
+      json = JSON.parse(raw)
+    } catch {
+      // Not JSON — fall through to the raw code block below.
+    }
+    if (json) {
       if (name === 'memory:createTopic' || name === 'memory:updateTopic') {
         const filename = json.data?.filename || json.filename
         return filename ? (
@@ -555,8 +562,6 @@ function ToolOutput({ name, input, result }: {
           </div>
         )
       }
-    } catch {
-      // Se non è JSON, fallback
     }
   }
 

--- a/src/components/project/chat/graph/SessionGraphView.tsx
+++ b/src/components/project/chat/graph/SessionGraphView.tsx
@@ -299,7 +299,7 @@ export function SessionGraphView({ processed, onSelectTool }: Props) {
         <div
           className="cl-tl-tip"
           style={{
-            left: Math.max(8, Math.min((tooltip.x ?? 0), (wrapRef.current?.clientWidth ?? 800) - 280)),
+            left: Math.max(8, Math.min((tooltip.x ?? 0), viewportWidth - 280)),
             top: tooltip.y,
           }}
         >

--- a/src/components/project/overview/ProjectOverviewContent.tsx
+++ b/src/components/project/overview/ProjectOverviewContent.tsx
@@ -242,27 +242,51 @@ export function ProjectView({
     return () => { alive = false; clearInterval(t) }
   }, [])
   const liveProc = procs.find(p => p.cwd === project.realPath)
-  const liveStart = useMemo(() => Date.now(), [liveProc?.pid])
-  const [, tick] = useState(0)
+  const livePid = liveProc?.pid
+  // Live uptime in state, computed inside the interval callback (never during
+  // render) so the render stays pure. Reseeds whenever the observed PID changes.
+  const [liveSec, setLiveSec] = useState(0)
   useEffect(() => {
-    if (!liveProc) return
-    const t = setInterval(() => tick(x => x + 1), 1000)
-    return () => clearInterval(t)
-  }, [liveProc])
-  const liveSec = liveProc ? Math.floor((Date.now() - liveStart) / 1000) : 0
+    if (livePid === undefined) return
+    let start: number | null = null
+    const update = () => {
+      if (start === null) start = Date.now()
+      setLiveSec(Math.floor((Date.now() - start) / 1000))
+    }
+    const seed = setTimeout(update, 0)
+    const t = setInterval(update, 1000)
+    return () => {
+      clearTimeout(seed)
+      clearInterval(t)
+    }
+  }, [livePid])
   const liveUptime = `${Math.floor(liveSec / 60)}m ${liveSec % 60}s`
+
+  // Wall-clock for the retention window, kept in state so render never calls
+  // Date.now() directly. Seeded right after mount and refreshed each minute;
+  // 0 until the first tick (statsSessions falls back to all sessions then).
+  const [nowMs, setNowMs] = useState(0)
+  useEffect(() => {
+    const tick = () => setNowMs(Date.now())
+    const seed = setTimeout(tick, 0)
+    const t = setInterval(tick, 60_000)
+    return () => {
+      clearTimeout(seed)
+      clearInterval(t)
+    }
+  }, [])
 
   // ── Derived ──
   const projectName = projectDisplayName(project.realPath)
   const retentionDays = normalizeRetentionDays(cleanupDays)
   const statsSessions = useMemo(() => {
-    const now = Date.now()
-    const cutoff = now - retentionDays * DAY_MS
+    if (nowMs === 0) return sessions
+    const cutoff = nowMs - retentionDays * DAY_MS
     return sessions.filter(s => {
       const t = new Date(s.date).getTime()
-      return !isNaN(t) && t >= cutoff && t <= now
+      return !isNaN(t) && t >= cutoff && t <= nowMs
     })
-  }, [sessions, retentionDays])
+  }, [sessions, retentionDays, nowMs])
   const sessionCount = statsSessions.length
   const totalTokens = statsSessions.reduce((s, x) => s + x.totalTokens, 0)
   const totalCost = statsSessions.reduce((s, x) => s + x.estimatedCost, 0)
@@ -279,13 +303,13 @@ export function ProjectView({
     [sessions, project.hash, isSessionPinned],
   )
   const hasPinnedSession = pinnedSessions.length > 0
+  // Effective tag filter: a selection whose tag was deleted is treated as no
+  // filter (derived, not an effect, so it can never get stuck on a stale tag).
+  const activeTag = tagFilter && projectTags.some(t => t.name === tagFilter) ? tagFilter : null
   const visibleSessions = useMemo(() => {
-    if (!tagFilter) return sessions
-    return sessions.filter(s => tagsForSession(s.filename).includes(tagFilter))
-  }, [sessions, tagFilter, tagsForSession])
-  useEffect(() => {
-    if (tagFilter && !projectTags.some(t => t.name === tagFilter)) setTagFilter(null)
-  }, [tagFilter, projectTags])
+    if (!activeTag) return sessions
+    return sessions.filter(s => tagsForSession(s.filename).includes(activeTag))
+  }, [sessions, activeTag, tagsForSession])
 
   const memTopics = useMemo(
     () => [...(memory?.index ?? []), ...(memory?.projectLevelIndex ?? [])],
@@ -489,15 +513,15 @@ export function ProjectView({
             <div className="cl-sec-head">
               <h2>Sessions</h2>
               <span className="ct">
-                {tagFilter
-                  ? `${visibleSessions.length} tagged #${tagFilter}`
+                {activeTag
+                  ? `${visibleSessions.length} tagged #${activeTag}`
                   : `${sessions.length} total · sorted by last activity`}
               </span>
             </div>
             <TagBar
               tags={projectTags}
               counts={tagCounts}
-              activeTag={tagFilter}
+              activeTag={activeTag}
               totalCount={sessions.length}
               onSelect={setTagFilter}
               onRename={renameTag}
@@ -505,7 +529,7 @@ export function ProjectView({
             />
             {visibleSessions.length === 0 ? (
               <div className="cl-empty">
-                {tagFilter ? `No sessions tagged #${tagFilter}.` : 'No sessions yet.'}
+                {activeTag ? `No sessions tagged #${activeTag}.` : 'No sessions yet.'}
               </div>
             ) : (
               <SessionRows sessions={visibleSessions} projectHash={project.hash} cleanupDays={cleanupDays} onOpen={s => onNavigate({ type: 'chat', project, session: s })} />

--- a/src/components/project/shared/CreateFormKit.tsx
+++ b/src/components/project/shared/CreateFormKit.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useMemo, useLayoutEffect } from 'react'
+import { useState, useRef, useEffect, useMemo, useCallback } from 'react'
 import { createPortal } from 'react-dom'
 
 // Shared building blocks for the "create" pages (skills, agents).
@@ -162,22 +162,30 @@ export function ToolsInput({ value, onChange, placeholder, accent }: {
   // The dropdown is portaled to <body> so it escapes ancestors that clip
   // (e.g. the edit card uses backdrop-filter, which clips descendants in
   // Chromium even with overflow: visible). Position is tracked from the box.
-  useLayoutEffect(() => {
-    if (!open) { setRect(null); setHover(null); return }
-    const update = () => {
-      const el = boxRef.current
-      if (!el) return
-      const r = el.getBoundingClientRect()
-      setRect({ left: r.left, top: r.bottom, width: r.width })
-    }
-    update()
-    window.addEventListener('scroll', update, true)
-    window.addEventListener('resize', update)
+  const measure = useCallback(() => {
+    const el = boxRef.current
+    if (!el) return
+    const r = el.getBoundingClientRect()
+    setRect({ left: r.left, top: r.bottom, width: r.width })
+  }, [])
+
+  // Opening the dropdown measures the box up-front (in the event handler, so no
+  // synchronous setState lands in an effect); the effect below only keeps it
+  // anchored on scroll/resize while open. The portal renders solely when
+  // `open && rect`, so a stale rect after close is never visible.
+  const openMenu = () => {
+    measure()
+    setOpen(true)
+  }
+  useEffect(() => {
+    if (!open) return
+    window.addEventListener('scroll', measure, true)
+    window.addEventListener('resize', measure)
     return () => {
-      window.removeEventListener('scroll', update, true)
-      window.removeEventListener('resize', update)
+      window.removeEventListener('scroll', measure, true)
+      window.removeEventListener('resize', measure)
     }
-  }, [open])
+  }, [open, measure])
 
   // Literal class strings (no dynamic interpolation) so Tailwind's JIT keeps them.
   const chipCls = accent === 'violet'
@@ -220,9 +228,9 @@ export function ToolsInput({ value, onChange, placeholder, accent }: {
           className="flex-1 min-w-[100px] bg-transparent px-1 py-0.5 text-[13px] font-mono text-[var(--cl-ink)] placeholder:text-[var(--cl-ink-4)] outline-none"
           placeholder={value.length ? '' : placeholder}
           value={draft}
-          onChange={e => { setDraft(e.target.value); setOpen(true) }}
-          onFocus={() => setOpen(true)}
-          onBlur={() => setTimeout(() => setOpen(false), 120)}
+          onChange={e => { setDraft(e.target.value); openMenu() }}
+          onFocus={openMenu}
+          onBlur={() => setTimeout(() => { setOpen(false); setHover(null) }, 120)}
           onKeyDown={e => {
             if (e.key === 'Enter' || e.key === ',') { e.preventDefault(); if (draft.trim()) add(draft) }
             else if (e.key === 'Backspace' && !draft && value.length) removeAt(value.length - 1)

--- a/src/components/project/shared/DeleteSessionDialog.tsx
+++ b/src/components/project/shared/DeleteSessionDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 
 import { useSessionArtifacts, useDeleteSession } from '../../../hooks/useIPC'
 import type { SessionArtifact } from '../../../types'
@@ -36,13 +36,15 @@ export function DeleteSessionDialog({
 
   const artifacts = useMemo(() => data?.artifacts ?? [], [data])
 
-  // Inizializza le checkbox dai default del backend quando arrivano gli artefatti.
-  useEffect(() => {
-    if (!data) return
+  // Seed the checkboxes from the backend defaults as soon as the artifacts
+  // arrive (React's "adjust state during render" pattern — no effect needed).
+  const [lastData, setLastData] = useState(data)
+  if (data && data !== lastData) {
+    setLastData(data)
     const init: Record<string, boolean> = {}
     for (const a of data.artifacts) init[a.path] = a.locked ? true : a.defaultSelected
     setSelected(init)
-  }, [data])
+  }
 
   const toggle = (a: SessionArtifact) => {
     if (a.locked) return

--- a/src/components/project/shared/EntityDetailView.tsx
+++ b/src/components/project/shared/EntityDetailView.tsx
@@ -593,8 +593,19 @@ export function EntityDetailView({
   )
 
   const [editState, setEditState] = useState<EditState>(initial)
-  useEffect(() => { setEditState(initial) }, [initial])
-  useEffect(() => { setError(null) }, [mode])
+  // Re-seed the edit buffer when the source content changes, and clear any
+  // stale error when toggling view/edit — both via React's "adjust state during
+  // render" pattern instead of effects.
+  const [lastInitial, setLastInitial] = useState(initial)
+  if (initial !== lastInitial) {
+    setLastInitial(initial)
+    setEditState(initial)
+  }
+  const [lastMode, setLastMode] = useState(mode)
+  if (mode !== lastMode) {
+    setLastMode(mode)
+    setError(null)
+  }
 
   const dirty =
     mode === 'edit' &&

--- a/src/components/project/shared/MarkdownDocView.tsx
+++ b/src/components/project/shared/MarkdownDocView.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect, useState } from 'react'
+import { ReactNode, useState } from 'react'
 import Markdown from '../../Markdown'
 import { TopBar } from './TopBar'
 
@@ -111,10 +111,14 @@ export function MarkdownDocView({
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  useEffect(() => {
+  // Re-seed local state when the source content prop changes (React's
+  // "adjust state during render" pattern — no effect needed).
+  const [lastContent, setLastContent] = useState(content)
+  if (content !== lastContent) {
+    setLastContent(content)
     setCurrent(content)
     setDraft(content)
-  }, [content])
+  }
 
   const dirty = mode === 'edit' && draft !== current
 

--- a/src/components/project/shared/SearchPopover.tsx
+++ b/src/components/project/shared/SearchPopover.tsx
@@ -146,12 +146,23 @@ export function SearchPopover({
   const [hl, setHl] = useState(0)
   const [activeFilter, setActiveFilter] = useState<SearchFilter>('all')
 
+  // Reset the search buffer each time the popover opens or switches mode
+  // (render-time adjustment; the focus side-effect stays in the effect below).
+  const resetKey = open ? mode : 'closed'
+  const [lastResetKey, setLastResetKey] = useState(resetKey)
+  if (resetKey !== lastResetKey) {
+    setLastResetKey(resetKey)
+    if (open) {
+      setQuery('')
+      setHl(0)
+      setActiveFilter(mode === 'projects' ? 'projects' : 'all')
+    }
+  }
+
   useEffect(() => {
     if (!open) return
-    setQuery('')
-    setHl(0)
-    setActiveFilter(mode === 'projects' ? 'projects' : 'all')
-    setTimeout(() => inputRef.current?.focus(), 10)
+    const id = setTimeout(() => inputRef.current?.focus(), 10)
+    return () => clearTimeout(id)
   }, [mode, open])
 
   useEffect(() => {
@@ -297,9 +308,11 @@ export function SearchPopover({
     return { sections: out, flat: out.flatMap(s => s.rows), counts }
   }, [activeFilter, agents, costByHash, currentHash, mcpServers, mcpTotalProjects, mode, pinned, pinnedSessions, projects, query, sessions, skills])
 
-  useEffect(() => {
-    if (hl >= flat.length) setHl(Math.max(0, flat.length - 1))
-  }, [flat.length, hl])
+  // Keep the highlighted row within range when the result set shrinks
+  // (render-time adjustment — converges as hl drops back into range).
+  if (hl > 0 && hl >= flat.length) {
+    setHl(Math.max(0, flat.length - 1))
+  }
 
   function selectRow(row: SearchRow) {
     if (row.kind === 'project') onSelectProject(row.project)

--- a/src/hooks/useTheme.tsx
+++ b/src/hooks/useTheme.tsx
@@ -38,16 +38,18 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   const [preference, setPreferenceState] = useState<ThemePreference>(readStoredPreference)
   const [systemResolved, setSystemResolved] = useState<ResolvedTheme>(systemTheme)
 
-  // Track the OS color scheme only while following the system; this keeps the
-  // app in sync if the user flips their OS theme while ClaudeLens is open.
+  // Track the OS color scheme so the app stays in sync if the user flips their
+  // OS theme while ClaudeLens is open. The listener runs regardless of the
+  // current preference (the initial value already comes from systemTheme()),
+  // which avoids a synchronous re-sync inside the effect; `resolved` below only
+  // consumes it when the preference is 'system'.
   useEffect(() => {
-    if (preference !== 'system' || typeof window === 'undefined' || !window.matchMedia) return
+    if (typeof window === 'undefined' || !window.matchMedia) return
     const mq = window.matchMedia(DARK_QUERY)
     const onChange = (e: MediaQueryListEvent) => setSystemResolved(e.matches ? 'dark' : 'light')
-    setSystemResolved(mq.matches ? 'dark' : 'light')
     mq.addEventListener('change', onChange)
     return () => mq.removeEventListener('change', onChange)
-  }, [preference])
+  }, [])
 
   const resolved: ResolvedTheme = preference === 'system' ? systemResolved : preference
 

--- a/src/tabs/ProjectOverview.tsx
+++ b/src/tabs/ProjectOverview.tsx
@@ -147,10 +147,13 @@ export default function ProjectOverview() {
     [mcpData],
   )
 
+  // Clear the loading flag whenever the global search is closed (render-time
+  // adjustment; the async loader below owns the flag while it's open).
+  if (!searchOpen && searchSessionsLoading) setSearchSessionsLoading(false)
+
   useEffect(() => {
     const projectsForSearch = projects ?? []
     if (!searchOpen || searchMode !== 'global' || projectsForSearch.length === 0) {
-      if (!searchOpen) setSearchSessionsLoading(false)
       return
     }
 

--- a/tsconfig.electron.json
+++ b/tsconfig.electron.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2020",
+    "lib": ["ES2020", "ES2022.Error"],
     "module": "node16",
     "moduleResolution": "node16",
     "outDir": "dist-electron",


### PR DESCRIPTION
## Highlights

- Ripristina la CI: il job **Lint** falliva su `main` dopo il bump major di Dependabot (#80), che ha aggiornato ESLint + `eslint-plugin-react-hooks` a v7 promuovendo a `error` diverse regole nuove.
- **30 errori risolti sistemando i pattern reali** — niente downgrade delle regole a `warn`, così il debito tecnico è azzerato anziché rimandato.

## Cosa cambia

| Regola | Fix |
|---|---|
| `preserve-caught-error` | `cause` allegato al `new Error` rilanciato in `duplicate-merge-executor.ts`; aggiunto lib `ES2022.Error` a `tsconfig.electron.json` (runtime Node lo supporta già) |
| `react-hooks/static-components` | estratto `Chip` come componente top-level (`ChatFilterChip`) in `ChatView` |
| `react-hooks/error-boundaries` | parsing dentro `try`, JSX restituito fuori (`ToolDetailPanel`) |
| `react-hooks/refs` | uso dello stato `viewportWidth` invece di leggere `wrapRef.current` durante il render (`SessionGraphView`) |
| `react-hooks/purity` | `Date.now()` spostato in clock di stato aggiornati da timer — uptime live + finestra retention (`ProjectOverviewContent`) |
| `react-hooks/set-state-in-effect` (×11, 7 file) | convertiti a **stato derivato** / **adjust-during-render**; `CreateFormKit` misura il dropdown nell'handler di apertura; `useTheme` ascolta la media query incondizionatamente |

## Verifica

- `npm run lint` → 0 errori
- `npm run typecheck` → OK
- `npm test` → 96/96
- `npm run build` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)