### PR TITLE
fix(robustness): guard invalid dates + zero-width timescale in pure formatters

### DIFF
--- a/src/components/project/chat/graph/useForceLayout.ts
+++ b/src/components/project/chat/graph/useForceLayout.ts
@@ -9,7 +9,9 @@ export function createTimeScale(
   range: { from: number; to: number },
 ): { scale: TimeScale; invert: InverseTimeScale } {
   const span = domain.end - domain.start || 1
-  const px = range.to - range.from
+  // Guard a zero-width pixel range (e.g. an unmeasured/collapsed container):
+  // without it `invert` divides by zero and returns NaN. Mirrors `span || 1`.
+  const px = range.to - range.from || 1
   const scale: TimeScale = (t) => range.from + ((t - domain.start) / span) * px
   const invert: InverseTimeScale = (p) => domain.start + ((p - range.from) / px) * span
   return { scale, invert }
@@ -67,5 +69,6 @@ export function fmtDuration(ms: number): string {
 
 export function fmtClockTime(t: number): string {
   const d = new Date(t)
+  if (Number.isNaN(d.getTime())) return ''
   return d.toLocaleTimeString('it-IT', { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false })
 }

--- a/src/components/project/memory/utils.ts
+++ b/src/components/project/memory/utils.ts
@@ -40,7 +40,9 @@ export function readingTime(wordCount: number): string {
 }
 
 export function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString('it-IT', {
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) return ''
+  return date.toLocaleDateString('it-IT', {
     day: '2-digit', month: 'short', year: 'numeric',
   })
 }

--- a/src/components/project/utils.ts
+++ b/src/components/project/utils.ts
@@ -1,7 +1,9 @@
 export function fmt(n: number) { return n.toLocaleString('en-US') }
 export function fmtCost(n: number) { return '$' + n.toFixed(4) }
 export function fmtDate(d: string) {
-  return new Date(d).toLocaleString('it-IT', { dateStyle: 'medium', timeStyle: 'short' })
+  const date = new Date(d)
+  if (Number.isNaN(date.getTime())) return ''
+  return date.toLocaleString('it-IT', { dateStyle: 'medium', timeStyle: 'short' })
 }
 
 // Compact token count for metric chips: 1_500 → {value:'2',unit:'k'},

--- a/test/project-formatters.test.ts
+++ b/test/project-formatters.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { fmtDate } from '../src/components/project/utils';
+import { formatDate } from '../src/components/project/memory/utils';
+import { fmtClockTime, createTimeScale } from '../src/components/project/chat/graph/useForceLayout';
+
+// Robustness fixes from the #99 audit: pure date/scale formatters must not
+// leak "Invalid Date" into the UI, and the timeline scale must not divide by
+// zero. Assertions avoid locale/timezone-specific exact strings — they check
+// the guard behaviour (empty vs. non-"Invalid" output) and numeric validity.
+
+describe('fmtDate — invalid-date guard (#99)', () => {
+  it('formats a valid ISO timestamp', () => {
+    const out = fmtDate('2026-01-15T10:30:00Z');
+    expect(out).not.toBe('');
+    expect(out).not.toMatch(/Invalid/i);
+  });
+
+  it('returns an empty string for an unparseable value instead of "Invalid Date"', () => {
+    expect(fmtDate('not a date')).toBe('');
+    expect(fmtDate('')).toBe('');
+  });
+});
+
+describe('formatDate — invalid-date guard (#99)', () => {
+  it('formats a valid ISO timestamp', () => {
+    expect(formatDate('2026-01-15T10:30:00Z')).not.toMatch(/Invalid/i);
+  });
+
+  it('returns an empty string for an unparseable value', () => {
+    expect(formatDate('nope')).toBe('');
+  });
+});
+
+describe('fmtClockTime — invalid-date guard (#99)', () => {
+  it('formats a valid epoch timestamp', () => {
+    expect(fmtClockTime(Date.UTC(2026, 0, 15, 10, 30, 0))).not.toMatch(/Invalid/i);
+  });
+
+  it('returns an empty string for NaN instead of "Invalid Date"', () => {
+    expect(fmtClockTime(NaN)).toBe('');
+  });
+});
+
+describe('createTimeScale — zero-width range guard (#99)', () => {
+  it('does not return NaN from invert when the pixel range is zero-width', () => {
+    const { invert } = createTimeScale({ start: 0, end: 1000 }, { from: 40, to: 40 });
+    expect(Number.isNaN(invert(40))).toBe(false);
+  });
+
+  it('round-trips scale/invert for a normal range', () => {
+    const { scale, invert } = createTimeScale({ start: 0, end: 1000 }, { from: 0, to: 100 });
+    expect(scale(500)).toBeCloseTo(50);
+    expect(invert(50)).toBeCloseTo(500);
+  });
+});


### PR DESCRIPTION
Addresses part of the #99 robustness audit — small, localized, pure-function guards with test coverage.

## Fixes

| Guard | Location | Before → After |
|-------|----------|----------------|
| Invalid date | `src/components/project/utils.ts` `fmtDate` | leaks `"Invalid Date"` → returns `''` |
| Invalid date | `src/components/project/memory/utils.ts` `formatDate` | leaks `"Invalid Date"` → returns `''` |
| Invalid date | `src/components/project/chat/graph/useForceLayout.ts` `fmtClockTime` | leaks `"Invalid Date"` → returns `''` |
| Divide-by-zero | `useForceLayout.ts` `createTimeScale` | `invert()` → `NaN` on a zero-width pixel range → `px \|\| 1` |

The date guards mirror the one `export.tsx:turnTime` already has (`Number.isNaN(d.getTime())`). The `createTimeScale` guard mirrors the existing `span || 1`, protecting `invert()` when the container is unmeasured/collapsed (`range.to === range.from`).

## Tests

New `test/project-formatters.test.ts` covers the valid path plus the degenerate inputs (unparseable string, `NaN`, zero-width range) for all four guards. Assertions avoid locale/timezone-specific exact strings.

## Verification

- `npm test` — 313 passed / 3 skipped
- `npm run typecheck` — clean (both tsconfigs)
- `npm run lint` — 0 errors (13 pre-existing warnings, none in the changed files)

Remaining #99 items are untouched and left for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0126VPB4VG1Q2WJmKBzs4n9c)_