### PR TITLE
refactor(entities): share frontmatter field registry + fix skill/agent edit and memory-writer guards

### DIFF
--- a/electron/modules/agents-reader.ts
+++ b/electron/modules/agents-reader.ts
@@ -1,7 +1,8 @@
 import { readFileSync, existsSync, readdirSync } from 'fs';
 import { join, basename } from 'path';
 import { CLAUDE_DIR } from '../utils';
-import { parseFrontmatter, getString, getBoolean, getStringArray, getNumber } from './frontmatter';
+import { parseFrontmatter, getString } from './frontmatter';
+import { AGENT_FIELDS, parseFields } from './entity-fields';
 
 export interface Agent {
   name: string;
@@ -52,54 +53,11 @@ interface AgentFrontmatter {
 
 function parseAgentMarkdown(content: string): { frontmatter: AgentFrontmatter; body: string } {
   const { frontmatter: raw, body } = parseFrontmatter(content);
-  const fm: AgentFrontmatter = {};
-
+  // All scalar/list fields come from the shared AGENT_FIELDS registry; `name`
+  // is read separately (required, with a filename fallback in readAgentFile).
+  const fm = parseFields(raw, AGENT_FIELDS) as AgentFrontmatter;
   const name = getString(raw, 'name');
   if (name !== undefined) fm.name = name;
-
-  const description = getString(raw, 'description');
-  if (description !== undefined) fm.description = description;
-
-  const model = getString(raw, 'model');
-  if (model !== undefined) fm.model = model;
-
-  // Il frontmatter usa `tools:` ma il modello dati lo espone come allowedTools.
-  const allowedTools = getStringArray(raw, 'tools');
-  if (allowedTools !== undefined) fm.allowedTools = allowedTools;
-
-  const disallowedTools = getStringArray(raw, 'disallowedTools');
-  if (disallowedTools !== undefined) fm.disallowedTools = disallowedTools;
-
-  const permissionMode = getString(raw, 'permissionMode');
-  if (permissionMode !== undefined) fm.permissionMode = permissionMode;
-
-  const isolation = getString(raw, 'isolation');
-  if (isolation !== undefined) fm.isolation = isolation;
-
-  const memory = getString(raw, 'memory');
-  if (memory !== undefined) fm.memory = memory;
-
-  const effort = getString(raw, 'effort');
-  if (effort !== undefined) fm.effort = effort;
-
-  const color = getString(raw, 'color');
-  if (color !== undefined) fm.color = color;
-
-  const skills = getStringArray(raw, 'skills');
-  if (skills !== undefined) fm.skills = skills;
-
-  const mcpServers = getStringArray(raw, 'mcpServers');
-  if (mcpServers !== undefined) fm.mcpServers = mcpServers;
-
-  const maxTurns = getNumber(raw, 'maxTurns');
-  if (maxTurns !== undefined) fm.maxTurns = maxTurns;
-
-  const background = getBoolean(raw, 'background');
-  if (background !== undefined) fm.background = background;
-
-  const disableModelInvocation = getBoolean(raw, 'disable_model_invocation');
-  if (disableModelInvocation !== undefined) fm.disableModelInvocation = disableModelInvocation;
-
   return { frontmatter: fm, body };
 }
 

--- a/electron/modules/agents-writer.ts
+++ b/electron/modules/agents-writer.ts
@@ -3,6 +3,7 @@ import { join } from 'path';
 import os from 'os';
 import { CLAUDE_DIR, validateEntityName, assertWithin } from '../utils';
 import { yamlScalar } from './frontmatter';
+import { AGENT_FIELDS, emitFields } from './entity-fields';
 
 export interface AgentInput {
   name: string;
@@ -24,31 +25,16 @@ export interface AgentInput {
 }
 
 function buildAgentMarkdown(input: AgentInput): string {
-  const lines: string[] = ['---'];
-  // Quote each scalar/list entry so a value with a colon, '#', etc. can't break
-  // the YAML block (which would make the reader drop ALL frontmatter on load).
-  const list = (arr: string[]) => `[${arr.map(yamlScalar).join(', ')}]`;
-
-  lines.push(`name: ${yamlScalar(input.name)}`);
-  if (input.description) lines.push(`description: ${yamlScalar(input.description)}`);
-  if (input.model) lines.push(`model: ${yamlScalar(input.model)}`);
-  if (input.allowedTools && input.allowedTools.length > 0) lines.push(`tools: ${list(input.allowedTools)}`);
-  if (input.disallowedTools && input.disallowedTools.length > 0) lines.push(`disallowedTools: ${list(input.disallowedTools)}`);
-  if (input.permissionMode) lines.push(`permissionMode: ${yamlScalar(input.permissionMode)}`);
-  if (input.maxTurns !== undefined) lines.push(`maxTurns: ${input.maxTurns}`);
-  if (input.background !== undefined) lines.push(`background: ${input.background}`);
-  if (input.isolation) lines.push(`isolation: ${yamlScalar(input.isolation)}`);
-  if (input.memory) lines.push(`memory: ${yamlScalar(input.memory)}`);
-  if (input.effort) lines.push(`effort: ${yamlScalar(input.effort)}`);
-  if (input.color) lines.push(`color: ${yamlScalar(input.color)}`);
-  if (input.skills && input.skills.length > 0) lines.push(`skills: ${list(input.skills)}`);
-  if (input.mcpServers && input.mcpServers.length > 0) lines.push(`mcpServers: ${list(input.mcpServers)}`);
-  if (input.disableModelInvocation !== undefined) lines.push(`disable_model_invocation: ${input.disableModelInvocation}`);
-
-  lines.push('---');
-  lines.push('');
-  lines.push(input.content);
-
+  // `name` is required and always first; the rest are emitted (and quoted) from
+  // the shared AGENT_FIELDS registry, so the writer can't drift from the reader.
+  const lines = [
+    '---',
+    `name: ${yamlScalar(input.name)}`,
+    ...emitFields(input as unknown as Record<string, unknown>, AGENT_FIELDS),
+    '---',
+    '',
+    input.content,
+  ];
   return lines.join('\n');
 }
 

--- a/electron/modules/entity-fields.ts
+++ b/electron/modules/entity-fields.ts
@@ -1,0 +1,104 @@
+import { getString, getBoolean, getStringArray, getNumber, yamlScalar } from './frontmatter';
+
+/**
+ * Single source of truth for the frontmatter fields of an agent / skill: the
+ * model key (`key`), the YAML key it maps to (`yamlKey`), and its scalar kind.
+ * Both the reader (`parseFields`) and the writer (`emitFields`) consume this,
+ * so a field's name and type are declared exactly once — the reader can never
+ * drift from the writer (e.g. an agent reading `tools:` while the writer emits
+ * `allowed-tools:`).
+ */
+export type FieldKind = 'string' | 'boolean' | 'number' | 'string[]';
+
+export interface EntityField {
+  key: string;
+  yamlKey: string;
+  kind: FieldKind;
+}
+
+// Order mirrors the frontmatter block each writer used to emit by hand.
+// `name` is handled separately by the reader/writer (required + filename
+// fallback for agents, directory-derived for skills), so it is NOT listed here.
+export const AGENT_FIELDS: EntityField[] = [
+  { key: 'description', yamlKey: 'description', kind: 'string' },
+  { key: 'model', yamlKey: 'model', kind: 'string' },
+  { key: 'allowedTools', yamlKey: 'tools', kind: 'string[]' },
+  { key: 'disallowedTools', yamlKey: 'disallowedTools', kind: 'string[]' },
+  { key: 'permissionMode', yamlKey: 'permissionMode', kind: 'string' },
+  { key: 'maxTurns', yamlKey: 'maxTurns', kind: 'number' },
+  { key: 'background', yamlKey: 'background', kind: 'boolean' },
+  { key: 'isolation', yamlKey: 'isolation', kind: 'string' },
+  { key: 'memory', yamlKey: 'memory', kind: 'string' },
+  { key: 'effort', yamlKey: 'effort', kind: 'string' },
+  { key: 'color', yamlKey: 'color', kind: 'string' },
+  { key: 'skills', yamlKey: 'skills', kind: 'string[]' },
+  { key: 'mcpServers', yamlKey: 'mcpServers', kind: 'string[]' },
+  { key: 'disableModelInvocation', yamlKey: 'disable_model_invocation', kind: 'boolean' },
+];
+
+export const SKILL_FIELDS: EntityField[] = [
+  { key: 'description', yamlKey: 'description', kind: 'string' },
+  { key: 'argumentHint', yamlKey: 'argument-hint', kind: 'string' },
+  { key: 'disableModelInvocation', yamlKey: 'disable-model-invocation', kind: 'boolean' },
+  { key: 'userInvocable', yamlKey: 'user-invocable', kind: 'boolean' },
+  { key: 'allowedTools', yamlKey: 'allowed-tools', kind: 'string[]' },
+  { key: 'model', yamlKey: 'model', kind: 'string' },
+  { key: 'context', yamlKey: 'context', kind: 'string' },
+  { key: 'agent', yamlKey: 'agent', kind: 'string' },
+];
+
+type FieldValue = string | boolean | number | string[];
+
+/**
+ * Read every field in `fields` from a parsed frontmatter record, keyed by the
+ * model `key`. A field absent (or holding an unusable value) is omitted, so the
+ * caller keeps optional fields `undefined` rather than forcing empty values.
+ */
+export function parseFields(
+  raw: Record<string, unknown>,
+  fields: EntityField[]
+): Record<string, FieldValue> {
+  const out: Record<string, FieldValue> = {};
+  for (const f of fields) {
+    let v: FieldValue | undefined;
+    switch (f.kind) {
+      case 'string':
+        v = getString(raw, f.yamlKey);
+        break;
+      case 'boolean':
+        v = getBoolean(raw, f.yamlKey);
+        break;
+      case 'number':
+        v = getNumber(raw, f.yamlKey);
+        break;
+      case 'string[]':
+        v = getStringArray(raw, f.yamlKey);
+        break;
+    }
+    if (v !== undefined) out[f.key] = v;
+  }
+  return out;
+}
+
+/**
+ * Emit the frontmatter lines for `input` per `fields`. Strings and list entries
+ * are quoted via `yamlScalar` so a value with a colon, `#`, etc. can't break the
+ * YAML block (which would make the reader drop ALL frontmatter on load). Absent,
+ * null, empty-string, and empty-array values are skipped.
+ */
+export function emitFields(input: Record<string, unknown>, fields: EntityField[]): string[] {
+  const lines: string[] = [];
+  for (const f of fields) {
+    const v = input[f.key];
+    if (v === undefined || v === null) continue;
+    if (f.kind === 'string[]') {
+      const arr = v as string[];
+      if (arr.length > 0) lines.push(`${f.yamlKey}: [${arr.map(yamlScalar).join(', ')}]`);
+    } else if (f.kind === 'boolean' || f.kind === 'number') {
+      lines.push(`${f.yamlKey}: ${v}`);
+    } else if (v !== '') {
+      lines.push(`${f.yamlKey}: ${yamlScalar(v as string)}`);
+    }
+  }
+  return lines;
+}

--- a/electron/modules/memory-writer.ts
+++ b/electron/modules/memory-writer.ts
@@ -123,12 +123,16 @@ export function createTopic(memoryDir: string, input: TopicInput): string {
 }
 
 export function updateTopic(memoryDir: string, filename: string, input: TopicInput): void {
-  writeFileSync(join(memoryDir, filename), buildTopicFileContent(input), 'utf-8');
+  validateTopicInput(input);
+  const target = join(memoryDir, filename);
+  assertWithin(memoryDir, target);
+  writeFileSync(target, buildTopicFileContent(input), 'utf-8');
   updateLineInMemoryMd(join(memoryDir, 'MEMORY.md'), filename, input.description);
 }
 
 export function deleteTopic(memoryDir: string, filename: string): void {
   const filePath = join(memoryDir, filename);
+  assertWithin(memoryDir, filePath);
   if (existsSync(filePath)) unlinkSync(filePath);
   removeLineFromMemoryMd(join(memoryDir, 'MEMORY.md'), filename);
 }

--- a/electron/modules/skills-reader.ts
+++ b/electron/modules/skills-reader.ts
@@ -1,7 +1,8 @@
 import { readFileSync, existsSync, readdirSync, statSync } from 'fs';
 import { join, basename, relative, extname, sep } from 'path';
 import { CLAUDE_DIR } from '../utils';
-import { parseFrontmatter, getString, getBoolean, getStringArray } from './frontmatter';
+import { parseFrontmatter } from './frontmatter';
+import { SKILL_FIELDS, parseFields } from './entity-fields';
 
 /** Role buckets used to group a skill's supporting files in the UI. */
 export type SkillFileRole = 'doc' | 'script' | 'template' | 'asset' | 'extension' | 'eval' | 'meta';
@@ -158,36 +159,10 @@ export function parseSkillMarkdown(content: string): {
   body: string;
 } {
   const { frontmatter: raw, body } = parseFrontmatter(content);
-  const fm: SkillFrontmatter = {};
+  // Scalar/list fields come from the shared SKILL_FIELDS registry; `hooks` is a
+  // nested map (not a scalar), so it is read separately below.
+  const fm = parseFields(raw, SKILL_FIELDS) as SkillFrontmatter;
 
-  // Ogni campo valutato una sola volta, assegnato solo se definito (preserva
-  // i campi opzionali come `undefined` invece di forzarli a un valore vuoto).
-  const description = getString(raw, 'description');
-  if (description !== undefined) fm.description = description;
-
-  const argumentHint = getString(raw, 'argument-hint');
-  if (argumentHint !== undefined) fm.argumentHint = argumentHint;
-
-  const disableModelInvocation = getBoolean(raw, 'disable-model-invocation');
-  if (disableModelInvocation !== undefined) fm.disableModelInvocation = disableModelInvocation;
-
-  const userInvocable = getBoolean(raw, 'user-invocable');
-  if (userInvocable !== undefined) fm.userInvocable = userInvocable;
-
-  const allowedTools = getStringArray(raw, 'allowed-tools');
-  if (allowedTools !== undefined) fm.allowedTools = allowedTools;
-
-  const model = getString(raw, 'model');
-  if (model !== undefined) fm.model = model;
-
-  const context = getString(raw, 'context');
-  if (context !== undefined) fm.context = context;
-
-  const agent = getString(raw, 'agent');
-  if (agent !== undefined) fm.agent = agent;
-
-  // `hooks` is declared on the Skill type and forwarded below, but was never
-  // actually parsed — so a skill's hooks block was silently dropped.
   const rawHooks = raw['hooks'];
   if (rawHooks && typeof rawHooks === 'object' && !Array.isArray(rawHooks)) {
     fm.hooks = rawHooks as Record<string, unknown>;

--- a/electron/modules/skills-writer.ts
+++ b/electron/modules/skills-writer.ts
@@ -2,7 +2,7 @@ import { writeFileSync, mkdirSync, existsSync } from 'fs';
 import { join } from 'path';
 import os from 'os';
 import { CLAUDE_DIR, validateEntityName, assertWithin } from '../utils';
-import { yamlScalar } from './frontmatter';
+import { SKILL_FIELDS, emitFields } from './entity-fields';
 
 export interface SkillInput {
   name: string;
@@ -18,24 +18,15 @@ export interface SkillInput {
 }
 
 function buildSkillMarkdown(input: SkillInput): string {
-  const lines: string[] = ['---'];
-  // Quote each scalar/list entry so a value with a colon, '#', etc. can't break
-  // the YAML block (which would make the reader drop ALL frontmatter on load).
-  const list = (arr: string[]) => `[${arr.map(yamlScalar).join(', ')}]`;
-
-  if (input.description) lines.push(`description: ${yamlScalar(input.description)}`);
-  if (input.argumentHint) lines.push(`argument-hint: ${yamlScalar(input.argumentHint)}`);
-  if (input.disableModelInvocation !== undefined) lines.push(`disable-model-invocation: ${input.disableModelInvocation}`);
-  if (input.userInvocable !== undefined) lines.push(`user-invocable: ${input.userInvocable}`);
-  if (input.allowedTools && input.allowedTools.length > 0) lines.push(`allowed-tools: ${list(input.allowedTools)}`);
-  if (input.model) lines.push(`model: ${yamlScalar(input.model)}`);
-  if (input.context) lines.push(`context: ${yamlScalar(input.context)}`);
-  if (input.agent) lines.push(`agent: ${yamlScalar(input.agent)}`);
-
-  lines.push('---');
-  lines.push('');
-  lines.push(input.content);
-
+  // A skill's name is its directory, not a frontmatter field, so the block is
+  // emitted (and quoted) entirely from the shared SKILL_FIELDS registry.
+  const lines = [
+    '---',
+    ...emitFields(input as unknown as Record<string, unknown>, SKILL_FIELDS),
+    '---',
+    '',
+    input.content,
+  ];
   return lines.join('\n');
 }
 

--- a/src/components/project/shared/entityOptions.ts
+++ b/src/components/project/shared/entityOptions.ts
@@ -199,15 +199,33 @@ function parseFmEntries(fm: string): { key: string; lines: string[] }[] {
   return out
 }
 
+/**
+ * YAML-safe inline scalar for *writing* a frontmatter value. A simple plain
+ * scalar is emitted verbatim; anything that could break the block — a colon,
+ * `#`, quotes, brackets, a leading/trailing space, or a number/bool/null-looking
+ * word — is emitted as a JSON double-quoted string (a valid YAML flow scalar
+ * that round-trips back through js-yaml). Without this a description like
+ * "Use this skill when: editing" written unquoted makes the reader throw on load
+ * and drop the ENTIRE frontmatter (description, tools, model, …).
+ */
+export function yamlInline(v: string): string {
+  const plain =
+    /^[A-Za-z0-9][A-Za-z0-9_ ./-]*$/.test(v) &&
+    v === v.trim() &&
+    !/^(true|false|null|yes|no|on|off)$/i.test(v) &&
+    !/^-?\d/.test(v)
+  return plain ? v : JSON.stringify(v)
+}
+
 function emitOption(def: OptionDef, v: OptionValue): string | null {
   if (v == null) return null
   if (def.isBool) return `${def.frontmatterKey}: ${v ? 'true' : 'false'}`
   if (def.isArray) {
     const arr = v as string[]
-    return arr.length ? `${def.frontmatterKey}: [${arr.join(', ')}]` : null
+    return arr.length ? `${def.frontmatterKey}: [${arr.map(yamlInline).join(', ')}]` : null
   }
   if (def.isNumber) return `${def.frontmatterKey}: ${v}`
-  return v === '' ? null : `${def.frontmatterKey}: ${v}`
+  return v === '' ? null : `${def.frontmatterKey}: ${yamlInline(String(v))}`
 }
 
 /**
@@ -230,19 +248,38 @@ function serializeWithPreserved(
   return ['---', ...emitted, ...preserved, '---', '', body].join('\n')
 }
 
+/**
+ * Serialize an agent/skill back to markdown: emit `name`/`description` + the
+ * managed option lines (all YAML-quoted), then re-append any unmodeled
+ * frontmatter keys (e.g. a skill's `hooks`) untouched. `emitName` is true for
+ * agents (name is a frontmatter field) and false for skills (name is the dir).
+ */
+function serializeEntity(
+  entity: { name: string; rawContent: string },
+  body: string,
+  opts: { description: string; options: Record<string, OptionValue>; defs: OptionDef[]; emitName: boolean }
+): string {
+  const emitted: string[] = []
+  if (opts.emitName) emitted.push(`name: ${yamlInline(entity.name)}`)
+  if (opts.description) emitted.push(`description: ${yamlInline(opts.description)}`)
+  for (const def of opts.defs) {
+    const line = emitOption(def, opts.options[def.key])
+    if (line) emitted.push(line)
+  }
+  const managed = [
+    ...(opts.emitName ? ['name'] : []),
+    'description',
+    ...opts.defs.map(d => d.frontmatterKey),
+  ]
+  return serializeWithPreserved(entity.rawContent, managed, emitted, body)
+}
+
 export function serializeAgent(
   agent: Agent,
   body: string,
   opts: { description: string; options: Record<string, OptionValue> }
 ): string {
-  const emitted: string[] = [`name: ${agent.name}`]
-  if (opts.description) emitted.push(`description: ${opts.description}`)
-  for (const def of AGENT_OPTION_DEFS) {
-    const line = emitOption(def, opts.options[def.key])
-    if (line) emitted.push(line)
-  }
-  const managed = ['name', 'description', ...AGENT_OPTION_DEFS.map(d => d.frontmatterKey)]
-  return serializeWithPreserved(agent.rawContent, managed, emitted, body)
+  return serializeEntity(agent, body, { ...opts, defs: AGENT_OPTION_DEFS, emitName: true })
 }
 
 export function serializeSkill(
@@ -250,14 +287,7 @@ export function serializeSkill(
   body: string,
   opts: { description: string; options: Record<string, OptionValue> }
 ): string {
-  const emitted: string[] = []
-  if (opts.description) emitted.push(`description: ${opts.description}`)
-  for (const def of SKILL_OPTION_DEFS) {
-    const line = emitOption(def, opts.options[def.key])
-    if (line) emitted.push(line)
-  }
-  const managed = ['description', ...SKILL_OPTION_DEFS.map(d => d.frontmatterKey)]
-  return serializeWithPreserved(skill.rawContent, managed, emitted, body)
+  return serializeEntity(skill, body, { ...opts, defs: SKILL_OPTION_DEFS, emitName: false })
 }
 
 /**

--- a/test/entity-writers.test.ts
+++ b/test/entity-writers.test.ts
@@ -1,11 +1,28 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, existsSync, readFileSync } from 'fs';
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { tmpdir, homedir } from 'os';
 import { join } from 'path';
 import { createSkill } from '../electron/modules/skills-writer';
 import { createAgent } from '../electron/modules/agents-writer';
 import { readAgentFile } from '../electron/modules/agents-reader';
 import { readSkillDir } from '../electron/modules/skills-reader';
+import {
+  serializeSkill,
+  serializeAgent,
+  readOptions,
+  SKILL_OPTION_DEFS,
+  AGENT_OPTION_DEFS,
+} from '../src/components/project/shared/entityOptions';
+
+// The renderer edit path serializes an entity to raw markdown that is written
+// verbatim (markdownFile:write), then read back with js-yaml. These helpers pass
+// only the fields the serializer reads (name + rawContent) and the current
+// option values, mirroring what EntityDetailView hands to serialize().
+const asSkill = (s: { name: string; rawContent: string }) =>
+  s as unknown as Parameters<typeof serializeSkill>[0];
+const asAgent = (a: { name: string; rawContent: string }) =>
+  a as unknown as Parameters<typeof serializeAgent>[0];
+const asRecord = (o: unknown) => o as Record<string, unknown>;
 
 // createSkill/createAgent honor a projectPath by writing under
 // {projectPath}/.claude/(skills|agents). The writers anchor containment on the
@@ -112,5 +129,73 @@ describe('createAgent (issue #58)', () => {
     const filePath = createAgent({ name: 'numish', content: 'b', description: 'x', model: '4.8' }, proj);
     const agent = readAgentFile(filePath, 'project');
     expect(agent!.model).toBe('4.8');
+  });
+});
+
+// Regression: editing (not creating) a skill/agent goes through the renderer's
+// serializeSkill/serializeAgent → raw markdownFile:write, with NO server-side
+// re-canonicalization. An unquoted description containing ': ' or '#' used to
+// break the YAML on read and drop the whole frontmatter.
+describe('edit round-trip via renderer serializer', () => {
+  it('skill: preserves a description with a colon and #', () => {
+    createSkill({ name: 'edit-skill', content: 'Body', description: 'old', model: 'sonnet' }, proj);
+    const dir = join(proj, '.claude', 'skills', 'edit-skill');
+    const skill = readSkillDir(dir, 'project')!;
+    const description = 'Use this skill when: editing, fixing # or building the deck';
+    const raw = serializeSkill(asSkill(skill), skill.content, {
+      description,
+      options: readOptions(asRecord(skill), SKILL_OPTION_DEFS),
+    });
+    writeFileSync(join(dir, 'SKILL.md'), raw, 'utf-8');
+    const reread = readSkillDir(dir, 'project')!;
+    expect(reread.description).toBe(description);
+    expect(reread.model).toBe('sonnet');
+  });
+
+  it('agent: preserves a description with a colon and keeps a numeric-looking model a string', () => {
+    const filePath = createAgent(
+      { name: 'edit-agent', content: 'Body', description: 'old', model: '4.8', color: 'blue' },
+      proj
+    );
+    const agent = readAgentFile(filePath, 'project')!;
+    const description = 'Use this agent when the user asks: X # and Y';
+    const raw = serializeAgent(asAgent(agent), agent.content, {
+      description,
+      options: readOptions(asRecord(agent), AGENT_OPTION_DEFS),
+    });
+    writeFileSync(filePath, raw, 'utf-8');
+    const reread = readAgentFile(filePath, 'project')!;
+    expect(reread.missingRequired).toEqual([]);
+    expect(reread.description).toBe(description);
+    expect(reread.model).toBe('4.8');
+    expect(reread.color).toBe('blue');
+  });
+
+  it('skill: an edit preserves an unmodeled hooks block', () => {
+    const dir = join(proj, '.claude', 'skills', 'hooked');
+    mkdirSync(dir, { recursive: true });
+    const original = [
+      '---',
+      'description: original',
+      'hooks:',
+      '  PreToolUse:',
+      '    - matcher: Bash',
+      '---',
+      '',
+      'Body',
+    ].join('\n');
+    writeFileSync(join(dir, 'SKILL.md'), original, 'utf-8');
+    const skill = readSkillDir(dir, 'project')!;
+    expect(skill.hooks).toBeDefined();
+
+    const raw = serializeSkill(asSkill(skill), skill.content, {
+      description: 'new desc',
+      options: readOptions(asRecord(skill), SKILL_OPTION_DEFS),
+    });
+    writeFileSync(join(dir, 'SKILL.md'), raw, 'utf-8');
+    const reread = readSkillDir(dir, 'project')!;
+    expect(reread.description).toBe('new desc');
+    expect(reread.hooks).toBeDefined();
+    expect(JSON.stringify(reread.hooks)).toContain('PreToolUse');
   });
 });

--- a/test/memory.test.ts
+++ b/test/memory.test.ts
@@ -358,6 +358,35 @@ describe('updateTopic', () => {
     expect(index.filter(l => l.includes(`(${filename})`))).toHaveLength(1);
     expect(index).toContain(`- [${filename}](${filename}) — updated over lines`);
   });
+
+  it('rejects an invalid topic type on update (parity with create)', () => {
+    const filename = createTopic(memoryDir, {
+      name: 'Topic',
+      description: 'd',
+      type: 'user',
+      content: 'body',
+    });
+    expect(() =>
+      updateTopic(memoryDir, filename, {
+        name: 'Topic',
+        description: 'd',
+        type: 'bogus' as never,
+        content: 'body',
+      })
+    ).toThrow(/Invalid topic type/);
+  });
+
+  it('refuses a filename that escapes the memory dir', () => {
+    expect(() =>
+      updateTopic(memoryDir, '../escape.md', {
+        name: 'Topic',
+        description: 'd',
+        type: 'user',
+        content: 'body',
+      })
+    ).toThrow(/outside/);
+    expect(existsSync(join(memoryDir, '..', 'escape.md'))).toBe(false);
+  });
 });
 
 describe('deleteTopic', () => {
@@ -376,6 +405,14 @@ describe('deleteTopic', () => {
     const index = readFileSync(join(memoryDir, 'MEMORY.md'), 'utf-8');
     expect(index).not.toContain(filename);
     expect(index).not.toContain('gone soon');
+  });
+
+  it('refuses a filename that escapes the memory dir', () => {
+    // A sibling file outside memoryDir must be safe from a traversal filename.
+    const outside = join(tmp, 'keep.md');
+    writeFileSync(outside, 'keep me', 'utf-8');
+    expect(() => deleteTopic(memoryDir, '../keep.md')).toThrow(/outside/);
+    expect(existsSync(outside)).toBe(true);
   });
 
   it('leaves sibling index lines intact when deleting one topic', () => {


### PR DESCRIPTION
## Summary

Refactor and bug-fix of the read/update system shared by **agents, skills and memory** entities.

### Refactor
- New `electron/modules/entity-fields.ts` — single source of truth for agent/skill frontmatter fields (`AGENT_FIELDS`/`SKILL_FIELDS`) plus generic `parseFields()`/`emitFields()`. Both readers and writers now consume it, so the field↔YAML-key mapping can no longer drift between them.
- `agents-reader`/`skills-reader` parse via `parseFields()`; `agents-writer`/`skills-writer` emit via `emitFields()` — the hand-rolled per-field boilerplate is gone.
- Renderer `entityOptions.ts`: merged the near-identical `serializeAgent`/`serializeSkill` into one `serializeEntity` helper (public API unchanged).

### Bug fixes
1. **Skill/agent edit corrupted the frontmatter** — the renderer edit path serialized YAML *without quoting*, so a `description` containing `:` or `#` broke the block on the next read and dropped all frontmatter. Added `yamlInline()` to quote unsafe scalars.
2. `memory-writer.updateTopic` now runs `validateTopicInput` + `assertWithin` (was skipping type validation).
3. `memory-writer.deleteTopic` now runs `assertWithin` (parity with `createTopic`; previously accepted a traversal filename).

### Tests
Added coverage for the edit round-trip with `:`/`#` in the description, `hooks` preservation on edit, `updateTopic` rejecting an invalid type, and update/delete rejecting a traversal filename.

Verified: `npm run typecheck` clean · `npm run lint` 0 errors · `npx vitest run` 248 passed / 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)