### PR TITLE
fix(transcripts): strip only known framing tags, preserving code/generics

### DIFF
--- a/electron/modules/cost-tracker.ts
+++ b/electron/modules/cost-tracker.ts
@@ -1,6 +1,7 @@
 import { readFileSync, existsSync, statSync } from 'fs';
 import { join, basename } from 'path';
 import { glob } from 'glob';
+import { stripFramingTags } from '../utils';
 
 export interface UsageData {
   inputTokens: number;
@@ -173,8 +174,9 @@ function extractFirstUserText(json: Record<string, unknown>): string | undefined
     }
   }
 
-  // Salta messaggi tecnici (caveat, comandi, tool_result)
-  const stripped = text.replace(/<[^>]+>/g, '').trim();
+  // Salta messaggi tecnici (caveat, comandi, tool_result) rimuovendo solo i tag
+  // di framing noti, così prosa con `<`/`>` da codice resta intatta (#93).
+  const stripped = stripFramingTags(text).trim();
   if (!stripped) return undefined;
   if (stripped.startsWith('Caveat:') || stripped.startsWith('[Request interrupted')) return undefined;
   return stripped;

--- a/electron/modules/session-reader.ts
+++ b/electron/modules/session-reader.ts
@@ -1,6 +1,7 @@
 import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import { glob } from 'glob';
+import { stripFramingTags } from '../utils';
 
 export type ChatContentBlock =
   | { type: 'text'; text: string }
@@ -112,8 +113,9 @@ export function readChatSession(filePath: string, options: ReadChatOptions = {})
           if (isCommand) {
             blocks = [{ type: 'text', text: rawContent }];
           } else {
-            // Salta messaggi tecnici (caveat, ecc.)
-            const stripped = rawContent.replace(/<[^>]+>/g, '').trim();
+            // Salta messaggi tecnici (caveat, ecc.) rimuovendo solo i tag di
+            // framing noti, così prosa con `<`/`>` da codice resta intatta (#93).
+            const stripped = stripFramingTags(rawContent).trim();
             if (!stripped) continue;
             blocks = [{ type: 'text', text: stripped }];
           }

--- a/electron/utils.ts
+++ b/electron/utils.ts
@@ -121,3 +121,27 @@ function readCwdFromJsonl(filePath: string): string | null {
   }
   return null;
 }
+
+// Framing tags Claude Code wraps around technical/system content in transcripts.
+// We strip these (rather than any `<...>`) so prose containing code or generics —
+// `if (a < b && c > d)`, `List<String>` — survives intact (issue #93).
+const FRAMING_TAGS = [
+  'command-name',
+  'command-message',
+  'command-args',
+  'command-contents',
+  'local-command-stdout',
+  'local-command-stderr',
+  'local-command-caveat',
+  'system-reminder',
+].join('|');
+
+const FRAMING_TAG_RE = new RegExp(`<\\/?(?:${FRAMING_TAGS})\\b[^>]*>`, 'gi');
+
+/**
+ * Remove only the known Claude Code framing tags from a transcript string,
+ * leaving user prose (including `<`/`>` from code) untouched.
+ */
+export function stripFramingTags(text: string): string {
+  return text.replace(FRAMING_TAG_RE, '');
+}

--- a/test/cost-tracker.test.ts
+++ b/test/cost-tracker.test.ts
@@ -373,6 +373,22 @@ describe('getSessionList', () => {
     );
   });
 
+  it('firstUserMessage strips only framing tags, keeping code/generics (#93)', async () => {
+    writeSession(tmp, 'sess.jsonl', [
+      JSON.stringify({
+        type: 'user',
+        timestamp: '2026-05-01T09:00:00.000Z',
+        message: {
+          content: '<system-reminder></system-reminder>Compare List<String> to Map<K,V>',
+        },
+      }),
+      assistantLine({ model: 'claude-sonnet-4-5', input: 10, output: 10 }),
+    ]);
+
+    const [s] = await getSessionList(tmp);
+    expect(s.firstUserMessage).toBe('Compare List<String> to Map<K,V>');
+  });
+
   it('sorts sessions by date descending', async () => {
     writeSession(tmp, 'older.jsonl', [
       assistantLine({

--- a/test/session-reader.test.ts
+++ b/test/session-reader.test.ts
@@ -28,13 +28,17 @@ describe('readChatSession', () => {
     expect(readChatSession(join(dir, 'nope.jsonl'))).toEqual([]);
   });
 
-  it('parses a user message with string content (tags stripped)', () => {
+  it('strips only known framing tags, preserving code/generics (#93)', () => {
     const p = writeJsonl('s.jsonl', [
       line({
         type: 'user',
         uuid: 'u1',
         timestamp: '2026-01-01T00:00:00Z',
-        message: { role: 'user', content: 'Hello <foo>tagged</foo> world' },
+        message: {
+          role: 'user',
+          content:
+            '<system-reminder></system-reminder>if (a < b && c > d) return List<String>;',
+        },
       }),
     ]);
     const msgs = readChatSession(p);
@@ -42,7 +46,10 @@ describe('readChatSession', () => {
     expect(msgs[0].uuid).toBe('u1');
     expect(msgs[0].role).toBe('user');
     expect(msgs[0].timestamp).toBe('2026-01-01T00:00:00Z');
-    expect(msgs[0].content).toEqual([{ type: 'text', text: 'Hello tagged world' }]);
+    // Known framing tags removed; code generics like List<String> survive.
+    expect(msgs[0].content).toEqual([
+      { type: 'text', text: 'if (a < b && c > d) return List<String>;' },
+    ]);
   });
 
   it('preserves command-name string content without stripping tags', () => {
@@ -68,11 +75,11 @@ describe('readChatSession', () => {
         timestamp: 't',
         message: {
           role: 'user',
-          content: '<caveat>system reminder</caveat>'.replace('system reminder', ''),
+          content: '<system-reminder></system-reminder>',
         },
       }),
     ]);
-    // content "<caveat></caveat>" -> stripped -> "" -> skipped
+    // content "<system-reminder></system-reminder>" -> stripped -> "" -> skipped
     expect(readChatSession(p)).toEqual([]);
   });
 


### PR DESCRIPTION
## Highlights
- User prose containing code or generics is no longer mangled in the session list and chat.

## Problem
`text.replace(/<[^>]+>/g, '')` in `session-reader.ts` and `cost-tracker.ts` (`extractFirstUserText`) deleted **every** `<...>` pair, so programming prompts lost content:
- `if (a < b && c > d) return;` → `if (a  d) return;`
- `Compare List<String> to Map<K,V>` → `Compare List to Map`

## Fix
Add a shared `stripFramingTags()` helper in `electron/utils.ts` that removes only Claude Code's known framing tags (`command-name`, `system-reminder`, `local-command-*`, …), leaving user text intact. Both readers now use it. Tests updated.

Closes #93