### PR TITLE
fix(session-reader): guard tool_result array element types to avoid dropping messages

### DIFF
--- a/electron/modules/session-reader.ts
+++ b/electron/modules/session-reader.ts
@@ -42,12 +42,21 @@ function parseContentArray(raw: unknown[]): ChatContentBlock[] {
       const content =
         typeof b.content === 'string' ? b.content :
         Array.isArray(b.content)
-          ? (b.content as Array<{ type?: string; text?: string; tool_name?: string }>)
-              .map(c =>
-                c.type === 'tool_reference' && c.tool_name
-                  ? `→ ${c.tool_name}`
-                  : (c.text ?? '')
-              )
+          ? (b.content as Array<unknown>)
+              .map(c => {
+                // Nel formato Anthropic gli elementi possono essere stringhe
+                // semplici (`["text"]`) o anche `null`: senza guardia sul tipo
+                // l'accesso a `c.type` lancerebbe TypeError, scartando l'intero
+                // messaggio dal try/catch per-riga.
+                if (typeof c === 'string') return c;
+                if (c && typeof c === 'object') {
+                  const block = c as { type?: string; text?: string; tool_name?: string };
+                  return block.type === 'tool_reference' && block.tool_name
+                    ? `→ ${block.tool_name}`
+                    : (block.text ?? '');
+                }
+                return '';
+              })
               .join('\n')
           : '';
       blocks.push({

--- a/src/components/project/chat/ChatView.tsx
+++ b/src/components/project/chat/ChatView.tsx
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import type { CSSProperties } from 'react'
-import { saveMarkdownExport, savePdfExport, useChatSession, useSessionSubagents, useGlobalAgents, useProjectAgents } from '../../../hooks/useIPC'
-import { SessionSummary } from '../../../hooks/useIPC'
+import { saveMarkdownExport, savePdfExport, useChatSession, useSessionSubagents, useGlobalAgents, useProjectAgents, useAllSkills } from '../../../hooks/useIPC'
+import { SessionSummary, Skill, Agent } from '../../../hooks/useIPC'
 import { sessionTitle } from '../utils'
-import { buildProcessedMessages, correlateSessionAgents, describeTurn, touchedFiles, ChatDetailsFilter, SessionAgent, ToolGroup, TouchedFile, TurnDescriptor } from './utils'
+import { buildProcessedMessages, correlateSessionAgents, correlateSessionSkills, describeTurn, touchedFiles, skillInitial, ChatDetailsFilter, SessionAgent, SessionSkill, ToolGroup, TouchedFile, TurnDescriptor } from './utils'
 import { buildChatExportDocument, CHAT_EXPORT_PRESETS, ChatExportFormat, ChatExportPreset } from './export'
 import { ToolDetailPanel } from './ToolDetailPanel'
 import { SubagentTranscriptPanel } from './SubagentTranscriptPanel'
@@ -13,7 +13,6 @@ import { TopBar } from '../shared/TopBar'
 import { DeleteSessionDialog } from '../shared/DeleteSessionDialog'
 import { SessionGraphView } from './graph/SessionGraphView'
 import { QueryError } from '../../QueryError'
-import { projectDisplayName } from '../shared/projectName'
 
 type ViewMode = 'chat' | 'timeline'
 
@@ -204,6 +203,81 @@ function AgentOrbCluster({
   )
 }
 
+/** Skill counterpart of AgentOrbCluster — overlapping first-letter orbs (all in
+ *  the brand accent, skills carry no per-identity color) for the footer dock. */
+function SkillOrbCluster({ skills }: { skills: SessionSkill[] }) {
+  const shown = skills.slice(0, 4)
+  const overflow = skills.length - shown.length
+  return (
+    <span className="cl-dock-orbs">
+      {shown.map((s, i) => (
+        <span key={s.key} className="cl-dock-orb" style={{ zIndex: shown.length - i, ...orbStyle('var(--cl-accent)') }}>{skillInitial(s.name)}</span>
+      ))}
+      {overflow > 0 && <span className="cl-dock-orb cl-dock-orb--more" style={{ zIndex: 0 }}>+{overflow}</span>}
+    </span>
+  )
+}
+
+/** The skill dock sheet — sibling of AgentDockSheet. Lists every skill invoked in
+ *  the session; a row deep-links to the skill detail when the definition resolves,
+ *  otherwise it just locates the invocation in the transcript. The locate button
+ *  always jumps to the invocation card. */
+function SkillDockSheet({
+  skills,
+  activeKey,
+  onOpen,
+  onLocate,
+}: {
+  skills: SessionSkill[]
+  activeKey: string | null
+  onOpen: (skill: Skill) => void
+  onLocate: (turnN: number) => void
+}) {
+  return (
+    <div className="cl-sheet cl-sheet--agents" role="menu">
+      <div className="cl-sheet-head">
+        <span className="cl-dock-sheet-label">Skills used · {skills.length}</span>
+      </div>
+      <div className="cl-dock-rows">
+        {skills.map(s => {
+          const canOpen = s.skill !== null
+          return (
+            <div key={s.key} className="cl-dock-row" data-active={activeKey === s.key || undefined}>
+              <button
+                type="button"
+                className="cl-dock-row-main"
+                onClick={() => (canOpen ? onOpen(s.skill!) : onLocate(s.turnN))}
+                title={canOpen ? 'View skill' : 'Locate invocation in chat'}
+              >
+                <span className="orb" aria-hidden style={orbStyle('var(--cl-accent)')}>{skillInitial(s.name)}</span>
+                <span className="body">
+                  <span className="r1">
+                    <span className="name">{s.name}</span>
+                    {s.scope && <span className="status">{s.scope}</span>}
+                  </span>
+                  {s.description && <span className="desc">{s.description}</span>}
+                  {!canOpen && (
+                    <span className="meta"><span className="steps">no definition</span></span>
+                  )}
+                </span>
+              </button>
+              <button
+                type="button"
+                className="cl-dock-row-locate"
+                onClick={() => onLocate(s.turnN)}
+                title="Jump to invocation in chat"
+                aria-label="Jump to invocation in chat"
+              >
+                <LocateGlyph />
+              </button>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
 /** The agent dock that lives inside the control pill (Focus layout, variant 4):
  *  an overlapping avatar cluster + count that toggles a sheet listing every
  *  sub-agent. The sheet is rendered by ChatControlPill above the pill; this just
@@ -312,6 +386,10 @@ function ChatControlPill({
   agentColorOf,
   onOpenAgent,
   onLocateAgent,
+  skills,
+  activeSkillKey,
+  onOpenSkill,
+  onLocateSkill,
 }: {
   showTranscriptControls: boolean
   filter: TurnFilter
@@ -336,10 +414,14 @@ function ChatControlPill({
   agentColorOf: (agent: SessionAgent) => string | undefined
   onOpenAgent: (agent: SessionAgent) => void
   onLocateAgent: (turnN: number) => void
+  skills: SessionSkill[]
+  activeSkillKey: string | null
+  onOpenSkill: (skill: Skill) => void
+  onLocateSkill: (turnN: number) => void
 }) {
-  // Only one sheet is raised above the pill at a time: the agent dock list or
-  // the export/delete menu.
-  const [sheet, setSheet] = useState<'export' | 'agents' | null>(null)
+  // Only one sheet is raised above the pill at a time: the agent dock list, the
+  // skill dock list, or the export/delete menu.
+  const [sheet, setSheet] = useState<'export' | 'agents' | 'skills' | null>(null)
   const rootRef = useRef<HTMLDivElement | null>(null)
 
   useEffect(() => {
@@ -360,6 +442,7 @@ function ChatControlPill({
     })
   }
   const toggleAgents = () => setSheet(s => (s === 'agents' ? null : 'agents'))
+  const toggleSkills = () => setSheet(s => (s === 'skills' ? null : 'skills'))
 
   const chip = (id: TurnFilter, label: string, c: number) => (
     <button
@@ -388,6 +471,20 @@ function ChatControlPill({
           onLocate={turnN => {
             setSheet(null)
             onLocateAgent(turnN)
+          }}
+        />
+      )}
+      {sheet === 'skills' && skills.length > 0 && (
+        <SkillDockSheet
+          skills={skills}
+          activeKey={activeSkillKey}
+          onOpen={skill => {
+            setSheet(null)
+            onOpenSkill(skill)
+          }}
+          onLocate={turnN => {
+            setSheet(null)
+            onLocateSkill(turnN)
           }}
         />
       )}
@@ -476,6 +573,24 @@ function ChatControlPill({
             <span className="cl-pill-div" />
           </>
         )}
+        {skills.length > 0 && (
+          <>
+            <button
+              type="button"
+              className="cl-pill-dock"
+              aria-haspopup="menu"
+              aria-expanded={sheet === 'skills'}
+              data-on={sheet === 'skills' || undefined}
+              title={`${skills.length} skill${skills.length > 1 ? 's' : ''} used`}
+              onClick={toggleSkills}
+            >
+              <SkillOrbCluster skills={skills} />
+              <span className="cl-dock-count">{skills.length} <span>skills</span></span>
+              <DockCaretGlyph open={sheet === 'skills'} />
+            </button>
+            <span className="cl-pill-div" />
+          </>
+        )}
         <button className="cl-resume" type="button" onClick={onResume}>
           <PlayGlyph />
           <span>Resume</span>
@@ -500,16 +615,22 @@ export function ChatView({
   project,
   session,
   onBack,
+  onOpenSkill,
+  onOpenAgent,
 }: {
   project: { hash: string; realPath: string }
   session: SessionSummary
   onBack: () => void
+  /** Deep-link to a skill detail view (from an inline skill card or the dock). */
+  onOpenSkill?: (skill: Skill) => void
+  /** Deep-link to an agent detail view (from an inline agent card). */
+  onOpenAgent?: (agent: Agent) => void
 }) {
   const { data: messages, isLoading, isError, error, refetch } = useChatSession(project.hash, session.filename)
   const { data: subagentMetas } = useSessionSubagents(project.hash, session.filename)
   const { data: globalAgents } = useGlobalAgents()
   const { data: projectAgents } = useProjectAgents(project.realPath)
-  const projectName = projectDisplayName(project.realPath)
+  const { data: allSkills } = useAllSkills(project.realPath)
 
   // Resolve a dispatched sub-agent's identity color from its definition
   // (`subagent_type` → agent.color). Project agents win over globals on name
@@ -521,6 +642,23 @@ export function ChatView({
     for (const a of projectAgents ?? []) if (a.color) byName.set(a.name, a.color)
     return (subagentType: string) => byName.get(subagentType)
   }, [globalAgents, projectAgents])
+
+  // Resolve a sub-agent's full definition by name (project wins on clash) so an
+  // expanded agent card can deep-link to its detail view.
+  const agentOf = useMemo(() => {
+    const byName = new Map<string, Agent>()
+    for (const a of globalAgents ?? []) byName.set(a.name, a)
+    for (const a of projectAgents ?? []) byName.set(a.name, a)
+    return (subagentType: string) => byName.get(subagentType)
+  }, [globalAgents, projectAgents])
+
+  // Resolve a skill's full definition by name (the slash-command id) — feeds both
+  // the inline skill card link and the footer skill dock.
+  const skillOf = useMemo(() => {
+    const byName = new Map<string, Skill>()
+    for (const s of allSkills ?? []) byName.set(s.name, s)
+    return (name: string) => byName.get(name)
+  }, [allSkills])
   const [viewMode, setViewMode] = useState<ViewMode>('chat')
   const [detailsFilter, setDetailsFilter] = useState<ChatDetailsFilter>('minimal')
   const [selectedTool, setSelectedTool] = useState<ToolGroup | null>(null)
@@ -553,6 +691,13 @@ export function ChatView({
   const agents = useMemo(
     () => correlateSessionAgents(processed, subagentMetas ?? []),
     [processed, subagentMetas]
+  )
+
+  // Skills invoked in this session, linked to their definitions — drives the
+  // footer skill dock (sibling of the agent dock).
+  const skills = useMemo(
+    () => correlateSessionSkills(processed, allSkills ?? []),
+    [processed, allSkills]
   )
 
   // The detail filter (Minimal/Full) drives which turns are visible — Minimal
@@ -704,6 +849,17 @@ export function ChatView({
     return key ?? agents[0].key
   }, [agents, activeTurn])
 
+  const activeSkillKey = useMemo(() => {
+    if (skills.length === 0) return null
+    if (activeTurn === null) return skills[0].key
+    let key: string | null = null
+    for (const s of skills) {
+      if (s.turnN <= activeTurn) key = s.key
+      else break
+    }
+    return key ?? skills[0].key
+  }, [skills, activeTurn])
+
   const title = sessionTitle(session)
   const selectedExportPreset = CHAT_EXPORT_PRESETS.find(p => p.value === exportPreset) ?? CHAT_EXPORT_PRESETS[0]
 
@@ -770,6 +926,10 @@ export function ChatView({
       agentColorOf={a => agentTintColor(agentColorOf(a.subagentType))}
       onOpenAgent={setTranscriptAgent}
       onLocateAgent={jumpToTurn}
+      skills={skills}
+      activeSkillKey={activeSkillKey}
+      onOpenSkill={skill => onOpenSkill?.(skill)}
+      onLocateSkill={jumpToTurn}
     />
   )
 
@@ -882,6 +1042,10 @@ export function ChatView({
                           detailsFilter={detailsFilter}
                           onOpenToolDetail={setSelectedTool}
                           agentColorOf={agentColorOf}
+                          skillOf={skillOf}
+                          onOpenSkill={onOpenSkill}
+                          agentOf={agentOf}
+                          onOpenAgent={onOpenAgent}
                           turnIndex={item.idx + 1}
                           dimmed={activeFilter !== 'all' && descriptors[item.idx]?.visible && !matchesFilter(descriptors[item.idx])}
                           isContinuation={isContinuation}

--- a/src/components/project/chat/MessageBubble.tsx
+++ b/src/components/project/chat/MessageBubble.tsx
@@ -1,8 +1,8 @@
 import { memo, useState } from 'react'
 import type { CSSProperties, Ref } from 'react'
 import Markdown from '../../Markdown'
-import { ChatContentBlock } from '../../../hooks/useIPC'
-import { ProcessedMessage, ToolGroup, ChatDetailsFilter, ClaudeSlashCommand, parseAskUserQuestions, parseAnswersFromResultText, describeTurn, touchedFiles, fileCategoryTint, TouchedFile, AGENT_TOOLS, PLAN_TOOLS, QUESTION_TOOL } from './utils'
+import { ChatContentBlock, Skill, Agent } from '../../../hooks/useIPC'
+import { ProcessedMessage, ToolGroup, ChatDetailsFilter, ClaudeSlashCommand, parseAskUserQuestions, parseAnswersFromResultText, describeTurn, touchedFiles, fileCategoryTint, TouchedFile, skillInitial, AGENT_TOOLS, PLAN_TOOLS, QUESTION_TOOL } from './utils'
 import { fmtModel, modelColor } from '../utils'
 import { agentTintColor } from '../shared/entityOptions'
 import { ToolGroupCard } from './ToolGroupCard'
@@ -154,6 +154,91 @@ function SlashCommandCard({ command, timestamp }: { command: ClaudeSlashCommand;
   )
 }
 
+/** Inline card for a Skill invocation — a first-class sibling of SlashCommandCard
+ *  with a first-letter orb (no icon), the skill description, and an expandable
+ *  body surfacing the skill's definition (scope / model / tools / arguments) plus
+ *  a "View skill →" deep link. The link only shows once the card is expanded. */
+function SkillCommandCard({ command, timestamp, skill, onOpenSkill }: {
+  command: ClaudeSlashCommand
+  timestamp?: string
+  skill?: Skill
+  onOpenSkill?: (skill: Skill) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const desc = skill?.description ?? (command.description !== 'Claude Code command' ? command.description : '')
+  const showArgs = command.args && command.args !== command.command
+  const metaRows: [string, string][] = []
+  if (skill?.scope) metaRows.push(['Scope', skill.scope])
+  if (skill?.model) metaRows.push(['Model', skill.model])
+  if (skill?.argumentHint) metaRows.push(['Arguments', skill.argumentHint])
+  if (skill?.allowedTools?.length) metaRows.push(['Tools', skill.allowedTools.join(', ')])
+  const canOpen = !!(skill && onOpenSkill)
+  const hasExpandable = metaRows.length > 0 || !!showArgs || !!command.output || canOpen
+  const status = hasExpandable ? (open ? '▾' : '→') : ''
+
+  return (
+    <div
+      className={`cl-command-card cl-skill-card${open ? ' is-open' : ''}`}
+      style={{ '--tint': 'var(--cl-accent)' } as CSSProperties}
+    >
+      <div className="cl-command-card-row">
+        <button
+          type="button"
+          onClick={() => hasExpandable && setOpen(o => !o)}
+          className={`cl-command-card-main${!hasExpandable ? ' is-static' : ''}`}
+          aria-expanded={hasExpandable ? open : undefined}
+        >
+          <span className="cl-command-mono" aria-hidden>{skillInitial(command.command)}</span>
+          <span className="cl-command-id">
+            <span className="cl-command-name">
+              <span className="cl-skill-tag">Skill</span>
+              /{command.command}
+            </span>
+            {desc && <span className="cl-command-preview">{desc}</span>}
+          </span>
+          <span className="cl-command-right">
+            {timestamp && <time className="cl-command-time">{timestamp}</time>}
+            {status && <span className="cl-command-status">{status}</span>}
+          </span>
+        </button>
+      </div>
+      {open && (
+        <div className="cl-command-expanded">
+          {metaRows.length > 0 && (
+            <div className="cl-command-section cl-skill-meta">
+              {metaRows.map(([label, value]) => (
+                <div key={label} className="cl-skill-meta-row">
+                  <span className="k">{label}</span>
+                  <span className="v">{value}</span>
+                </div>
+              ))}
+            </div>
+          )}
+          {showArgs && (
+            <div className="cl-command-section">
+              <div className="cl-command-section-title">Args</div>
+              <pre>{command.args}</pre>
+            </div>
+          )}
+          {command.output && (
+            <div className="cl-command-section">
+              <div className="cl-command-section-title">Output</div>
+              <pre>{command.output}</pre>
+            </div>
+          )}
+          {canOpen && (
+            <div className="cl-command-section cl-entity-link-row">
+              <button type="button" className="cl-entity-link" onClick={() => onOpenSkill!(skill!)}>
+                View skill →
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
 /** Collapsed marker for a run of consecutive tool-only turns in minimal mode.
  *  A single badge with a "× N" multiplier replaces the stack of identical
  *  "1 tool hidden" rows so a long sequence of tool calls reads as one marker. */
@@ -221,6 +306,10 @@ export const MessageBubble = memo(function MessageBubble({
   detailsFilter,
   onOpenToolDetail,
   agentColorOf,
+  skillOf,
+  onOpenSkill,
+  agentOf,
+  onOpenAgent,
   turnIndex,
   dimmed,
   isContinuation,
@@ -233,6 +322,14 @@ export const MessageBubble = memo(function MessageBubble({
   onOpenToolDetail: (group: ToolGroup) => void
   /** Resolves a dispatched sub-agent's identity color from its `subagent_type`. */
   agentColorOf?: (subagentType: string) => string | undefined
+  /** Resolves a skill definition from a slash-command name (for the skill card link). */
+  skillOf?: (name: string) => Skill | undefined
+  /** Navigates to the skill detail view (deep link from an expanded skill card). */
+  onOpenSkill?: (skill: Skill) => void
+  /** Resolves an agent definition from its `subagent_type` (for the agent card link). */
+  agentOf?: (subagentType: string) => Agent | undefined
+  /** Navigates to the agent detail view (deep link from an expanded agent card). */
+  onOpenAgent?: (agent: Agent) => void
   turnIndex?: number
   /** Faded out because it doesn't match the active type filter (kept visible for context). */
   dimmed?: boolean
@@ -291,6 +388,15 @@ export const MessageBubble = memo(function MessageBubble({
   const { variant: roleVariant, label: roleLabel, initial: roleInitial, color: roleColor } =
     describeTurn(processed, detailsFilter, t => agentTintColor(agentColorOf?.(t)))
 
+  // Deep link surfaced at the foot of an expanded agent-dispatch card — resolves
+  // the dispatched sub-agent's definition by type, mirroring the skill card link.
+  const agentLink = (group: ToolGroup): { label: string; onClick: () => void } | undefined => {
+    if (!AGENT_TOOLS.has(group.use.name) || !agentOf || !onOpenAgent) return undefined
+    const t = (group.use.input as Record<string, unknown>).subagent_type as string | undefined
+    const agent = t ? agentOf(t) : undefined
+    return agent ? { label: 'View agent', onClick: () => onOpenAgent(agent) } : undefined
+  }
+
   const timestamp = new Date(msg.timestamp).toLocaleTimeString('it-IT', {
     hour: '2-digit',
     minute: '2-digit',
@@ -300,10 +406,14 @@ export const MessageBubble = memo(function MessageBubble({
   const turnNumber = turnIndex !== undefined ? String(turnIndex).padStart(2, '0') : roleInitial
 
   // Command turn: layout snello, niente "YOU · time", solo la card del comando.
+  // Una skill (slash command con `isSkill` o che risolve a una skill nota) usa
+  // la SkillCommandCard di prima classe; un comando normale la SlashCommandCard.
   if (isCommandTurn && command) {
+    const skill = skillOf?.(command.command)
+    const isSkill = command.isSkill || !!skill
     return (
       <article
-        className={`cl-turn cl-turn--command${isContinuation ? ' cl-turn--continuation' : ''}`}
+        className={`cl-turn cl-turn--${roleVariant}${isContinuation ? ' cl-turn--continuation' : ''}`}
         style={{ '--turn-role-color': roleColor } as CSSProperties}
         ref={innerRef}
         data-n={turnIndex}
@@ -315,7 +425,11 @@ export const MessageBubble = memo(function MessageBubble({
           <span className="cl-turn-spine" aria-hidden />
         </aside>
         <section className="cl-turn-body">
-          <SlashCommandCard command={command} timestamp={timestamp} />
+          {isSkill ? (
+            <SkillCommandCard command={command} timestamp={timestamp} skill={skill} onOpenSkill={onOpenSkill} />
+          ) : (
+            <SlashCommandCard command={command} timestamp={timestamp} />
+          )}
         </section>
       </article>
     )
@@ -409,14 +523,19 @@ export const MessageBubble = memo(function MessageBubble({
 
         {showAgentStrip && (
           <div className="cl-tool-stack">
-            {agentGroups.map((group, i) => (
-              <ToolGroupCard
-                key={i}
-                group={group}
-                showDetails
-                tint={agentTintColor(agentColorOf?.((group.use.input as Record<string, unknown>).subagent_type as string))}
-              />
-            ))}
+            {agentGroups.map((group, i) => {
+              const link = agentLink(group)
+              return (
+                <ToolGroupCard
+                  key={i}
+                  group={group}
+                  showDetails
+                  tint={agentTintColor(agentColorOf?.((group.use.input as Record<string, unknown>).subagent_type as string))}
+                  detailLabel={link?.label}
+                  onViewDetail={link?.onClick}
+                />
+              )
+            })}
           </div>
         )}
 
@@ -430,16 +549,21 @@ export const MessageBubble = memo(function MessageBubble({
 
         {showTools && standardToolGroups.length > 0 && (
           <div className="cl-tool-stack">
-            {standardToolGroups.map((group, i) => (
-              <ToolGroupCard
-                key={i}
-                group={group}
-                showDetails={showToolDetails}
-                tint={AGENT_TOOLS.has(group.use.name)
-                  ? agentTintColor(agentColorOf?.((group.use.input as Record<string, unknown>).subagent_type as string))
-                  : undefined}
-              />
-            ))}
+            {standardToolGroups.map((group, i) => {
+              const link = agentLink(group)
+              return (
+                <ToolGroupCard
+                  key={i}
+                  group={group}
+                  showDetails={showToolDetails}
+                  tint={AGENT_TOOLS.has(group.use.name)
+                    ? agentTintColor(agentColorOf?.((group.use.input as Record<string, unknown>).subagent_type as string))
+                    : undefined}
+                  detailLabel={link?.label}
+                  onViewDetail={link?.onClick}
+                />
+              )
+            })}
           </div>
         )}
       </section>

--- a/src/components/project/chat/ToolGroupCard.tsx
+++ b/src/components/project/chat/ToolGroupCard.tsx
@@ -3,12 +3,16 @@ import type { CSSProperties } from 'react'
 import { ToolGroup, isMemoryFile, toolMonogram, TOOL_TINT, AGENT_TOOLS } from './utils'
 import { ToolInput, ToolOutput } from './ToolDetailPanel'
 
-export function ToolGroupCard({ group, showDetails, tint: tintOverride }: {
+export function ToolGroupCard({ group, showDetails, tint: tintOverride, detailLabel, onViewDetail }: {
   group: ToolGroup
   showDetails: boolean
   /** Explicit tint color (e.g. a dispatched agent's identity color) overriding
    *  the tool-name default. */
   tint?: string
+  /** Optional deep-link shown at the foot of the expanded card (e.g. "View
+   *  agent" on an agent dispatch). Only rendered when the card is open. */
+  detailLabel?: string
+  onViewDetail?: () => void
 }) {
   const [open, setOpen] = useState(false)
   const { use, result } = group
@@ -33,7 +37,7 @@ export function ToolGroupCard({ group, showDetails, tint: tintOverride }: {
     ''
   )
   const resultPreview = result ? result.content.split('\n')[0]?.slice(0, 120) ?? '' : null
-  const hasExpandable = showDetails || (result && result.content.length > 80)
+  const hasExpandable = showDetails || (result && result.content.length > 80) || !!onViewDetail
   // Right-edge status glyph: resolved result → ✓/✕, otherwise a hint that the
   // row expands (caret when open, arrow when collapsed).
   const status = result ? (result.isError ? '✕' : '✓') : (hasExpandable ? (open ? '▾' : '→') : '')
@@ -87,6 +91,13 @@ export function ToolGroupCard({ group, showDetails, tint: tintOverride }: {
                 {result.isError ? 'Error' : 'Result'}
               </div>
               <ToolOutput name={use.name} input={use.input as Record<string, unknown>} result={result} />
+            </div>
+          )}
+          {onViewDetail && (
+            <div className="cl-tool-card-section cl-entity-link-row">
+              <button type="button" className="cl-entity-link" onClick={onViewDetail}>
+                {detailLabel ?? 'View detail'} →
+              </button>
             </div>
           )}
         </div>

--- a/src/components/project/chat/utils.ts
+++ b/src/components/project/chat/utils.ts
@@ -1,4 +1,4 @@
-import { ChatMessage, ChatContentBlock, SubagentMeta } from '../../../hooks/useIPC'
+import { ChatMessage, ChatContentBlock, SubagentMeta, Skill } from '../../../hooks/useIPC'
 
 export type ChatDetailsFilter = 'all' | 'minimal'
 
@@ -22,6 +22,22 @@ export type ClaudeSlashCommand = {
   args: string
   description: string
   output?: string
+  /** True when this slash command is actually a Skill invocation — detected by
+   *  the skill-expansion message Claude Code injects right after ("Base directory
+   *  for this skill: …"). Skills are surfaced as first-class cards, not plain
+   *  `/commands`. */
+  isSkill?: boolean
+}
+
+// Claude Code injects this as the first line of the user message that follows a
+// skill slash command — the skill's expanded prompt. It's the most reliable
+// signal that `/foo` is a Skill (works for project, global, and plugin skills,
+// none of which we'd otherwise be able to tell apart from a built-in command).
+const SKILL_EXPANSION_RE = /^\s*Base directory for this skill:/i
+
+function firstText(m: ChatMessage): string {
+  const t = m.content.find(b => b.type === 'text') as Extract<ChatContentBlock, { type: 'text' }> | undefined
+  return t?.text ?? ''
 }
 
 export const CLAUDE_BUILTIN_SLASH_COMMANDS: Record<string, string> = {
@@ -103,9 +119,15 @@ export function buildProcessedMessages(messages: ChatMessage[]): ProcessedMessag
     // Riconosci command flow
     let command: ClaudeSlashCommand | undefined
     if (msg.role === 'user') {
-      const firstText = msg.content.find(b => b.type === 'text') as Extract<ChatContentBlock, { type: 'text' }> | undefined
-      if (firstText) {
-        command = parseClaudeSlashCommand(firstText.text) ?? undefined
+      const text = msg.content.find(b => b.type === 'text') as Extract<ChatContentBlock, { type: 'text' }> | undefined
+      if (text) {
+        command = parseClaudeSlashCommand(text.text) ?? undefined
+        // A skill invocation is a slash command immediately followed by Claude
+        // Code's skill-expansion message — peek the next raw message to tell a
+        // skill apart from a plain built-in command.
+        if (command && i + 1 < messages.length && SKILL_EXPANSION_RE.test(firstText(messages[i + 1]))) {
+          command.isSkill = true
+        }
       }
     }
 
@@ -136,8 +158,10 @@ export function stripAnsi(text: string): string {
 // Riconosce sia il flusso XML di Claude Code (<command-name>/X</command-name>...)
 // sia il formato testuale "/X args". Ritorna null se non è un command noto.
 export function parseClaudeSlashCommand(text: string): ClaudeSlashCommand | null {
-  // 1. XML flow di Claude Code
-  const cmdMatch = text.match(/<command-name>\s*\/?([a-z][a-z0-9_-]*)\s*<\/command-name>/i)
+  // 1. XML flow di Claude Code — il nome può essere namespaced (`plugin:skill`),
+  // quindi la classe include `:` (senza, le skill di plugin non venivano
+  // riconosciute e il tag XML grezzo trapelava nella chat).
+  const cmdMatch = text.match(/<command-name>\s*\/?([a-z][a-z0-9_:-]*)\s*<\/command-name>/i)
   if (cmdMatch) {
     const command = cmdMatch[1].toLowerCase()
     // Il framing XML <command-name> è inequivocabile: trattalo sempre come comando,
@@ -151,7 +175,7 @@ export function parseClaudeSlashCommand(text: string): ClaudeSlashCommand | null
 
   // 2. Formato testuale plain "/cmd args"
   const trimmed = text.trimStart()
-  const match = trimmed.match(/^\/([a-z][a-z0-9_-]*)(?:\s+([\s\S]*))?$/)
+  const match = trimmed.match(/^\/([a-z][a-z0-9_:-]*)(?:\s+([\s\S]*))?$/)
   if (!match) return null
 
   const command = match[1]
@@ -230,7 +254,14 @@ export const AGENT_TOOLS = new Set(['Agent', 'Task'])
 export const PLAN_TOOLS = new Set(['EnterPlanMode', 'ExitPlanMode'])
 export const QUESTION_TOOL = 'AskUserQuestion'
 
-export type TurnVariant = 'user' | 'claude' | 'agent' | 'command' | 'question' | 'plan'
+export type TurnVariant = 'user' | 'claude' | 'agent' | 'command' | 'skill' | 'question' | 'plan'
+
+/** First-letter monogram for a skill, mirroring the agent orb rule (no icons,
+ *  just the initial). Strips a `plugin:` namespace so `document-skills:pdf` → "P". */
+export function skillInitial(command: string): string {
+  const seg = command.includes(':') ? command.split(':').pop()! : command
+  return (seg.match(/[A-Za-z]/)?.[0] ?? 'S').toUpperCase()
+}
 
 export type TurnDescriptor = {
   variant: TurnVariant
@@ -259,6 +290,9 @@ const ROLE_META: Record<TurnVariant, { label: string; initial: string; color: st
   // own identity tint (resolved in MessageBubble); accent is the unconfigured default.
   agent:    { label: 'Agent',    initial: 'C', color: 'var(--cl-accent)' },
   command:  { label: 'Command',  initial: '/', color: 'var(--cl-accent)' },
+  // A skill turn wears the brand accent and a first-letter orb (resolved below
+  // from the skill name); the static initial here is just a fallback.
+  skill:    { label: 'Skill',    initial: 'S', color: 'var(--cl-accent)' },
   question: { label: 'Question', initial: '?', color: 'var(--cl-warn)' },
   plan:     { label: 'Plan',     initial: 'P', color: 'var(--cl-accent)' },
 }
@@ -315,9 +349,10 @@ export function describeTurn(
   const isPlanTurn =
     showPlanStrip && textBlocks.length === 0 && !showAgentStrip && !showQuestions
   const isCommandTurn = !!command
+  const isSkillTurn = !!command?.isSkill
 
   const variant: TurnVariant =
-    isCommandTurn ? 'command'
+    isCommandTurn ? (isSkillTurn ? 'skill' : 'command')
     : isQuestionTurn ? 'question'
     : isAgentTurn ? 'agent'
     : isPlanTurn ? 'plan'
@@ -331,8 +366,10 @@ export function describeTurn(
     variant === 'agent'
       ? agentColor?.((agentGroups[0]?.use.input as Record<string, unknown>)?.subagent_type as string) ?? meta.color
       : meta.color
+  // Skill turns wear a first-letter orb (same rule as agents — no icons).
+  const initial = variant === 'skill' && command ? skillInitial(command.command) : meta.initial
 
-  return { variant, label: meta.label, initial: meta.initial, color, hasText, hasThinking, hasTools, hasQuestion, hasAgent, hasPlan, visible, toolsOnly }
+  return { variant, label: meta.label, initial, color, hasText, hasThinking, hasTools, hasQuestion, hasAgent, hasPlan, visible, toolsOnly }
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -407,6 +444,49 @@ export function correlateSessionAgents(
   })
 
   return agents
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Skill correlation — collects every skill invoked in the session (slash
+// commands flagged `isSkill`) and links each to its definition from the skills
+// registry by name, so the footer dock can list them and the inline card can
+// deep-link to the skill detail. Plugin/namespaced skills won't resolve to a
+// local definition (`skill: null`) — they still appear, just without a link.
+// ──────────────────────────────────────────────────────────────────────────
+export type SessionSkill = {
+  /** Stable key (turn index). */
+  key: string
+  /** 1-based turn index of the invocation — used to jump/scroll to its card. */
+  turnN: number
+  /** Display id (the slash-command name, e.g. `build-dmg`). */
+  name: string
+  description: string
+  scope?: 'global' | 'project'
+  /** Resolved skill definition, when one matches by name; null otherwise. */
+  skill: Skill | null
+}
+
+export function correlateSessionSkills(
+  processed: ProcessedMessage[],
+  skills: Skill[],
+): SessionSkill[] {
+  const byName = new Map(skills.map(s => [s.name, s]))
+  const out: SessionSkill[] = []
+  processed.forEach((p, idx) => {
+    const c = p.command
+    if (!c) return
+    const skill = byName.get(c.command) ?? null
+    if (!c.isSkill && !skill) return
+    out.push({
+      key: `skill-${idx + 1}`,
+      turnN: idx + 1,
+      name: c.command,
+      description: skill?.description ?? (c.description !== 'Claude Code command' ? c.description : ''),
+      scope: skill?.scope,
+      skill,
+    })
+  })
+  return out
 }
 
 export const TOOL_ICON: Record<string, string> = {

--- a/src/index.css
+++ b/src/index.css
@@ -2697,6 +2697,28 @@ body {
     0 4px 10px -3px color-mix(in oklch, var(--cl-accent) 50%, transparent);
 }
 
+/* Skill turn shares the command turn's quiet body + accent orb; the orb glyph is
+ * the skill's first letter (resolved upstream), per the agent no-icon rule. */
+.cl-turn--skill .cl-turn-body {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  padding: 0;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+}
+.cl-turn--skill:hover .cl-turn-body { background: transparent; }
+.cl-turn--skill .cl-turn-orb {
+  background:
+    radial-gradient(circle at 30% 24%, oklch(1 0 0 / 0.55), transparent 55%),
+    linear-gradient(180deg,
+      color-mix(in oklch, var(--cl-accent) 90%, white),
+      var(--cl-accent));
+  box-shadow:
+    inset 0 1px 0 oklch(1 0 0 / 0.45),
+    0 4px 10px -3px color-mix(in oklch, var(--cl-accent) 50%, transparent);
+}
+
 /* Command card — editorial (prototype's cx-cmd): paper + accent spine. */
 /* Command card — same visual grammar as .cl-tool-card */
 .cl-command-card {
@@ -2811,6 +2833,64 @@ body {
   white-space: pre-wrap;
   overflow-wrap: anywhere;
 }
+
+/* Skill card — a SlashCommandCard subtype: a "Skill" tag chip before the name,
+ * a properties grid (scope/model/tools/arguments), and the shared entity link. */
+.cl-skill-tag {
+  display: inline-flex;
+  align-items: center;
+  margin-right: 7px;
+  padding: 1px 6px;
+  border-radius: 5px;
+  background: color-mix(in oklch, var(--cl-accent) 16%, transparent);
+  color: var(--cl-accent);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  vertical-align: middle;
+}
+.cl-skill-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.cl-skill-meta-row {
+  display: grid;
+  grid-template-columns: 84px minmax(0, 1fr);
+  gap: 10px;
+  align-items: baseline;
+}
+.cl-skill-meta-row .k {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--cl-ink-4);
+}
+.cl-skill-meta-row .v {
+  min-width: 0;
+  color: var(--cl-ink-2);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+
+/* Shared deep-link row at the foot of an expanded skill/agent card. */
+.cl-entity-link-row { padding-top: 9px; padding-bottom: 9px; }
+.cl-entity-link {
+  border: 0;
+  background: transparent;
+  padding: 0;
+  color: var(--cl-accent);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.cl-entity-link:hover { text-decoration: underline; }
 /* Thinking — quiet editorial disclosure (prototype's cx-think). */
 .cl-thinking {
   width: 100%;

--- a/src/index.css
+++ b/src/index.css
@@ -2577,23 +2577,23 @@ body {
 }
 /* File chips at the foot of a turn: which files the hidden tools touched. */
 .cl-turn-files {
-  display: flex; flex-wrap: wrap; align-items: center; gap: 5px;
-  margin-top: 8px;
+  display: flex; flex-wrap: wrap; align-items: center; gap: 4px;
+  margin-top: 14px;
 }
 .cl-file-chip {
   position: relative;
-  display: inline-flex; align-items: center; gap: 4px;
+  display: inline-flex; align-items: center; gap: 3px;
   flex-shrink: 0;
-  padding: 3px 7px;
-  border: 1px solid color-mix(in oklab, var(--ft, var(--cl-ink-4)) 32%, var(--cl-line));
+  padding: 2px 5px;
+  border: none;
   border-radius: 999px;
-  background: color-mix(in oklab, var(--ft, var(--cl-ink-4)) 9%, transparent);
-  color: color-mix(in oklab, var(--ft, var(--cl-ink-4)) 70%, var(--cl-ink-3));
+  background: transparent;
+  color: color-mix(in oklab, var(--ft, var(--cl-ink-4)) 65%, var(--cl-ink-3));
   line-height: 1;
   cursor: default;
 }
-.cl-file-chip svg { opacity: 0.9; }
-.cl-file-chip-logo { width: 12px; height: 12px; flex-shrink: 0; }
+.cl-file-chip svg { opacity: 0.85; }
+.cl-file-chip-logo { width: 10px; height: 10px; flex-shrink: 0; }
 /* CSS-only tooltip (native title is unreliable in Electron) — shows the file
  *  name(s) above the chip on hover/focus. */
 .cl-file-chip[data-file]:hover::after,
@@ -2629,11 +2629,12 @@ body {
   pointer-events: none;
 }
 .cl-file-chip-ext {
-  font: 600 9.5px/1 var(--font-mono);
-  text-transform: uppercase; letter-spacing: 0.06em;
+  font: 600 9px/1 var(--font-mono);
+  text-transform: uppercase; letter-spacing: 0.05em;
+  padding-top: 1px;
 }
 .cl-file-chip--more {
-  font: 600 9.5px/1 var(--font-mono);
+  font: 600 9px/1 var(--font-mono);
   letter-spacing: 0.04em;
   color: var(--cl-ink-4);
   border-color: var(--cl-line);

--- a/src/index.css
+++ b/src/index.css
@@ -2222,18 +2222,14 @@ body {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 6px;
   font-family: var(--font-mono);
-  font-size: 9px;
+  font-size: 11px;
   font-weight: 700;
-  color: var(--cl-on-accent);
-  background: radial-gradient(circle at 30% 24%, oklch(1 0 0 / 0.5), transparent 55%), var(--orb-color, var(--cl-violet));
-  box-shadow: 0 0 0 1.5px var(--cl-paper);
+  color: var(--orb-color, var(--cl-violet));
 }
-.cl-dock-orb + .cl-dock-orb { margin-left: -7px; }
+.cl-dock-orb + .cl-dock-orb { margin-left: -4px; }
 .cl-dock-orb--more {
-  color: var(--cl-violet-ink);
-  background: color-mix(in oklch, var(--cl-violet-soft) 60%, var(--cl-paper));
+  color: var(--cl-violet);
 }
 .cl-dock-count {
   font-family: var(--font-mono);
@@ -2241,6 +2237,7 @@ body {
   font-weight: 600;
   letter-spacing: 0.06em;
   white-space: nowrap;
+  line-height: 1;
 }
 .cl-dock-count span { text-transform: uppercase; color: var(--cl-ink-4); font-weight: 500; }
 .cl-dock-fail {

--- a/src/tabs/ProjectOverview.tsx
+++ b/src/tabs/ProjectOverview.tsx
@@ -324,6 +324,8 @@ export default function ProjectOverview() {
               ? setView({ type: 'agents-live', project: view.project })
               : setView({ type: 'sessions', project: view.project })
             }
+            onOpenSkill={skill => setView({ type: 'skill-detail', skill })}
+            onOpenAgent={agent => setView({ type: 'agent-detail', agent })}
           />
         )
       case 'memory-topic':

--- a/test/chat-utils.test.ts
+++ b/test/chat-utils.test.ts
@@ -1,13 +1,15 @@
 import {
   buildProcessedMessages,
   correlateSessionAgents,
+  correlateSessionSkills,
+  skillInitial,
   stripAnsi,
   parseClaudeSlashCommand,
   parseLocalCommandOutput,
   parseAskUserQuestions,
   parseAnswersFromResultText,
 } from '../src/components/project/chat/utils';
-import { ChatMessage, ChatContentBlock, SubagentMeta } from '../src/types';
+import { ChatMessage, ChatContentBlock, SubagentMeta, Skill } from '../src/types';
 
 // ---- fixture helpers ----
 
@@ -400,5 +402,103 @@ describe('correlateSessionAgents', () => {
       msg('user', [toolResult('t1', 'out')]),
     ]);
     expect(correlateSessionAgents(processed, [])).toHaveLength(0);
+  });
+});
+
+// Skill expansion message Claude Code injects right after a skill slash command.
+const skillExpansion = (name: string) =>
+  text(`Base directory for this skill: /Users/x/.claude/skills/${name}\n\nDo the thing.`);
+
+const skillDef = (name: string, extra: Partial<Skill> = {}): Skill => ({
+  name,
+  path: `/Users/x/.claude/skills/${name}/SKILL.md`,
+  scope: 'project',
+  content: '',
+  rawContent: '',
+  ...extra,
+});
+
+describe('parseClaudeSlashCommand — namespaced (plugin) skills', () => {
+  it('recognizes a namespaced skill command (colon in name)', () => {
+    const result = parseClaudeSlashCommand('<command-name>/document-skills:pdf</command-name>');
+    expect(result?.command).toBe('document-skills:pdf');
+  });
+
+  it('does not treat an unknown plain-text namespaced command as a command', () => {
+    // The plain textual branch only recognizes known built-ins (to avoid turning
+    // arbitrary "/foo" prose into a command); skills always arrive via the XML
+    // <command-name> framing, which IS recognized above.
+    expect(parseClaudeSlashCommand('/document-skills:pdf')).toBeNull();
+  });
+});
+
+describe('skill detection in buildProcessedMessages', () => {
+  it('flags a slash command followed by the skill-expansion message as a skill', () => {
+    const processed = buildProcessedMessages([
+      msg('user', [text('<command-name>/build-dmg</command-name>')]),
+      msg('user', [skillExpansion('build-dmg')]),
+    ]);
+    expect(processed[0].command?.isSkill).toBe(true);
+  });
+
+  it('does not flag a plain command not followed by a skill expansion', () => {
+    const processed = buildProcessedMessages([
+      msg('user', [text('<command-name>/clear</command-name>')]),
+      msg('user', [text('hello')]),
+    ]);
+    expect(processed[0].command?.isSkill).toBeFalsy();
+  });
+});
+
+describe('skillInitial', () => {
+  it('takes the first letter, uppercased', () => {
+    expect(skillInitial('build-dmg')).toBe('B');
+  });
+  it('strips a plugin namespace and uses the skill segment', () => {
+    expect(skillInitial('document-skills:pdf')).toBe('P');
+  });
+});
+
+describe('correlateSessionSkills', () => {
+  it('collects a flagged skill and links it to its definition by name', () => {
+    const processed = buildProcessedMessages([
+      msg('user', [text('<command-name>/build-dmg</command-name>')]),
+      msg('user', [skillExpansion('build-dmg')]),
+    ]);
+    const skills = correlateSessionSkills(processed, [skillDef('build-dmg', { description: 'Builds the DMG', scope: 'project' })]);
+    expect(skills).toHaveLength(1);
+    expect(skills[0].name).toBe('build-dmg');
+    expect(skills[0].description).toBe('Builds the DMG');
+    expect(skills[0].scope).toBe('project');
+    expect(skills[0].skill).not.toBeNull();
+    expect(skills[0].turnN).toBe(1);
+  });
+
+  it('collects a skill known by name even without the expansion message', () => {
+    const processed = buildProcessedMessages([
+      msg('user', [text('<command-name>/arch-analysis</command-name>')]),
+      msg('user', [text('regular follow-up')]),
+    ]);
+    const skills = correlateSessionSkills(processed, [skillDef('arch-analysis')]);
+    expect(skills).toHaveLength(1);
+    expect(skills[0].skill).not.toBeNull();
+  });
+
+  it('includes a flagged skill with no local definition (skill: null)', () => {
+    const processed = buildProcessedMessages([
+      msg('user', [text('<command-name>/document-skills:pdf</command-name>')]),
+      msg('user', [skillExpansion('document-skills/pdf')]),
+    ]);
+    const skills = correlateSessionSkills(processed, []);
+    expect(skills).toHaveLength(1);
+    expect(skills[0].skill).toBeNull();
+  });
+
+  it('ignores plain commands that are neither flagged nor known skills', () => {
+    const processed = buildProcessedMessages([
+      msg('user', [text('<command-name>/clear</command-name>')]),
+      msg('user', [text('hello')]),
+    ]);
+    expect(correlateSessionSkills(processed, [])).toHaveLength(0);
   });
 });

--- a/test/session-reader.test.ts
+++ b/test/session-reader.test.ts
@@ -133,6 +133,29 @@ describe('readChatSession', () => {
     ]);
   });
 
+  it('handles tool_result array content with string and null elements (no message drop)', () => {
+    // Nel formato Anthropic content può essere `["text"]` o contenere `null`:
+    // senza guardia sul tipo l'intero messaggio veniva scartato (TypeError).
+    const p = writeJsonl('s.jsonl', [
+      line({
+        type: 'user',
+        uuid: 'r1',
+        timestamp: 't',
+        message: {
+          role: 'user',
+          content: [
+            { type: 'tool_result', tool_use_id: 'tu_1', content: ['plain', null, { text: 'block' }], is_error: false },
+          ],
+        },
+      }),
+    ]);
+    const msgs = readChatSession(p);
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].content).toEqual([
+      { type: 'tool_result', toolUseId: 'tu_1', content: 'plain\n\nblock', isError: false },
+    ]);
+  });
+
   it('skips meta and sidechain lines', () => {
     const p = writeJsonl('s.jsonl', [
       line({


### PR DESCRIPTION
## Highlights

- Fixes a **High-severity** data-loss bug where a single malformed \`tool_result\` block discarded the **entire** chat message.

## Problem

In \`session-reader.ts\`, when \`tool_result.content\` is an array, the \`.map()\` accessed \`c.type\`/\`c.text\` assuming each element is an object. In the Anthropic format elements may legitimately be plain strings (\`["text"]\`) or \`null\`, which threw a \`TypeError\` caught by the per-line \`try/catch\` — discarding the whole message from the chat.

## Fix

Guard the element type before access:
- \`string\` → used as-is
- object → existing \`tool_reference\` / \`text\` logic
- anything else (incl. \`null\`) → empty string

Added a regression test covering mixed array content (\`['plain', null, { text: 'block' }]\`).

Typecheck clean, 15/15 session-reader tests green.

Fixes #89