### PR TITLE
Prevent argument injection in claude CLI invocations

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -30,6 +30,7 @@ import { getInstalledPlugins } from './modules/plugins-reader';
 import { createSkill, SkillInput } from './modules/skills-writer';
 import { createAgent, AgentInput } from './modules/agents-writer';
 import { getGlobalMcp } from './modules/mcp-reader';
+import { buildDispatchBgArgs, buildAiRunArgs } from './modules/claude-cli-args';
 import { readEffectiveConfig } from './modules/config-reader';
 import {
   ChatSession,
@@ -1030,17 +1031,9 @@ ipcMain.handle(
         );
       }
 
-      const args = ['--bg'];
-      if (name) {
-        args.push('--name', name);
-      }
-      if (agent) {
-        args.push('--agent', agent);
-      }
-      if (model) {
-        args.push('--model', model);
-      }
-      args.push(prompt);
+      // Argv validato + prompt dietro `--`, così un valore che inizia con `-`
+      // non può iniettare flag nella CLI (issue #90).
+      const args = buildDispatchBgArgs({ prompt, name, agent, model });
 
       const { execFile } = await import('child_process');
       const { promisify } = await import('util');
@@ -1172,17 +1165,10 @@ ipcMain.handle(
     }
 
     return new Promise<IpcResult<null>>(resolve => {
-      // execFile-style: nessuna shell, l'istruzione passa come argomento separato
-      // (niente string-building né escaping fragile — cfr. agents:dispatchBg).
-      const args = [
-        '-p',
-        instruction,
-        '--model',
-        'Haiku',
-        '--allowedTools',
-        'Read,Glob,Grep,WebSearch,WebFetch',
-        '--no-session-persistence',
-      ];
+      // execFile-style: nessuna shell, l'istruzione passa come positional
+      // isolato dietro `--` — un'istruzione che inizia con `-` non può
+      // iniettare flag (issue #90; cfr. agents:dispatchBg).
+      const args = buildAiRunArgs(instruction);
       const proc = spawn('claude', args, {
         cwd: projectPath,
         env: claudeEnv(),

--- a/electron/modules/claude-cli-args.ts
+++ b/electron/modules/claude-cli-args.ts
@@ -1,0 +1,64 @@
+/**
+ * Costruzione degli argv per le invocazioni della CLI `claude`.
+ *
+ * `execFile`/`spawn` evitano la *shell* injection, ma non l'*argument*
+ * injection: qualsiasi valore che inizia con `-` verrebbe interpretato dalla
+ * CLI come flag (es. un prompt "--model x" altererebbe l'invocazione).
+ * Qui ogni positional utente è isolato dietro il sentinel end-of-options
+ * `--`, e i valori bound a flag (`--name`, `--agent`, `--model`) — che il
+ * sentinel non può proteggere — sono validati prima dell'uso.
+ */
+
+/** Modelli accettati dal dispatch background (le opzioni offerte dalla UI). */
+export const BG_MODEL_ALLOWLIST = ['opus', 'sonnet', 'haiku'] as const;
+
+/** Rifiuta i valori bound a flag che la CLI leggerebbe come flag a loro volta. */
+function assertNotFlagLike(value: string, label: string): void {
+  if (value.startsWith('-')) {
+    throw new Error(`Invalid ${label}: must not start with "-" (got ${JSON.stringify(value)})`);
+  }
+}
+
+export interface DispatchBgInput {
+  prompt: string;
+  name?: string;
+  agent?: string;
+  model?: string;
+}
+
+/** Argv per `claude --bg [...] -- <prompt>` (agents:dispatchBg). */
+export function buildDispatchBgArgs({ prompt, name, agent, model }: DispatchBgInput): string[] {
+  const args = ['--bg'];
+  if (name) {
+    assertNotFlagLike(name, 'session name');
+    args.push('--name', name);
+  }
+  if (agent) {
+    assertNotFlagLike(agent, 'agent name');
+    args.push('--agent', agent);
+  }
+  if (model) {
+    if (!(BG_MODEL_ALLOWLIST as readonly string[]).includes(model)) {
+      throw new Error(
+        `Invalid model ${JSON.stringify(model)}: expected one of ${BG_MODEL_ALLOWLIST.join(', ')}`
+      );
+    }
+    args.push('--model', model);
+  }
+  args.push('--', prompt);
+  return args;
+}
+
+/** Argv per `claude -p [...] -- <instruction>` (ai:run). */
+export function buildAiRunArgs(instruction: string): string[] {
+  return [
+    '-p',
+    '--model',
+    'Haiku',
+    '--allowedTools',
+    'Read,Glob,Grep,WebSearch,WebFetch',
+    '--no-session-persistence',
+    '--',
+    instruction,
+  ];
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claudelens-app",
-  "version": "2.1.2",
+  "version": "2.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claudelens-app",
-      "version": "2.1.2",
+      "version": "2.1.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/test/claude-cli-args.test.ts
+++ b/test/claude-cli-args.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildDispatchBgArgs,
+  buildAiRunArgs,
+  BG_MODEL_ALLOWLIST,
+} from '../electron/modules/claude-cli-args';
+
+describe('buildDispatchBgArgs', () => {
+  it('builds the minimal argv with the prompt behind --', () => {
+    expect(buildDispatchBgArgs({ prompt: 'fix the bug' })).toEqual(['--bg', '--', 'fix the bug']);
+  });
+
+  it('includes name/agent/model when provided', () => {
+    expect(
+      buildDispatchBgArgs({ prompt: 'do it', name: 'my task', agent: 'reviewer', model: 'opus' })
+    ).toEqual([
+      '--bg',
+      '--name',
+      'my task',
+      '--agent',
+      'reviewer',
+      '--model',
+      'opus',
+      '--',
+      'do it',
+    ]);
+  });
+
+  it('keeps a flag-looking prompt inert as a positional after --', () => {
+    const args = buildDispatchBgArgs({ prompt: '--model injected --add-dir /' });
+    const sentinel = args.indexOf('--');
+    expect(sentinel).toBeGreaterThan(-1);
+    expect(args.slice(sentinel)).toEqual(['--', '--model injected --add-dir /']);
+  });
+
+  it('omits empty optional values', () => {
+    expect(buildDispatchBgArgs({ prompt: 'p', name: '', agent: '', model: '' })).toEqual([
+      '--bg',
+      '--',
+      'p',
+    ]);
+  });
+
+  it('rejects a name starting with -', () => {
+    expect(() => buildDispatchBgArgs({ prompt: 'p', name: '--dangerously-skip' })).toThrow(
+      /session name/
+    );
+  });
+
+  it('rejects an agent starting with -', () => {
+    expect(() => buildDispatchBgArgs({ prompt: 'p', agent: '-x' })).toThrow(/agent name/);
+  });
+
+  it('accepts every allowlisted model and rejects anything else', () => {
+    for (const model of BG_MODEL_ALLOWLIST) {
+      expect(buildDispatchBgArgs({ prompt: 'p', model })).toContain(model);
+    }
+    expect(() => buildDispatchBgArgs({ prompt: 'p', model: '--model' })).toThrow(/Invalid model/);
+    expect(() => buildDispatchBgArgs({ prompt: 'p', model: 'gpt-4' })).toThrow(/Invalid model/);
+  });
+});
+
+describe('buildAiRunArgs', () => {
+  it('binds the instruction as the last positional after --', () => {
+    const args = buildAiRunArgs('summarize this');
+    expect(args.slice(-2)).toEqual(['--', 'summarize this']);
+    expect(args[0]).toBe('-p');
+    expect(args).toContain('--no-session-persistence');
+  });
+
+  it('keeps a flag-looking instruction inert', () => {
+    const args = buildAiRunArgs('--permission-mode bypassPermissions');
+    const sentinel = args.indexOf('--');
+    expect(args.slice(sentinel)).toEqual(['--', '--permission-mode bypassPermissions']);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a security vulnerability where user-provided values (prompt, instruction, name, agent, model) could be interpreted as CLI flags when passed to the `claude` command, allowing argument injection attacks.

## Changes

- **New module** `electron/modules/claude-cli-args.ts`:
  - `buildDispatchBgArgs()` — constructs validated argv for `claude --bg` invocations with the prompt isolated behind the `--` end-of-options sentinel
  - `buildAiRunArgs()` — constructs argv for `claude -p` invocations with the instruction isolated behind `--`
  - `BG_MODEL_ALLOWLIST` — allowlist of accepted model values (opus, sonnet, haiku)
  - Input validation that rejects flag-like values (starting with `-`) for name, agent, and model parameters

- **Updated** `electron/main.ts`:
  - `agents:dispatchBg` handler now uses `buildDispatchBgArgs()` instead of manually building argv
  - `ai:run` handler now uses `buildAiRunArgs()` instead of manually building argv
  - Both now properly isolate user input behind `--` to prevent flag injection

- **New test suite** `test/claude-cli-args.test.ts`:
  - Comprehensive tests for both builders covering normal cases, edge cases (flag-like prompts), validation errors, and allowlist enforcement

## Implementation Details

The vulnerability existed because user-provided values were passed directly as argv elements without protection. A prompt like `--model injected` would be interpreted as a flag rather than a positional argument. The fix uses the standard `--` end-of-options sentinel to mark where positional arguments begin, preventing any value from being interpreted as a flag. Additionally, values bound to actual flags (`--name`, `--agent`, `--model`) are validated before use to reject flag-like inputs that the sentinel cannot protect.

Addresses issue #90.

https://claude.ai/code/session_016UAnqtJtgP8H6nC3qMbNQe