### PR TITLE
fix(robustness): NaN-safe comparators for task/session sort + bg in-flight count

### DIFF
--- a/electron/modules/bg-sessions-reader.ts
+++ b/electron/modules/bg-sessions-reader.ts
@@ -121,7 +121,8 @@ export function getBgSessions(): BgSession[] {
       template: (state.template as string) ?? '',
       inFlightTasks:
         state.inFlight && typeof state.inFlight === 'object'
-          ? Number((state.inFlight as { tasks?: number }).tasks ?? 0)
+          ? // `|| 0` coerces a non-numeric tasks value (NaN) back to 0.
+            Number((state.inFlight as { tasks?: number }).tasks ?? 0) || 0
           : 0,
       // Probe the pid rather than trusting its mere presence in the roster: a
       // crashed worker leaves a stale pid. Treat the state field as a secondary

--- a/electron/modules/cost-tracker.ts
+++ b/electron/modules/cost-tracker.ts
@@ -580,5 +580,11 @@ export async function getSessionList(projectPath: string): Promise<SessionSummar
 
   return parsed
     .filter((s): s is SessionSummary => s !== null)
-    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+    // NaN-safe: an empty/invalid `date` makes `new Date(x).getTime()` NaN and the
+    // comparator NaN → arbitrary order. Treat an unparseable date as oldest.
+    .sort((a, b) => {
+      const tb = new Date(b.date).getTime();
+      const ta = new Date(a.date).getTime();
+      return (Number.isNaN(tb) ? 0 : tb) - (Number.isNaN(ta) ? 0 : ta);
+    });
 }

--- a/electron/modules/tasks-reader.ts
+++ b/electron/modules/tasks-reader.ts
@@ -69,7 +69,14 @@ export async function getProjectTasks(projectPath: string, tasksDir: string): Pr
       const tasks = taskFiles
         .map(parseTaskFile)
         .filter((t): t is Task => t !== null)
-        .sort((a, b) => Number(a.id) - Number(b.id));
+        // NaN-safe: a non-numeric id would make `Number(id)` NaN and the whole
+        // comparator NaN → arbitrary order. Fall back to a stable string compare.
+        .sort((a, b) => {
+          const na = Number(a.id);
+          const nb = Number(b.id);
+          if (Number.isNaN(na) || Number.isNaN(nb)) return String(a.id).localeCompare(String(b.id));
+          return na - nb;
+        });
 
       if (tasks.length === 0) continue;
 


### PR DESCRIPTION
More of the #99 robustness audit — three small, localized guards so comparators/counters never go `NaN`.

## Fixes

| Guard | Location | Issue |
|-------|----------|-------|
| Non-numeric id | `tasks-reader.ts` (per-session task sort) | `Number(id)` on a non-numeric id → `NaN`, making the whole comparator `NaN` → arbitrary order. Now falls back to a stable `localeCompare`. |
| Empty/invalid date | `cost-tracker.ts` `getSessionList` sort | `new Date('').getTime()` → `NaN` → arbitrary order. An unparseable date is now treated as oldest. |
| Non-numeric count | `bg-sessions-reader.ts` `inFlightTasks` | `Number('abc')` → `NaN` shown as the in-flight count. `\|\| 0` coerces it back to 0. |

All three are defensive — the inputs are normally well-formed (numeric ids, a `mtime` date fallback, a numeric `tasks` field), but a malformed value shouldn't scramble a list or surface `NaN`. The comparators are inline in file-reading functions, so they're covered by the existing suite + the build rather than new dedicated tests.

## Verification (full CI reproduced locally on this commit)
- `npm run typecheck` — clean (both tsconfigs)
- `npm run lint` — 0 errors (13 pre-existing warnings)
- `npm test` — 313 passed / 3 skipped
- `npm run build` — ✓

## Note on the rest of #99
While picking this batch I audited the remaining items: several are already resolved (the `memory-writer` path guards and the `memory-reader` js-yaml frontmatter parsing landed in #122; the date/timescale guards in #135). The `correlateSessionAgents` 100-char prompt key is a **deliberate, test-documented tradeoff** (the dispatch prompt and the stored first message diverge past the head, so lengthening the key would break correlation) — left as-is. Remaining items are larger/riskier (transcript virtualization, `tsconfig.electron` strictness, CI `format:check`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0126VPB4VG1Q2WJmKBzs4n9c)_