### PR TITLE
perf(markdown): memoize Markdown to skip re-highlighting on unrelated re-renders

### DIFF
--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -1,4 +1,4 @@
-import { isValidElement, useRef, useState } from 'react'
+import { isValidElement, memo, useRef, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import remarkFrontmatter from 'remark-frontmatter'
@@ -102,7 +102,14 @@ interface Props {
   className?: string
 }
 
-export default function Markdown({ children, className = '' }: Props) {
+// Memoized: parsing markdown and re-highlighting every fenced block (via
+// rehype-highlight / highlight.js) is one of the costliest things the renderer
+// does per paint, and <Markdown> is mounted in many parents that re-render for
+// unrelated reasons (editing a sibling field, hover, density toggles, live
+// streams). With string-only props and module-level plugins/components, a
+// shallow prop compare lets it skip the whole pipeline whenever `children` is
+// unchanged — keeping those re-renders cheap.
+function Markdown({ children, className = '' }: Props) {
   return (
     <div className={`prose prose-sm prose-lens max-w-none ${className}`}>
       <ReactMarkdown
@@ -115,3 +122,5 @@ export default function Markdown({ children, className = '' }: Props) {
     </div>
   )
 }
+
+export default memo(Markdown)


### PR DESCRIPTION
## What

Wrap the shared `Markdown` component in `React.memo`.

## Why

Rendering markdown runs react-markdown + rehype-highlight (highlight.js), which re-parses and re-highlights every fenced code block on each render — one of the costliest things the renderer does per paint. `<Markdown>` is mounted in ~9 views (entity detail/edit, tool detail panel, memory topic, AI assistant stream, chat) that re-render for reasons unrelated to their markdown (typing in a sibling field, hover, density toggles, live streams). Its props are two strings (`children`, `className`) and the remark/rehype plugins + components map are module-level constants, so a shallow prop comparison lets it skip the whole markdown pipeline whenever the content is unchanged.

## Notes

Part of a UI-fluidity pass. Confirmed already-good baselines: `data:changed` invalidation is targeted + debounced, and `ChatView` already memoizes its heavy derivations with `MessageBubble` under `memo`. The bigger remaining win — virtualizing long transcripts/lists — is intentionally left as a dedicated follow-up, since it touches the auto-scroll bottom-pinning, the minimap scroll-spy and scroll-to-turn and needs manual validation.

## Tests

`npm run typecheck`, `npm run lint` (0 new warnings) and `npm test` all green.
