### PR TITLE
perf(cost-tracker): cache + incremental parse of session transcripts

### DIFF
--- a/electron/modules/cost-tracker.ts
+++ b/electron/modules/cost-tracker.ts
@@ -1,4 +1,5 @@
-import { readFileSync, existsSync, statSync } from 'fs';
+import { existsSync } from 'fs';
+import { stat, open } from 'fs/promises';
 import { join, basename } from 'path';
 import { glob } from 'glob';
 import { stripFramingTags } from '../utils';
@@ -245,68 +246,214 @@ function extractLineData(json: any): LineData | null {
   };
 }
 
-function parseJsonlSession(filePath: string): ParsedSession {
-  const result: ParsedSession = {
+// Running accumulator for one session: the parsed totals plus the bookkeeping
+// (`seenUsage`, `modelCounts`, the trailing incomplete line) needed to keep
+// parsing *incrementally* as the transcript grows, without re-reading from byte 0.
+interface SessionAccumulator {
+  inputTokens: number;
+  outputTokens: number;
+  cacheWriteTokens: number;
+  cacheReadTokens: number;
+  messageCount: number;
+  date: string;
+  modelCounts: Record<string, number>;
+  customTitle?: string;
+  aiTitle?: string;
+  firstUserMessage?: string;
+  dropped: number;
+  // Usage identities already counted, so a repeated content-block line for the
+  // same turn isn't double-counted (issue #56) — carried across increments.
+  seenUsage: Set<string>;
+}
+
+// Cached parse state per transcript file. JSONL transcripts are append-only, so
+// an unchanged file (same mtime+size) is served from `acc` with no I/O, and a
+// grown file is read only from `consumed` onward — the dominant win when the
+// watcher invalidates the session list on every append of the *active* session.
+interface ParseCacheEntry {
+  consumed: number;   // bytes already folded into `acc`
+  mtimeMs: number;
+  // Bytes after the last newline not yet terminated (a half-written final line);
+  // a Buffer, not a string, so a multi-byte UTF-8 char split across a read
+  // boundary is never decoded mid-sequence (newline 0x0A can't occur inside one).
+  partial: Buffer;
+  acc: SessionAccumulator;
+}
+
+const parseCache = new Map<string, ParseCacheEntry>();
+
+// Observability for tests/diagnostics: lets a test prove an unchanged file is a
+// cache hit (no read) and a grown file is read incrementally (not from scratch).
+const parseStats = { cacheHits: 0, fullParses: 0, incrementalParses: 0, fileReads: 0 };
+export function getParseStats() {
+  return { ...parseStats };
+}
+export function resetParseCache() {
+  parseCache.clear();
+  parseStats.cacheHits = 0;
+  parseStats.fullParses = 0;
+  parseStats.incrementalParses = 0;
+  parseStats.fileReads = 0;
+}
+
+function newAccumulator(): SessionAccumulator {
+  return {
     inputTokens: 0, outputTokens: 0, cacheWriteTokens: 0, cacheReadTokens: 0,
-    messageCount: 0, date: '', model: undefined, models: {}, customTitle: undefined,
-    aiTitle: undefined, firstUserMessage: undefined,
+    messageCount: 0, date: '', modelCounts: {}, dropped: 0, seenUsage: new Set(),
   };
+}
 
-  if (!existsSync(filePath)) return result;
-
+// Fold a single complete JSONL line into the accumulator (mutates `acc`). Mirrors
+// the per-line logic of the old synchronous parser, line-for-line.
+function foldLine(line: string, acc: SessionAccumulator): void {
+  const trimmed = line.trim();
+  if (!trimmed) return;
+  let json: any;
   try {
-    const lines = readFileSync(filePath, 'utf-8').split('\n').filter(l => l.trim());
-    const modelCounts: Record<string, number> = {};
-    const seenUsage = new Set<string>();
-    let dropped = 0;
+    json = JSON.parse(trimmed);
+  } catch {
+    acc.dropped++;
+    return;
+  }
+  const parsed = extractLineData(json);
+  if (!parsed) return;
 
-    for (const line of lines) {
-      let json: any;
-      try {
-        json = JSON.parse(line);
-      } catch {
-        dropped++;
-        continue;
-      }
-      const parsed = extractLineData(json);
-      if (!parsed) continue;
+  if (parsed.customTitle) acc.customTitle = parsed.customTitle;
+  if (parsed.aiTitle) acc.aiTitle = parsed.aiTitle;
+  if (!acc.firstUserMessage && parsed.firstUserMessage) acc.firstUserMessage = parsed.firstUserMessage;
+  if (parsed.date) acc.date = parsed.date;
 
-      if (parsed.customTitle) result.customTitle = parsed.customTitle;
-      if (parsed.aiTitle) result.aiTitle = parsed.aiTitle;
-      if (!result.firstUserMessage && parsed.firstUserMessage) result.firstUserMessage = parsed.firstUserMessage;
-      if (parsed.date) result.date = parsed.date;
-
-      if (parsed.inputTokens || parsed.outputTokens || parsed.cacheWriteTokens || parsed.cacheReadTokens) {
-        // Skip lines that repeat a usage we've already counted for this turn.
-        if (parsed.usageKey) {
-          if (seenUsage.has(parsed.usageKey)) continue;
-          seenUsage.add(parsed.usageKey);
-        }
-        result.messageCount++;
-        if (parsed.model) modelCounts[parsed.model] = (modelCounts[parsed.model] ?? 0) + 1;
-        result.inputTokens      += parsed.inputTokens;
-        result.outputTokens     += parsed.outputTokens;
-        result.cacheWriteTokens += parsed.cacheWriteTokens;
-        result.cacheReadTokens  += parsed.cacheReadTokens;
-      }
+  if (parsed.inputTokens || parsed.outputTokens || parsed.cacheWriteTokens || parsed.cacheReadTokens) {
+    if (parsed.usageKey) {
+      if (acc.seenUsage.has(parsed.usageKey)) return;
+      acc.seenUsage.add(parsed.usageKey);
     }
+    acc.messageCount++;
+    if (parsed.model) acc.modelCounts[parsed.model] = (acc.modelCounts[parsed.model] ?? 0) + 1;
+    acc.inputTokens      += parsed.inputTokens;
+    acc.outputTokens     += parsed.outputTokens;
+    acc.cacheWriteTokens += parsed.cacheWriteTokens;
+    acc.cacheReadTokens  += parsed.cacheReadTokens;
+  }
+}
 
-    result.models = modelCounts;
-    const entries = Object.entries(modelCounts);
-    if (entries.length > 0) result.model = entries.sort((a, b) => b[1] - a[1])[0][0];
-    if (!result.date) result.date = statSync(filePath).mtime.toISOString();
+// Project the running accumulator into the immutable ParsedSession the callers
+// consume. `models` is copied so a later incremental fold can't mutate a result
+// already handed out.
+function finalize(acc: SessionAccumulator, mtimeMs: number): ParsedSession {
+  const entries = Object.entries(acc.modelCounts);
+  return {
+    inputTokens: acc.inputTokens,
+    outputTokens: acc.outputTokens,
+    cacheWriteTokens: acc.cacheWriteTokens,
+    cacheReadTokens: acc.cacheReadTokens,
+    messageCount: acc.messageCount,
+    date: acc.date || new Date(mtimeMs).toISOString(),
+    model: entries.length > 0 ? entries.sort((a, b) => b[1] - a[1])[0][0] : undefined,
+    models: { ...acc.modelCounts },
+    customTitle: acc.customTitle,
+    aiTitle: acc.aiTitle,
+    firstUserMessage: acc.firstUserMessage,
+  };
+}
 
-    if (dropped > 0) {
-      console.warn(`[cost-tracker] skipped ${dropped} malformed JSONL line(s) in ${filePath}`);
-    }
-  } catch (error) {
-    console.error(`Errore leggendo JSONL da ${filePath}: ${error}`);
+// Parse a session transcript, reusing cached work. Three paths:
+//   • unchanged (mtime+size match)  → serve `acc`, zero I/O      (cacheHits)
+//   • grown (append-only)           → read & fold only the tail  (incrementalParses)
+//   • new / truncated / replaced    → read & fold from byte 0     (fullParses)
+// Assumes append-only writes (Claude Code never rewrites a transcript's prefix);
+// any size shrink or same-size-different-mtime falls back to a full re-parse.
+async function parseSession(filePath: string): Promise<ParsedSession> {
+  let st: Awaited<ReturnType<typeof stat>>;
+  try {
+    st = await stat(filePath);
+  } catch {
+    parseCache.delete(filePath);
+    return finalize(newAccumulator(), Date.now());
+  }
+  if (!st.isFile()) {
+    parseCache.delete(filePath);
+    return finalize(newAccumulator(), st.mtimeMs);
   }
 
-  return result;
+  const cached = parseCache.get(filePath);
+  if (cached && cached.mtimeMs === st.mtimeMs && cached.consumed === st.size) {
+    parseStats.cacheHits++;
+    return finalize(cached.acc, st.mtimeMs);
+  }
+
+  const incremental = !!cached && st.size > cached.consumed;
+  const entry: ParseCacheEntry = incremental
+    ? cached!
+    : { consumed: 0, mtimeMs: st.mtimeMs, partial: Buffer.alloc(0), acc: newAccumulator() };
+  if (incremental) parseStats.incrementalParses++;
+  else parseStats.fullParses++;
+
+  const droppedBefore = entry.acc.dropped;
+  const len = st.size - entry.consumed;
+  let chunk = Buffer.alloc(0);
+  if (len > 0) {
+    try {
+      const fh = await open(filePath, 'r');
+      try {
+        const buf = Buffer.allocUnsafe(len);
+        const { bytesRead } = await fh.read(buf, 0, len, entry.consumed);
+        chunk = buf.subarray(0, bytesRead);
+        parseStats.fileReads++;
+      } finally {
+        await fh.close();
+      }
+    } catch (error) {
+      console.error(`Errore leggendo JSONL da ${filePath}: ${error}`);
+      return finalize(entry.acc, st.mtimeMs);
+    }
+  }
+
+  // Fold every newline-terminated line; keep the trailing remainder (a partial
+  // final line) buffered for the next increment. Splitting on the newline *byte*
+  // is UTF-8-safe (0x0A never appears inside a multi-byte sequence).
+  const combined = Buffer.concat([entry.partial, chunk]);
+  let start = 0;
+  for (let i = 0; i < combined.length; i++) {
+    if (combined[i] === 0x0a) {
+      foldLine(combined.toString('utf-8', start, i), entry.acc);
+      start = i + 1;
+    }
+  }
+
+  entry.partial = combined.subarray(start);
+  entry.consumed += chunk.length;
+  entry.mtimeMs = st.mtimeMs;
+  parseCache.set(filePath, entry);
+
+  const newlyDropped = entry.acc.dropped - droppedBefore;
+  if (newlyDropped > 0) {
+    console.warn(`[cost-tracker] skipped ${newlyDropped} malformed JSONL line(s) in ${filePath}`);
+  }
+
+  return finalize(entry.acc, st.mtimeMs);
 }
 
 // ─── Public API ───────────────────────────────────────────────────────────────
+
+// Map with bounded concurrency: parses sessions in parallel (the I/O win) while
+// capping open file descriptors, so a project with hundreds of transcripts can't
+// hit EMFILE on the cold pass. Order is preserved.
+async function mapLimit<T, R>(items: T[], limit: number, fn: (item: T) => Promise<R>): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  async function worker(): Promise<void> {
+    while (next < items.length) {
+      const idx = next++;
+      results[idx] = await fn(items[idx]);
+    }
+  }
+  const workers = Array.from({ length: Math.min(limit, items.length) }, () => worker());
+  await Promise.all(workers);
+  return results;
+}
+
+const PARSE_CONCURRENCY = 8;
 
 async function findSessionFiles(projectPath: string): Promise<string[]> {
   const sessionsDir = join(projectPath, 'sessions');
@@ -334,8 +481,8 @@ async function aggregateProject(projectPath: string): Promise<ProjectAggregate> 
   let inputTokens = 0, outputTokens = 0, cacheWriteTokens = 0, cacheReadTokens = 0;
   let cost = 0;
 
-  for (const f of files) {
-    const s = parseJsonlSession(f);
+  const parsed = await mapLimit(files, PARSE_CONCURRENCY, f => parseSession(f));
+  for (const s of parsed) {
     inputTokens      += s.inputTokens;
     outputTokens     += s.outputTokens;
     cacheWriteTokens += s.cacheWriteTokens;
@@ -398,17 +545,16 @@ export async function calculateCostSummary(claudeDir: string): Promise<ProjectCo
 
 export async function getSessionList(projectPath: string): Promise<SessionSummary[]> {
   const files = await findSessionFiles(projectPath);
-  const sessions: SessionSummary[] = [];
 
-  for (const filePath of files) {
+  const parsed = await mapLimit(files, PARSE_CONCURRENCY, async (filePath): Promise<SessionSummary | null> => {
     try {
-      const s = parseJsonlSession(filePath);
+      const s = await parseSession(filePath);
       const totalTokens = s.inputTokens + s.outputTokens;
       const estimatedCost = calculateCost(
         s.inputTokens, s.outputTokens, s.cacheWriteTokens, s.cacheReadTokens, s.model
       );
 
-      sessions.push({
+      return {
         filename: basename(filePath),
         date: s.date,
         inputTokens: s.inputTokens,
@@ -425,11 +571,14 @@ export async function getSessionList(projectPath: string): Promise<SessionSummar
         aiTitle: s.aiTitle,
         firstUserMessage: s.firstUserMessage,
         template: s.template,
-      });
+      };
     } catch {
       // sessione non leggibile
+      return null;
     }
-  }
+  });
 
-  return sessions.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+  return parsed
+    .filter((s): s is SessionSummary => s !== null)
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claudelens-app",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claudelens-app",
-      "version": "2.0.5",
+      "version": "2.0.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claudelens-app",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "ClaudeLens — GUI for Claude Code data",
   "author": "Giulio Di Giamberardino",
   "license": "MIT",

--- a/src/components/project/terminal/SessionOutline.tsx
+++ b/src/components/project/terminal/SessionOutline.tsx
@@ -311,7 +311,7 @@ export function SessionOutline({
             );
           }
           if (r.kind === 'skill') {
-            const route = skillHasViewableOutput(r.skill.group) ? 'output reale' : r.skill.skill ? 'def' : 'launch';
+            const route = skillHasViewableOutput(r.skill.group) ? 'output' : r.skill.skill ? 'def' : 'launch';
             return (
               <button key={`s${i}`} type="button" className="cl-otrow" style={rowBase} onClick={() => onSkillClick(r.skill)}>
                 <SquareGlyph bg="var(--cl-accent)">✦</SquareGlyph>

--- a/test/cost-tracker.test.ts
+++ b/test/cost-tracker.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'fs';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, appendFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import {
@@ -8,6 +8,8 @@ import {
   getPricingMeta,
   isModelPriced,
   calculateCacheSavings,
+  getParseStats,
+  resetParseCache,
   PRICING_LAST_UPDATED,
 } from '../electron/modules/cost-tracker';
 
@@ -546,5 +548,151 @@ describe('firstUserMessage skips tool_result turns (not real user input)', () =>
     // Before the fix the tool_result turn's text block ("tool output follows")
     // was taken as the first user message.
     expect(s.firstUserMessage).toBe('Fix the bug in the parser');
+  });
+});
+
+// ─── Parse cache: incremental, append-only re-reads ───────────────────────────
+// The watcher invalidates the session list on every append of the *active*
+// session. These cover the mtime/size cache that serves unchanged files with no
+// I/O and folds only the appended tail of a grown transcript.
+describe('parse cache — append-only incremental parsing', () => {
+  it('serves an unchanged transcript from cache on refetch (no re-read)', async () => {
+    resetParseCache();
+    writeSession(tmp, 'a.jsonl', [
+      assistantLine({ model: 'claude-sonnet-4-5', input: 100, output: 50, id: 'm1', requestId: 'r1' }),
+    ]);
+
+    const first = await getSessionList(tmp);
+    const cold = getParseStats();
+    expect(cold.fullParses).toBe(1);
+    expect(cold.fileReads).toBe(1);
+    expect(cold.cacheHits).toBe(0);
+
+    const second = await getSessionList(tmp);
+    const warm = getParseStats();
+    expect(warm.cacheHits).toBe(1); // served from cache
+    expect(warm.fileReads).toBe(1); // NO additional read
+    expect(warm.fullParses).toBe(1); // not re-parsed
+    expect(second).toEqual(first); // identical result
+  });
+
+  it('reads only the appended tail when the transcript grows', async () => {
+    resetParseCache();
+    writeSession(tmp, 'a.jsonl', [
+      assistantLine({ model: 'claude-sonnet-4-5', input: 100, output: 50, id: 'm1', requestId: 'r1' }),
+    ]);
+    const [s1] = await getSessionList(tmp);
+    expect(s1.inputTokens).toBe(100);
+    const before = getParseStats();
+
+    appendFileSync(
+      join(tmp, 'a.jsonl'),
+      assistantLine({ model: 'claude-sonnet-4-5', input: 200, output: 30, id: 'm2', requestId: 'r2' }) + '\n'
+    );
+    const [s2] = await getSessionList(tmp);
+    const after = getParseStats();
+
+    expect(after.incrementalParses).toBe(before.incrementalParses + 1);
+    expect(after.fullParses).toBe(before.fullParses); // NOT a full re-parse
+    expect(s2.inputTokens).toBe(300);
+    expect(s2.outputTokens).toBe(80);
+    expect(s2.messageCount).toBe(2);
+  });
+
+  it('incremental folding equals a full parse, deduping across the append boundary', async () => {
+    // The duplicate of m1 (same id+requestId) lands in a *later* increment than
+    // the original — it must still be counted once (issue #56 across the boundary).
+    const l1 = assistantLine({ model: 'claude-opus-4-5', input: 100, output: 50, id: 'm1', requestId: 'r1' });
+    const dup = assistantLine({ model: 'claude-opus-4-5', input: 100, output: 50, id: 'm1', requestId: 'r1' });
+    const l2 = assistantLine({ model: 'claude-opus-4-5', input: 200, output: 60, id: 'm2', requestId: 'r2' });
+
+    // Incremental: write l1, then append dup, then append l2 — parsing between each.
+    resetParseCache();
+    writeSession(tmp, 'a.jsonl', [l1]);
+    await getSessionList(tmp);
+    appendFileSync(join(tmp, 'a.jsonl'), dup + '\n');
+    await getSessionList(tmp);
+    appendFileSync(join(tmp, 'a.jsonl'), l2 + '\n');
+    const [inc] = await getSessionList(tmp);
+
+    // Full: the same final content parsed from scratch in a fresh dir + clean cache.
+    const tmp2 = mkdtempSync(join(tmpdir(), 'cl-cost-'));
+    resetParseCache();
+    writeSession(tmp2, 'a.jsonl', [l1, dup, l2]);
+    const [full] = await getSessionList(tmp2);
+    rmSync(tmp2, { recursive: true, force: true });
+
+    expect(inc.messageCount).toBe(2); // dup counted once
+    expect(inc).toEqual(full);
+  });
+
+  it('buffers a half-written final line and folds it once when completed', async () => {
+    resetParseCache();
+    const file = join(tmp, 'a.jsonl');
+    const l1 = assistantLine({ model: 'claude-sonnet-4-5', input: 100, output: 10, id: 'm1', requestId: 'r1' });
+    const l2 = assistantLine({ model: 'claude-sonnet-4-5', input: 200, output: 20, id: 'm2', requestId: 'r2' });
+
+    // l1 complete + the first 20 bytes of l2, with no terminating newline.
+    writeFileSync(file, l1 + '\n' + l2.slice(0, 20), 'utf-8');
+    const [a] = await getSessionList(tmp);
+    expect(a.messageCount).toBe(1); // the partial l2 is buffered, not yet counted
+    expect(a.inputTokens).toBe(100);
+
+    appendFileSync(file, l2.slice(20) + '\n');
+    const [b] = await getSessionList(tmp);
+    expect(b.messageCount).toBe(2); // l2 completed and counted exactly once
+    expect(b.inputTokens).toBe(300);
+  });
+
+  it('falls back to a full re-parse when the transcript shrinks (replaced/truncated)', async () => {
+    resetParseCache();
+    writeSession(tmp, 'a.jsonl', [
+      assistantLine({ model: 'claude-opus-4-5', input: 100, output: 50, id: 'm1', requestId: 'r1' }),
+      assistantLine({ model: 'claude-opus-4-5', input: 100, output: 50, id: 'm2', requestId: 'r2' }),
+    ]);
+    const [s1] = await getSessionList(tmp);
+    expect(s1.inputTokens).toBe(200);
+    const before = getParseStats();
+
+    // Replace with a shorter, different transcript (smaller byte size).
+    writeSession(tmp, 'a.jsonl', [
+      assistantLine({ model: 'claude-opus-4-5', input: 7, output: 3, id: 'x1', requestId: 'rx' }),
+    ]);
+    const [s2] = await getSessionList(tmp);
+    const after = getParseStats();
+
+    expect(after.fullParses).toBe(before.fullParses + 1); // re-parsed from byte 0
+    expect(after.incrementalParses).toBe(before.incrementalParses); // not treated as a growth
+    expect(s2.inputTokens).toBe(7);
+    expect(s2.messageCount).toBe(1);
+  });
+
+  it('does not re-read a large transcript on an unchanged refetch (perf)', async () => {
+    resetParseCache();
+    const lines: string[] = [];
+    for (let i = 0; i < 5000; i++) {
+      lines.push(assistantLine({ model: 'claude-sonnet-4-5', input: 10, output: 5, id: `m${i}`, requestId: `r${i}` }));
+    }
+    writeSession(tmp, 'big.jsonl', lines);
+
+    const t0 = performance.now();
+    const [cold] = await getSessionList(tmp);
+    const coldMs = performance.now() - t0;
+    expect(cold.messageCount).toBe(5000);
+    expect(getParseStats().fileReads).toBe(1);
+
+    const t1 = performance.now();
+    const [warm] = await getSessionList(tmp);
+    const warmMs = performance.now() - t1;
+    const stats = getParseStats();
+
+    expect(stats.fileReads).toBe(1); // hard proof: no second read of 5000 lines
+    expect(stats.cacheHits).toBe(1);
+    expect(warm.messageCount).toBe(5000);
+    expect(warmMs).toBeLessThan(coldMs); // the cache hit is strictly cheaper
+    console.log(
+      `[perf] cold parse ${coldMs.toFixed(2)}ms → warm refetch ${warmMs.toFixed(2)}ms ` +
+        `(${(coldMs / Math.max(warmMs, 0.001)).toFixed(0)}x faster)`
+    );
   });
 });


### PR DESCRIPTION
## Summary

Avoids re-parsing unchanged session transcripts on every watcher-triggered refetch — the dominant cost during an active session, when the live `.jsonl` is appended continuously and the watcher invalidates the whole session list.

Previously `getSessionList`/`aggregateProject` re-read and fully re-parsed **every** `.jsonl` in the project (synchronously, from byte 0) on each refetch, even though only one file had changed and historical transcripts are immutable.

## Changes

- **mtime+size parse cache** — an unchanged transcript is served from cache with zero I/O.
- **Append-only incremental parsing** — a grown transcript is read only from the last consumed offset; buffers a half-written final line (UTF-8-safe byte split), dedupes usage across the append boundary, and falls back to a full re-parse on truncation/replace.
- **Async I/O** — `fs/promises` (`open`/`read`) instead of blocking `readFileSync`; the two call sites now parse in parallel with bounded concurrency (cap 8) to avoid EMFILE on the cold pass.
- **Observability** — `getParseStats`/`resetParseCache` (real counters, used by the tests).

## Verification

- Full suite: **173 passing** (no regression on the 26 original cost-tracker tests).
- 6 new integration tests: cache hit (no re-read), incremental tail-read, incremental-equals-full-parse with dedup across the boundary, half-written final line, truncation fallback, and perf.
- **Perf**: 5000-line transcript, unchanged refetch **16.4ms → 0.27ms (~61x faster)** — proven hard via `fileReads` staying at 1.
- `npm run typecheck` + `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYAU8dyxGoskTbrqp8wcdx
