### PR TITLE
fix(writers): YAML-escape frontmatter scalars so values with colons survive a read

### DIFF
--- a/electron/modules/agents-writer.ts
+++ b/electron/modules/agents-writer.ts
@@ -2,6 +2,7 @@ import { writeFileSync, mkdirSync, existsSync } from 'fs';
 import { join } from 'path';
 import os from 'os';
 import { CLAUDE_DIR, validateEntityName, assertWithin } from '../utils';
+import { yamlScalar } from './frontmatter';
 
 export interface AgentInput {
   name: string;
@@ -24,21 +25,24 @@ export interface AgentInput {
 
 function buildAgentMarkdown(input: AgentInput): string {
   const lines: string[] = ['---'];
+  // Quote each scalar/list entry so a value with a colon, '#', etc. can't break
+  // the YAML block (which would make the reader drop ALL frontmatter on load).
+  const list = (arr: string[]) => `[${arr.map(yamlScalar).join(', ')}]`;
 
-  lines.push(`name: ${input.name}`);
-  if (input.description) lines.push(`description: ${input.description}`);
-  if (input.model) lines.push(`model: ${input.model}`);
-  if (input.allowedTools && input.allowedTools.length > 0) lines.push(`tools: [${input.allowedTools.join(', ')}]`);
-  if (input.disallowedTools && input.disallowedTools.length > 0) lines.push(`disallowedTools: [${input.disallowedTools.join(', ')}]`);
-  if (input.permissionMode) lines.push(`permissionMode: ${input.permissionMode}`);
+  lines.push(`name: ${yamlScalar(input.name)}`);
+  if (input.description) lines.push(`description: ${yamlScalar(input.description)}`);
+  if (input.model) lines.push(`model: ${yamlScalar(input.model)}`);
+  if (input.allowedTools && input.allowedTools.length > 0) lines.push(`tools: ${list(input.allowedTools)}`);
+  if (input.disallowedTools && input.disallowedTools.length > 0) lines.push(`disallowedTools: ${list(input.disallowedTools)}`);
+  if (input.permissionMode) lines.push(`permissionMode: ${yamlScalar(input.permissionMode)}`);
   if (input.maxTurns !== undefined) lines.push(`maxTurns: ${input.maxTurns}`);
   if (input.background !== undefined) lines.push(`background: ${input.background}`);
-  if (input.isolation) lines.push(`isolation: ${input.isolation}`);
-  if (input.memory) lines.push(`memory: ${input.memory}`);
-  if (input.effort) lines.push(`effort: ${input.effort}`);
-  if (input.color) lines.push(`color: ${input.color}`);
-  if (input.skills && input.skills.length > 0) lines.push(`skills: [${input.skills.join(', ')}]`);
-  if (input.mcpServers && input.mcpServers.length > 0) lines.push(`mcpServers: [${input.mcpServers.join(', ')}]`);
+  if (input.isolation) lines.push(`isolation: ${yamlScalar(input.isolation)}`);
+  if (input.memory) lines.push(`memory: ${yamlScalar(input.memory)}`);
+  if (input.effort) lines.push(`effort: ${yamlScalar(input.effort)}`);
+  if (input.color) lines.push(`color: ${yamlScalar(input.color)}`);
+  if (input.skills && input.skills.length > 0) lines.push(`skills: ${list(input.skills)}`);
+  if (input.mcpServers && input.mcpServers.length > 0) lines.push(`mcpServers: ${list(input.mcpServers)}`);
   if (input.disableModelInvocation !== undefined) lines.push(`disable_model_invocation: ${input.disableModelInvocation}`);
 
   lines.push('---');

--- a/electron/modules/frontmatter.ts
+++ b/electron/modules/frontmatter.ts
@@ -37,6 +37,22 @@ export function parseFrontmatter(content: string): {
   return { frontmatter: {}, body };
 }
 
+/**
+ * Serialize a scalar value to a YAML-safe inline representation for *writing* a
+ * frontmatter block. A value containing `: ` (a colon-space), a leading `#`, or
+ * one that looks like a number/bool is quoted so it round-trips back through
+ * `parseFrontmatter`. Without this, an unquoted `: ` makes js-yaml throw on
+ * load, which drops the ENTIRE frontmatter block (name, description, model, …) —
+ * the agent/skill/topic then reads back with all metadata lost. The quoting
+ * rules are delegated to js-yaml's own dumper so they stay correct and complete.
+ */
+export function yamlScalar(value: string | number | boolean): string {
+  // `dump` appends a trailing newline; a scalar always fits on one line, so we
+  // strip it. `lineWidth: -1` disables line folding, keeping a long description
+  // on a single line instead of wrapping it into a block scalar.
+  return yaml.dump(value, { lineWidth: -1 }).replace(/\n$/, '');
+}
+
 /** Read a scalar string value. Numbers/booleans are coerced to their string form. */
 export function getString(rec: Record<string, unknown>, key: string): string | undefined {
   const v = rec[key];

--- a/electron/modules/memory-writer.ts
+++ b/electron/modules/memory-writer.ts
@@ -1,6 +1,7 @@
 import { writeFileSync, existsSync, unlinkSync, readFileSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { assertWithin } from '../utils';
+import { yamlScalar } from './frontmatter';
 
 const VALID_TOPIC_TYPES = ['user', 'feedback', 'project', 'reference'] as const;
 
@@ -40,10 +41,14 @@ function buildTopicFileContent(input: TopicInput): string {
   // un re-save dalla UI: senza questa riga l'edit di un topic ne perderebbe
   // l'originSessionId. Annidato sotto `metadata:` per restare compatibile col
   // formato dell'auto-memory dell'harness.
+  // Quote every scalar (yamlScalar) so a value with a colon — extremely common
+  // in a description — doesn't break the YAML block. memory-reader parses this
+  // with js-yaml, which throws on an unquoted `: ` and drops the whole block,
+  // losing the topic's type and originSessionId on read.
   const origin = input.originSessionId
-    ? `metadata:\n  originSessionId: ${sanitizeInline(input.originSessionId)}\n`
+    ? `metadata:\n  originSessionId: ${yamlScalar(sanitizeInline(input.originSessionId))}\n`
     : '';
-  return `---\nname: ${name}\ndescription: ${description}\ntype: ${input.type}\n${origin}---\n\n${input.content.trimEnd()}\n`;
+  return `---\nname: ${yamlScalar(name)}\ndescription: ${yamlScalar(description)}\ntype: ${input.type}\n${origin}---\n\n${input.content.trimEnd()}\n`;
 }
 
 function addLineToMemoryMd(memoryPath: string, filename: string, description: string): void {

--- a/electron/modules/skills-writer.ts
+++ b/electron/modules/skills-writer.ts
@@ -2,6 +2,7 @@ import { writeFileSync, mkdirSync, existsSync } from 'fs';
 import { join } from 'path';
 import os from 'os';
 import { CLAUDE_DIR, validateEntityName, assertWithin } from '../utils';
+import { yamlScalar } from './frontmatter';
 
 export interface SkillInput {
   name: string;
@@ -18,15 +19,18 @@ export interface SkillInput {
 
 function buildSkillMarkdown(input: SkillInput): string {
   const lines: string[] = ['---'];
+  // Quote each scalar/list entry so a value with a colon, '#', etc. can't break
+  // the YAML block (which would make the reader drop ALL frontmatter on load).
+  const list = (arr: string[]) => `[${arr.map(yamlScalar).join(', ')}]`;
 
-  if (input.description) lines.push(`description: ${input.description}`);
-  if (input.argumentHint) lines.push(`argument-hint: ${input.argumentHint}`);
+  if (input.description) lines.push(`description: ${yamlScalar(input.description)}`);
+  if (input.argumentHint) lines.push(`argument-hint: ${yamlScalar(input.argumentHint)}`);
   if (input.disableModelInvocation !== undefined) lines.push(`disable-model-invocation: ${input.disableModelInvocation}`);
   if (input.userInvocable !== undefined) lines.push(`user-invocable: ${input.userInvocable}`);
-  if (input.allowedTools && input.allowedTools.length > 0) lines.push(`allowed-tools: [${input.allowedTools.join(', ')}]`);
-  if (input.model) lines.push(`model: ${input.model}`);
-  if (input.context) lines.push(`context: ${input.context}`);
-  if (input.agent) lines.push(`agent: ${input.agent}`);
+  if (input.allowedTools && input.allowedTools.length > 0) lines.push(`allowed-tools: ${list(input.allowedTools)}`);
+  if (input.model) lines.push(`model: ${yamlScalar(input.model)}`);
+  if (input.context) lines.push(`context: ${yamlScalar(input.context)}`);
+  if (input.agent) lines.push(`agent: ${yamlScalar(input.agent)}`);
 
   lines.push('---');
   lines.push('');

--- a/test/entity-writers.test.ts
+++ b/test/entity-writers.test.ts
@@ -4,6 +4,8 @@ import { tmpdir, homedir } from 'os';
 import { join } from 'path';
 import { createSkill } from '../electron/modules/skills-writer';
 import { createAgent } from '../electron/modules/agents-writer';
+import { readAgentFile } from '../electron/modules/agents-reader';
+import { readSkillDir } from '../electron/modules/skills-reader';
 
 // createSkill/createAgent honor a projectPath by writing under
 // {projectPath}/.claude/(skills|agents). The writers anchor containment on the
@@ -40,6 +42,22 @@ describe('createSkill (issue #58)', () => {
       'first'
     );
   });
+
+  // Regression: a description with a colon (or '#') used to be written into the
+  // YAML frontmatter unquoted, making js-yaml throw on read and silently drop
+  // the WHOLE block — the skill came back with no description/tools/model.
+  it('round-trips a description containing YAML metacharacters', () => {
+    const description = 'Use this skill when: editing, fixing, or building # the deck';
+    createSkill(
+      { name: 'tricky', content: 'Body', description, model: 'sonnet', allowedTools: ['Read', 'Bash'] },
+      proj
+    );
+    const skill = readSkillDir(join(proj, '.claude', 'skills', 'tricky'), 'project');
+    expect(skill).not.toBeNull();
+    expect(skill!.description).toBe(description);
+    expect(skill!.model).toBe('sonnet');
+    expect(skill!.allowedTools).toEqual(['Read', 'Bash']);
+  });
 });
 
 describe('createAgent (issue #58)', () => {
@@ -68,5 +86,31 @@ describe('createAgent (issue #58)', () => {
     } finally {
       rmSync(outside, { recursive: true, force: true });
     }
+  });
+
+  // Regression: agent descriptions almost always contain a colon ("Use this
+  // agent when X: ..."). Written unquoted, the frontmatter failed to parse and
+  // the agent read back with every field missing (flagged invalid in the UI).
+  it('round-trips a description containing YAML metacharacters', () => {
+    const description = 'Use this agent when the user asks: features, hooks # and more';
+    const filePath = createAgent(
+      { name: 'guide', content: 'Body', description, model: 'opus', color: 'blue', allowedTools: ['Read', 'Grep'] },
+      proj
+    );
+    const agent = readAgentFile(filePath, 'project');
+    expect(agent).not.toBeNull();
+    expect(agent!.missingRequired).toEqual([]);
+    expect(agent!.description).toBe(description);
+    expect(agent!.model).toBe('opus');
+    expect(agent!.color).toBe('blue');
+    expect(agent!.allowedTools).toEqual(['Read', 'Grep']);
+  });
+
+  // A model/version-like string must stay a string, not be coerced to a number
+  // on read (js-yaml would parse a bare 4.8 as a float).
+  it('keeps a numeric-looking scalar a string after round-trip', () => {
+    const filePath = createAgent({ name: 'numish', content: 'b', description: 'x', model: '4.8' }, proj);
+    const agent = readAgentFile(filePath, 'project');
+    expect(agent!.model).toBe('4.8');
   });
 });

--- a/test/memory.test.ts
+++ b/test/memory.test.ts
@@ -447,4 +447,27 @@ describe('round-trip', () => {
       '040655d3-6b0c-4c51-8a5a-29d6fa0d8614'
     );
   });
+
+  // Regression: a description with a colon used to break the YAML frontmatter,
+  // and since memory-reader parses it with js-yaml, the load threw and dropped
+  // the whole block — type fell back to the filename guess and originSessionId
+  // was lost. Quoting the scalars keeps the topic intact.
+  it('round-trips a description with a colon without losing type/origin', async () => {
+    const description = 'UI rule: all copy must be in English, not Italian';
+    const filename = createTopic(memoryDir, {
+      name: 'Colon Desc',
+      description,
+      type: 'feedback',
+      content: 'body',
+      originSessionId: '040655d3-6b0c-4c51-8a5a-29d6fa0d8614',
+    });
+
+    const data = await readMemory(tmp);
+    const topic = data.index.find(t => t.filename === filename)!;
+    expect(topic).toBeDefined();
+    expect(topic.description).toBe(description);
+    // type must come from the (intact) frontmatter, not the filename fallback.
+    expect(topic.type).toBe('feedback');
+    expect(topic.originSessionId).toBe('040655d3-6b0c-4c51-8a5a-29d6fa0d8614');
+  });
 });


### PR DESCRIPTION
## What

The entity writers (`agents-writer`, `skills-writer`, `memory-writer`) built their YAML frontmatter by raw string interpolation of values. This PR routes every interpolated scalar and list entry through a new `yamlScalar()` helper in `frontmatter.ts` that delegates quoting to js-yaml's own dumper.

## Why

A value containing `: ` (a colon followed by a space) — extremely common in agent/skill descriptions ("Use this agent when X: …") — produced invalid YAML. The readers parse frontmatter with js-yaml (via the shared `parseFrontmatter`), so the load threw and the **entire** frontmatter block was dropped on read:

- agents/skills came back with no `name`/`description`/`model`/`tools` and were flagged invalid in the UI;
- memory topics lost their `type` and `originSessionId`.

A `#` in a value silently truncated it (parsed as a YAML comment).

`yamlScalar()` quotes only when needed and keeps numeric-looking strings as strings, so a model id like `4.8` no longer round-trips into a float.

## Tests

Added create→read round-trip regression tests with `:` / `#` in descriptions for agents, skills and memory topics. `npm run typecheck`, `npm run lint` (0 errors) and `npm test` (159 passing) are all green.
