### PR TITLE
security(ipc): confine markdownFile:write/delete to ~/.claude

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -91,6 +91,9 @@ interface SafeWritePathOptions {
   // I CLAUDE.md di progetto possono stare fuori dalla home (realPath = cwd letto dal .jsonl),
   // quindi il containment nella home si applica solo ai path sotto ~/.claude (markdownFile:*).
   requireUnderHome?: boolean;
+  // Confinamento più stretto a una directory specifica (es. CLAUDE_DIR per
+  // markdownFile:*, che scrive solo sotto ~/.claude/plans e skills). (#91)
+  requireUnder?: string;
 }
 
 // Valida un path fornito dal renderer prima di scriverci/cancellarlo (vedi #14):
@@ -104,6 +107,12 @@ function assertSafeWritePath(filePath: string, opts: SafeWritePathOptions = {}):
     const home = os.homedir();
     if (resolved !== home && !resolved.startsWith(home + sep)) {
       throw new Error('Path must be under home directory');
+    }
+  }
+  if (opts.requireUnder) {
+    const baseDir = resolve(opts.requireUnder);
+    if (resolved !== baseDir && !resolved.startsWith(baseDir + sep)) {
+      throw new Error(`Path must be under ${baseDir}`);
     }
   }
   const base = basename(resolved);
@@ -365,7 +374,7 @@ ipcMain.handle('claudeMd:writeFile', async (_event, filePath: string, content: s
 ipcMain.handle('markdownFile:write', async (_event, filePath: string, content: string) => {
   try {
     const fs = require('fs') as typeof import('fs');
-    const safePath = assertSafeWritePath(filePath, { requireUnderHome: true });
+    const safePath = assertSafeWritePath(filePath, { requireUnder: CLAUDE_DIR });
     const dir = require('path').dirname(safePath) as string;
     if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
     fs.writeFileSync(safePath, content, 'utf-8');
@@ -381,7 +390,7 @@ ipcMain.handle(
     try {
       const fs = require('fs') as typeof import('fs');
       const path = require('path') as typeof import('path');
-      const safePath = assertSafeWritePath(filePath, { requireUnderHome: true });
+      const safePath = assertSafeWritePath(filePath, { requireUnder: CLAUDE_DIR });
       if (fs.existsSync(safePath)) fs.rmSync(safePath);
       // Per le skill (skills/<name>/SKILL.md) rimuovi la cartella contenitore se resta vuota.
       if (opts?.pruneEmptyDir) {


### PR DESCRIPTION
## Highlights
- The generic markdown write/delete IPC surface is now confined to `~/.claude`, matching what it actually targets (plans + skills).

## Problem
`markdownFile:write` and `markdownFile:delete` validated `requireUnderHome: true` + a `.md` extension, but not confinement to `~/.claude`. They only ever target `~/.claude/plans` and skills, yet could create/overwrite any `*.md` anywhere under `$HOME` (with recursive `mkdirSync`) and, via `pruneEmptyDir`, remove the containing directory.

## Fix
Add a `requireUnder` option to `assertSafeWritePath` and pass `CLAUDE_DIR` for both `markdownFile:*` handlers. The existing `home + sep` containment style (correct against the `~/.claude-evil` prefix bypass) is reused for the tighter base dir.

Closes #91