### PR TITLE
fix(chat): export fidelity — command/notification turns, fenced blank lines, fence collisions

### DIFF
--- a/src/components/project/chat/export.tsx
+++ b/src/components/project/chat/export.tsx
@@ -10,10 +10,11 @@ import rehypeHighlight from 'rehype-highlight'
 import hljsLightCss from 'highlight.js/styles/github.css?raw'
 import { ChatContentBlock, SessionSummary } from '../../../types'
 import { fmt, fmtCost, fmtDate, fmtModel, sessionTitle } from '../utils'
-import { ProcessedMessage, ToolGroup } from './utils'
+import { ClaudeSlashCommand, ProcessedMessage, TaskNotification, ToolGroup } from './utils'
 import {
   Highlight,
   exportHighlightCss,
+  fencedCodeRanges,
   materializeHighlightSentinels,
   wrapHighlightsWithSentinels,
 } from './highlights'
@@ -125,14 +126,15 @@ function previewValue(value: unknown, max = 96): string {
   return text.replace(/\s+/g, ' ').trim().slice(0, max)
 }
 
-function toolPreview(input: Record<string, unknown>): string {
+function toolPreview(input: Record<string, unknown> | null | undefined): string {
+  const i = input ?? {}
   return (
-    previewValue(input.file_path) ||
-    previewValue(input.command) ||
-    previewValue(input.pattern) ||
-    previewValue(input.description) ||
-    previewValue(input.url) ||
-    previewValue(input.prompt)
+    previewValue(i.file_path) ||
+    previewValue(i.command) ||
+    previewValue(i.pattern) ||
+    previewValue(i.description) ||
+    previewValue(i.url) ||
+    previewValue(i.prompt)
   )
 }
 
@@ -142,7 +144,12 @@ function jsonFence(value: unknown): string {
 
 function fence(value: string, lang = 'text'): string {
   const cleaned = value.trimEnd()
-  const marker = cleaned.includes('```') ? '~~~' : '```'
+  // A fence must be longer than any backtick run inside it, or the content
+  // would close it early (the old ```/~~~ toggle still broke on content
+  // carrying both markers).
+  const runs = cleaned.match(/`{3,}/g)
+  const longest = runs ? Math.max(...runs.map(r => r.length)) : 0
+  const marker = '`'.repeat(Math.max(3, longest + 1))
   return `${marker}${lang}\n${cleaned}\n${marker}`
 }
 
@@ -181,6 +188,11 @@ function showsTools(options: ExportOptions): boolean {
  *  an empty shell ("No visible message text.") — skip it entirely instead. */
 function turnHasVisibleContent(processed: ProcessedMessage, options: ExportOptions): boolean {
   const { msg, toolGroups } = processed
+  // A slash-command turn always shows (the command IS the user's message); a
+  // task-notification is a background-agent system event, surfaced only when
+  // the preset shows tool activity (the "message" preset strips it).
+  if (processed.command) return true
+  if (processed.notification) return showsTools(options)
   if (textBlocks(msg.content).some(b => b.text.trim())) return true
   if (options.includeThinking && thinkingBlocks(msg.content).some(b => b.thinking.trim())) return true
   return toolGroups.length > 0 && showsTools(options)
@@ -217,6 +229,20 @@ function blockHighlights(highlights: Highlight[], uuid: string, blockIndex: numb
   return highlights.filter(h => h.messageUuid === uuid && h.blockIndex === blockIndex)
 }
 
+/** Markdown one-liner for a slash-command turn — mirrors the live view's
+ *  command card instead of leaking the raw <command-name> XML framing that
+ *  Claude Code persists in the user message. */
+function commandMarkdown(command: ClaudeSlashCommand, options: ExportOptions): string[] {
+  const args = command.args && command.args !== command.command ? ` ${command.args}` : ''
+  const lines = [`\`/${command.command}\`${args}`, '']
+  if (command.output && showsTools(options)) lines.push(fence(command.output), '')
+  return lines
+}
+
+function notificationMarkdown(notification: TaskNotification): string[] {
+  return [`*Task event (${notification.status}): ${notification.summary}*`, '']
+}
+
 function buildTurnMarkdown(
   processed: ProcessedMessage,
   index: number,
@@ -224,8 +250,15 @@ function buildTurnMarkdown(
   highlights: Highlight[],
 ): string[] {
   const { msg, toolGroups } = processed
-  const heading = `### ${String(index + 1).padStart(2, '0')} ${roleLabel(msg.role)}${turnTime(msg.timestamp) ? ` - ${turnTime(msg.timestamp)}` : ''}`
+  const who = processed.notification ? 'Task event' : roleLabel(msg.role)
+  const heading = `### ${String(index + 1).padStart(2, '0')} ${who}${turnTime(msg.timestamp) ? ` - ${turnTime(msg.timestamp)}` : ''}`
   const lines = [heading, '']
+
+  // Command / notification turns replace their raw text blocks (which carry
+  // Claude Code's internal XML framing) with the same compact representation
+  // the live view renders.
+  if (processed.command) return [...lines, ...commandMarkdown(processed.command, options)]
+  if (processed.notification) return [...lines, ...notificationMarkdown(processed.notification)]
 
   if (options.includeThinking) {
     for (const block of thinkingBlocks(msg.content)) {
@@ -277,10 +310,30 @@ function buildTurnMarkdown(
   return lines
 }
 
+/** The session's primary model id: first real model from the per-model usage
+ *  map, falling back to the flat `model` field (an empty `models` map used to
+ *  short-circuit the fallback away). */
+function primaryModelOf(session: SessionSummary): string | undefined {
+  const fromMap = session.models
+    ? Object.keys(session.models).filter(k => k !== '<synthetic>')[0]
+    : undefined
+  return fromMap ?? session.model
+}
+
+/** Collapse runs of 4+ newlines (generation artifacts) — but never inside a
+ *  fenced code block, where blank lines are content (a tool result or a code
+ *  sample would come out altered). */
+function collapseBlankRuns(text: string): string {
+  const fences = fencedCodeRanges(text)
+  return text.replace(/\n{4,}/g, (m, offset: number) =>
+    fences.some(f => offset >= f.from && offset < f.to) ? m : '\n\n\n',
+  )
+}
+
 function buildMarkdown(input: BuildChatExportInput, options: ExportOptions): string {
   const { session, processed, preset } = input
   const title = sessionTitle(session, 120)
-  const primaryModel = session.models ? Object.keys(session.models).filter(k => k !== '<synthetic>')[0] : session.model
+  const primaryModel = primaryModelOf(session)
   // The absolute project path is deliberately omitted — it can leak the username
   // and internal directory structure into a shared export.
   const lines = [
@@ -305,7 +358,7 @@ function buildMarkdown(input: BuildChatExportInput, options: ExportOptions): str
       lines.push(...buildTurnMarkdown(p, i, options, highlights))
     })
 
-  return lines.join('\n').replace(/\n{4,}/g, '\n\n\n').trimEnd() + '\n'
+  return collapseBlankRuns(lines.join('\n')).trimEnd() + '\n'
 }
 
 function escapeHtml(value: string): string {
@@ -370,6 +423,32 @@ function renderToolHtml(group: ToolGroup, options: ExportOptions): string {
   `
 }
 
+/** HTML for a slash-command turn — the compact command chip the live view
+ *  shows, never the raw <command-name> XML persisted in the transcript. */
+function renderCommandHtml(command: ClaudeSlashCommand, options: ExportOptions): string {
+  const args = command.args && command.args !== command.command ? command.args : ''
+  const output = command.output && showsTools(options)
+    ? `<pre><code>${escapeHtml(command.output)}</code></pre>`
+    : ''
+  return `
+    <div class="command-line">
+      <code>/${escapeHtml(command.command)}</code>
+      ${args ? `<span class="command-args">${escapeHtml(args)}</span>` : ''}
+    </div>
+    ${output}
+  `
+}
+
+function renderNotificationHtml(notification: TaskNotification): string {
+  return `
+    <div class="tool-note">
+      <span>Task event</span>
+      <em>${escapeHtml(notification.summary)}</em>
+      <b class="${notification.status === 'completed' ? 'is-ok' : 'is-error'}">${escapeHtml(notification.status)}</b>
+    </div>
+  `
+}
+
 function renderTurnHtml(
   processed: ProcessedMessage,
   _index: number,
@@ -378,8 +457,15 @@ function renderTurnHtml(
 ): string {
   const { msg, toolGroups } = processed
   const time = turnTime(msg.timestamp)
-  const role = roleLabel(msg.role)
-  const textHtml = textBlocks(msg.content)
+  const role = processed.notification ? 'Task event' : roleLabel(msg.role)
+  // Command / notification turns replace their raw text blocks (Claude Code's
+  // internal XML framing) with the live view's compact representation.
+  const specialHtml = processed.command
+    ? renderCommandHtml(processed.command, options)
+    : processed.notification
+      ? renderNotificationHtml(processed.notification)
+      : null
+  const textHtml = specialHtml !== null ? '' : textBlocks(msg.content)
     .map((block, blockIndex) => {
       const hls = blockHighlights(highlights, msg.uuid, blockIndex)
       // Sentinels are injected into the raw text, pass through react-markdown as
@@ -419,7 +505,7 @@ function renderTurnHtml(
         ${model ? `<span class="turn-sep">·</span>${model}` : ''}
       </header>
       ${thinkingHtml}
-      ${textHtml || '<p class="muted">No visible message text.</p>'}
+      ${specialHtml ?? (textHtml || '<p class="muted">No visible message text.</p>')}
       ${toolsHtml}
     </article>
   `
@@ -428,7 +514,7 @@ function renderTurnHtml(
 function buildHtml(input: BuildChatExportInput, options: ExportOptions): string {
   const { session, processed } = input
   const title = sessionTitle(session, 120)
-  const primaryModel = session.models ? Object.keys(session.models).filter(k => k !== '<synthetic>')[0] : session.model
+  const primaryModel = primaryModelOf(session)
 
   return `<!doctype html>
 <html>
@@ -506,6 +592,10 @@ function buildHtml(input: BuildChatExportInput, options: ExportOptions): string 
     .message-text { margin-bottom: 8px; }
     .message-text > :first-child { margin-top: 0; }
     .message-text > :last-child { margin-bottom: 0; }
+    /* Slash-command turn: the compact command chip (mirrors the live view). */
+    .command-line { margin-bottom: 8px; }
+    .command-line code { font-weight: 700; }
+    .command-args { margin-left: 8px; color: #5f5a52; }
     ${exportHighlightCss()}
     /* Markdown body elements (react-markdown + GFM output). */
     em { font-style: italic; }

--- a/test/export.test.tsx
+++ b/test/export.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { buildChatExportDocument } from '../src/components/project/chat/export'
 import type { SessionSummary, ChatMessage } from '../src/types'
-import type { ProcessedMessage } from '../src/components/project/chat/utils'
+import { buildProcessedMessages, type ProcessedMessage } from '../src/components/project/chat/utils'
 import type { Highlight } from '../src/components/project/chat/highlights'
 
 // Integration coverage for the react-markdown-backed HTML export: confirms
@@ -187,5 +187,137 @@ describe('buildChatExportDocument (react-markdown HTML)', () => {
     })
     expect(doc.html).toContain('<math')
     expect(doc.html).not.toContain('$$i_{\\text{entra}}')
+  })
+})
+
+describe('buildChatExportDocument (command / notification turns)', () => {
+  const commandMessages: ChatMessage[] = [
+    {
+      uuid: 'c1',
+      role: 'user',
+      timestamp: '2026-06-23T10:30:00Z',
+      content: [
+        {
+          type: 'text',
+          text: '<command-name>/compact</command-name>\n<command-message>compact</command-message>\n<command-args>focus on tests</command-args>',
+        },
+      ],
+    },
+    {
+      uuid: 'c2',
+      role: 'user',
+      timestamp: '2026-06-23T10:30:05Z',
+      content: [{ type: 'text', text: '<local-command-stdout>Compacted successfully</local-command-stdout>' }],
+    },
+  ]
+
+  it('renders a slash-command turn as the command chip, never the raw XML framing', () => {
+    const doc = buildChatExportDocument({
+      session,
+      processed: buildProcessedMessages(commandMessages),
+      preset: 'message',
+    })
+    expect(doc.markdown).toContain('`/compact` focus on tests')
+    expect(doc.markdown).not.toContain('<command-name>')
+    expect(doc.html).toContain('/compact')
+    expect(doc.html).not.toContain('&lt;command-name&gt;')
+    // The "message" preset strips the command's stdout along with tool detail.
+    expect(doc.markdown).not.toContain('Compacted successfully')
+  })
+
+  it('includes the command output in presets that show tool activity', () => {
+    const doc = buildChatExportDocument({
+      session,
+      processed: buildProcessedMessages(commandMessages),
+      preset: 'docs',
+    })
+    expect(doc.markdown).toContain('Compacted successfully')
+    expect(doc.html).toContain('Compacted successfully')
+  })
+
+  const notificationMessages: ChatMessage[] = [
+    {
+      uuid: 'n1',
+      role: 'user',
+      timestamp: '2026-06-23T10:31:00Z',
+      content: [
+        {
+          type: 'text',
+          text: '<task-notification><task-id>t1</task-id><status>completed</status><summary>Background agent finished</summary></task-notification>',
+        },
+      ],
+    },
+  ]
+
+  it('skips task notifications in the "message" preset', () => {
+    const doc = buildChatExportDocument({
+      session,
+      processed: buildProcessedMessages(notificationMessages),
+      preset: 'message',
+    })
+    expect(doc.markdown).not.toContain('task-notification')
+    expect(doc.markdown).not.toContain('Background agent finished')
+    expect(doc.html).not.toContain('task-notification')
+  })
+
+  it('renders task notifications compactly (no raw XML) in tool-showing presets', () => {
+    const doc = buildChatExportDocument({
+      session,
+      processed: buildProcessedMessages(notificationMessages),
+      preset: 'docs',
+    })
+    expect(doc.markdown).toContain('Task event (completed): Background agent finished')
+    expect(doc.markdown).not.toContain('<task-notification>')
+    expect(doc.html).toContain('Background agent finished')
+    expect(doc.html).not.toContain('&lt;task-notification&gt;')
+  })
+})
+
+describe('buildChatExportDocument (fidelity)', () => {
+  it('preserves blank-line runs inside a fenced code block in the Markdown export', () => {
+    const code = ['```python', 'a = 1', '', '', '', 'b = 2', '```'].join('\n')
+    const doc = buildChatExportDocument({
+      session,
+      processed: [assistantTurn('a1', `Ecco il codice:\n\n${code}`)],
+      preset: 'message',
+    })
+    expect(doc.markdown).toContain('a = 1\n\n\n\nb = 2')
+  })
+
+  it('wraps tool results containing both ``` and ~~~ in a longer backtick fence', () => {
+    const content = 'uses ```js fences\nand ~~~ too'
+    const msg: ChatMessage = {
+      uuid: 'a2',
+      role: 'assistant',
+      timestamp: '2026-06-23T10:32:00Z',
+      model: 'claude-opus-4-8',
+      content: [
+        { type: 'text', text: 'ran a tool' },
+        { type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'cat file' } },
+      ],
+    }
+    const resultMsg: ChatMessage = {
+      uuid: 'u9',
+      role: 'user',
+      timestamp: '2026-06-23T10:32:05Z',
+      content: [{ type: 'tool_result', toolUseId: 't1', content, isError: false }],
+    }
+    const doc = buildChatExportDocument({
+      session,
+      processed: buildProcessedMessages([msg, resultMsg]),
+      preset: 'audit',
+    })
+    // The fence must be longer than any backtick run inside the content, so the
+    // embedded ``` can't close it early.
+    expect(doc.markdown).toContain('````text\nuses ```js fences\nand ~~~ too\n````')
+  })
+
+  it('falls back to session.model for the Model line when the models map is empty', () => {
+    const doc = buildChatExportDocument({
+      session: { ...session, models: {}, model: 'claude-opus-4-8' },
+      processed: [assistantTurn('a1', 'ciao')],
+      preset: 'message',
+    })
+    expect(doc.markdown).toContain('> Model:')
   })
 })


### PR DESCRIPTION
Review of the chat export pipeline surfaced four bugs, all reproduced with
unit tests before fixing:

- Slash-command turns leaked Claude Code's raw <command-name>/<command-args>
  XML framing into both the Markdown and HTML/PDF exports. They now render as
  the compact command chip the live view shows (`/cmd` + args), with the
  command's stdout included only in presets that show tool activity.
- Task-notification turns leaked the raw <task-notification> XML. They now
  export as a compact 'Task event' line in tool-showing presets and are
  skipped entirely by the Message preset (consistent with its 'no agents'
  contract).
- The final \n{4,} cleanup collapsed blank-line runs inside fenced code
  blocks too, altering exported code samples and tool results. The collapse
  is now fence-aware (reuses fencedCodeRanges).
- fence() toggled between ``` and ~~~, so content carrying both markers
  broke out of its fence. It now sizes the backtick fence longer than any
  run inside the content.

Also hardened toolPreview against a missing tool input and fixed the
primary-model fallback (an empty models map suppressed the Model line even
when session.model was set).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01M5AL6w5kWnDVGkrWxhxauu