### PR TITLE
fix(duplicates): prevent session-rename collisions in project merge

### DIFF
--- a/electron/modules/duplicate-merger.ts
+++ b/electron/modules/duplicate-merger.ts
@@ -138,14 +138,15 @@ export function computeMergePlan(
   }
 
   // ── Sessioni ───────────────────────────────────────────────────────────────
-  const destSessionSet = new Set(destSessions);
+  // `takenSessionNames` viene aggiornato ad ogni iterazione (sia con targetName
+  // rinominati sia con filename lasciati invariati) per evitare che due file
+  // source finiscano per essere assegnati allo stesso nome di destinazione.
+  const takenSessionNames = new Set(destSessions);
   const sessions: SessionMove[] = sourceSessions.map(filename => {
-    const collides = destSessionSet.has(filename);
-    return {
-      filename,
-      collides,
-      targetName: collides ? uniqueRenameTarget(filename, destSessionSet) : filename,
-    };
+    const collides = takenSessionNames.has(filename);
+    const targetName = collides ? uniqueRenameTarget(filename, takenSessionNames) : filename;
+    takenSessionNames.add(targetName);
+    return { filename, collides, targetName };
   });
 
   // ── Riscrittura cwd ──────────────────────────────────────────────────────────

--- a/test/duplicate-merger.test.ts
+++ b/test/duplicate-merger.test.ts
@@ -1,0 +1,37 @@
+import { mkdtempSync, mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { computeMergePlan } from '../electron/modules/duplicate-merger';
+
+let projectsDir: string;
+
+beforeEach(() => {
+  projectsDir = mkdtempSync(join(tmpdir(), 'cl-merge-'));
+});
+
+describe('computeMergePlan — session rename collisions', () => {
+  it('never assigns the same targetName to two different source sessions', () => {
+    // La dest ha già "X.jsonl". La source ha sia "X.jsonl" (che quindi va
+    // rinominato) sia "X_2.jsonl" (che di per sé non collide con la dest, ma
+    // colliderebbe con il nome generato per l'altro file se non si tiene
+    // traccia dei target già assegnati in questa stessa esecuzione).
+    const sourceHash = '-tmp-source';
+    const destHash = '-tmp-dest';
+    const sourceDir = join(projectsDir, sourceHash);
+    const destDir = join(projectsDir, destHash);
+    mkdirSync(sourceDir, { recursive: true });
+    mkdirSync(destDir, { recursive: true });
+
+    const cwdLine = (cwd: string) =>
+      JSON.stringify({ type: 'user', cwd, message: { role: 'user', content: 'hi' } });
+
+    writeFileSync(join(destDir, 'X.jsonl'), cwdLine('/tmp/dest-project'), 'utf-8');
+    writeFileSync(join(sourceDir, 'X.jsonl'), cwdLine('/tmp/source-project'), 'utf-8');
+    writeFileSync(join(sourceDir, 'X_2.jsonl'), cwdLine('/tmp/source-project'), 'utf-8');
+
+    const plan = computeMergePlan(projectsDir, sourceHash, destHash);
+
+    const targetNames = plan.sessions.map(s => s.targetName);
+    expect(new Set(targetNames).size).toBe(targetNames.length);
+  });
+});


### PR DESCRIPTION
## Summary

- `computeMergePlan`'s session-rename pass (`electron/modules/duplicate-merger.ts`) only checked each source `.jsonl` filename against the *destination's* existing files, never against the `targetName`s it had already assigned to other source sessions earlier in the same run.
- This let two source sessions collide on the same destination name — e.g. `X.jsonl` gets defensively renamed to `X_2.jsonl` to dodge a name already in the destination, while another source file is *literally* named `X_2.jsonl` and (seeing no destination collision) keeps its own name. Both then target `X_2.jsonl`.
- Downstream, `duplicate-merge-executor.ts` writes both moves to that same target path, silently overwriting the first — one session transcript is lost from the merged project (only the pre-merge backup preserves it, invisibly).
- The memory-topic merge a few lines below already handles this correctly (`takenTargets` seeded from the destination set, updated after every assignment); the session merge was missing the same pattern.

## Fix

Track a single mutable `takenSessionNames` set, seeded from the destination's existing filenames, and add each session's resolved `targetName` to it right after assignment — mirroring the existing memory-merge logic in the same file.

## Test plan

- [x] Added `test/duplicate-merger.test.ts`, a regression test that reproduces the exact collision scenario (dest has `X.jsonl`; source has both `X.jsonl` and `X_2.jsonl`) and asserts all `targetName`s are unique.
- [x] Verified the new test fails against the pre-fix code (`git stash` the fix) and passes with it applied.
- [x] `npm run typecheck`, `npm run lint`, `npm test` all pass (283 tests).
- Not related to the live chat streaming path (`chat-runner.ts`/`chat-stream.ts`) — untouched.


---
_Generated by [Claude Code](https://claude.ai/code/session_015z1xVgvPPmwFj3HSkYYo2E)_