### PR TITLE
fix(chat): do not render plain '/word ...' user messages as slash commands

### DIFF
--- a/src/components/project/chat/utils.ts
+++ b/src/components/project/chat/utils.ts
@@ -173,9 +173,12 @@ export function parseClaudeSlashCommand(text: string): ClaudeSlashCommand | null
     return { command, args, description }
   }
 
-  // 2. Formato testuale plain "/cmd args"
-  const trimmed = text.trimStart()
-  const match = trimmed.match(/^\/([a-z][a-z0-9_:-]*)(?:\s+([\s\S]*))?$/)
+  // 2. Formato testuale plain "/cmd" — senza il framing XML è ambiguo: una frase
+  // utente come "/clear the cache" o "/help me debug" inizia con uno slash ma NON
+  // è un comando. Trattalo come comando solo se è il bare "/cmd" senza testo a
+  // seguire (gli args reali arrivano sempre dal flow XML <command-args>). (#92)
+  const trimmed = text.trim()
+  const match = trimmed.match(/^\/([a-z][a-z0-9_:-]*)$/)
   if (!match) return null
 
   const command = match[1]
@@ -184,7 +187,7 @@ export function parseClaudeSlashCommand(text: string): ClaudeSlashCommand | null
 
   return {
     command,
-    args: match[2]?.trim() ?? '',
+    args: '',
     description,
   }
 }

--- a/test/chat-utils.test.ts
+++ b/test/chat-utils.test.ts
@@ -201,13 +201,12 @@ describe('parseClaudeSlashCommand', () => {
     expect(result?.description).toBe('End the current session');
   });
 
-  it('parses plain textual "/cmd args" format', () => {
-    const result = parseClaudeSlashCommand('/model opus');
-    expect(result).toEqual({
-      command: 'model',
-      args: 'opus',
-      description: 'Select or change the AI model',
-    });
+  it('does not treat plain "/cmd words..." as a command — it is user prose (#92)', () => {
+    // Without XML framing, "/clear the cache" / "/help me debug" are sentences a
+    // user typed, not slash commands. Real command args always arrive via XML.
+    expect(parseClaudeSlashCommand('/clear the cache')).toBeNull();
+    expect(parseClaudeSlashCommand('/help me debug this')).toBeNull();
+    expect(parseClaudeSlashCommand('/model opus')).toBeNull();
   });
 
   it('parses plain textual command without args', () => {


### PR DESCRIPTION
## Highlights
- User messages that merely start with a slash (`/clear the cache`, `/help me debug`) are now shown as normal text, not misrendered as command cards.

## Problem
The plain-text branch of `parseClaudeSlashCommand` matched `/^\/([a-z][a-z0-9_-]*)(?:\s+([\s\S]*))?$/`, so any sentence beginning with `/help`, `/clear`, `/config`, `/model`, `/cost`, … was parsed as that command and the original text replaced by a "Command: …" rendering.

## Fix
The XML `<command-name>`/`<command-args>` framing is the reliable signal and is unchanged. The plain-text fallback now only fires on a bare `/cmd` with **no** trailing text. Tests updated.

Closes #92