### PR TITLE
perf(readers): scan only top-level session .jsonl, not sub-agent transcripts

### DIFF
--- a/electron/modules/plans-reader.ts
+++ b/electron/modules/plans-reader.ts
@@ -124,7 +124,10 @@ function toPlan(ref: PlanRef): Plan {
 // Restituisce solo i gruppi non vuoti, sessione più recente prima.
 export async function getProjectPlans(projectPath: string): Promise<PlanGroup[]> {
   try {
-    const sessionFiles = await glob('**/*.jsonl', { cwd: projectPath, absolute: true });
+    // Non-recursive: real session files are direct children. `**/*.jsonl` would
+    // also match `{sessionId}/subagents/**/agent-*.jsonl`, roughly doubling I/O
+    // by re-reading every sub-agent transcript (#95). Aligned with findSessionFiles.
+    const sessionFiles = await glob('*.jsonl', { cwd: projectPath, absolute: true });
     const groups: { group: PlanGroup; sortKey: string }[] = [];
 
     for (const sessionFile of sessionFiles) {

--- a/electron/modules/tasks-reader.ts
+++ b/electron/modules/tasks-reader.ts
@@ -52,7 +52,10 @@ function parseTaskFile(filePath: string): Task | null {
 // con file JSON e li raggruppa. Restituisce solo i gruppi non vuoti, sessione più recente prima.
 export async function getProjectTasks(projectPath: string, tasksDir: string): Promise<TaskGroup[]> {
   try {
-    const sessionFiles = await glob('**/*.jsonl', { cwd: projectPath, absolute: false });
+    // Non-recursive: real session files are direct children. `**/*.jsonl` would
+    // also match `{sessionId}/subagents/**/agent-*.jsonl`, triggering an extra
+    // per-file glob for transcripts that never have a tasks folder (#95).
+    const sessionFiles = await glob('*.jsonl', { cwd: projectPath, absolute: false });
     const groups: { group: TaskGroup; mtime: number }[] = [];
 
     for (const sessionFile of sessionFiles) {


### PR DESCRIPTION
## Highlights
- Plans/Tasks readers no longer re-read every sub-agent transcript — roughly halves filesystem I/O on busy projects.

## Problem
`getProjectPlans` (`plans-reader.ts`) and `getProjectTasks` (`tasks-reader.ts`) globbed `**/*.jsonl`, which matches not only real session files (direct children) but also `{sessionId}/subagents/**/agent-*.jsonl`. In this repo that is **412** files vs **205** real sessions: `plans-reader` read 207 extra files in full, `tasks-reader` ran an extra `glob` per file.

## Fix
Use the non-recursive `*.jsonl` pattern (node-glob does not descend on `*`), matching `findSessionFiles` in `cost-tracker`.

Closes #95