### PR TITLE
fix(cost-tracker): malformed timestamp no longer zeroes out remaining token count

### DIFF
--- a/electron/modules/cost-tracker.ts
+++ b/electron/modules/cost-tracker.ts
@@ -184,7 +184,11 @@ function extractFirstUserText(json: Record<string, unknown>): string | undefined
 // for well-formed lines that carry nothing we track (kept separate from JSON
 // parse failures, which the caller counts and logs).
 function extractLineData(json: any): LineData | null {
-  const date = json.timestamp ? new Date(json.timestamp).toISOString() : '';
+  // Guard against malformed timestamps: `new Date('not-a-date').toISOString()`
+  // throws RangeError, which (called outside the per-line JSON.parse try) would
+  // abort the whole file and under-count every later line (issue #88).
+  const d = json.timestamp ? new Date(json.timestamp) : null;
+  const date = d && !isNaN(d.getTime()) ? d.toISOString() : '';
   const customTitle = json.type === 'custom-title' ? (json.customTitle as string | undefined) : undefined;
   const aiTitle = json.type === 'ai-title' ? (json.aiTitle as string | undefined) : undefined;
   const firstUserMessage = extractFirstUserText(json as Record<string, unknown>);

--- a/test/cost-tracker.test.ts
+++ b/test/cost-tracker.test.ts
@@ -125,6 +125,28 @@ describe('getProjectUsage — token summation & known-model cost', () => {
   });
 });
 
+describe('malformed timestamp does not abort the file (issue #88)', () => {
+  it('keeps counting later lines when one line has a non-ISO timestamp', async () => {
+    writeSession(tmp, 'a.jsonl', [
+      assistantLine({ model: 'claude-sonnet-4-5', input: 1000, output: 500 }),
+      assistantLine({
+        model: 'claude-sonnet-4-5',
+        input: 9999,
+        output: 9999,
+        timestamp: 'not-a-date',
+      }),
+      assistantLine({ model: 'claude-sonnet-4-5', input: 2000, output: 1500 }),
+    ]);
+
+    const { usage } = await getProjectUsage(tmp);
+
+    // The malformed line is still counted (only its date is dropped), and the
+    // line after it is NOT lost — before the fix the loop aborted on line 2.
+    expect(usage.inputTokens).toBe(1000 + 9999 + 2000);
+    expect(usage.outputTokens).toBe(500 + 9999 + 1500);
+  });
+});
+
 describe('usage dedup by message.id / requestId (issue #56)', () => {
   it('counts a usage carried by repeated message.id+requestId lines only once', async () => {
     // Claude Code emits one line per content block of an assistant turn, each


### PR DESCRIPTION
## Summary

Fixes #88 — a malformed timestamp in a single JSONL line no longer aborts the rest of the file's token count.

`extractLineData` did `new Date(json.timestamp).toISOString()` (`electron/modules/cost-tracker.ts`). A well-formed JSON line with a non-ISO `timestamp` throws `RangeError: Invalid time value`. Because that call sits outside the per-line `JSON.parse` try, the error unwound to the outer catch and **aborted the `for` loop over the remaining lines** — every later line went uncounted and the session tokens/cost were under-reported.

## Change

Validate the date before calling `toISOString()`, dropping only the bad date instead of failing the whole line/file:

```ts
const d = json.timestamp ? new Date(json.timestamp) : null;
const date = d && !isNaN(d.getTime()) ? d.toISOString() : '';
```

## Test

Added a case in `test/cost-tracker.test.ts` that places a line with `timestamp: 'not-a-date'` between two valid lines and asserts:
- the malformed line is still counted (only its date is dropped);
- the line **after** it is not lost.

`vitest` 19/19 green · `typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
