### PR TITLE
fix(memory): updateTopic refuses a missing topic instead of creating a stray file (#99)

### DIFF
--- a/electron/modules/memory-writer.ts
+++ b/electron/modules/memory-writer.ts
@@ -126,6 +126,13 @@ export function updateTopic(memoryDir: string, filename: string, input: TopicInp
   validateTopicInput(input);
   const target = join(memoryDir, filename);
   assertWithin(memoryDir, target);
+  // Update must target an existing topic. Without this guard writeFileSync would
+  // silently CREATE the file, and updateLineInMemoryMd — which only rewrites an
+  // already-present index line — would leave it out of MEMORY.md: an orphaned,
+  // unindexed topic. Creation is createTopic's job (it indexes + dedupes names).
+  if (!existsSync(target)) {
+    throw new Error(`Cannot update topic "${filename}": it does not exist.`);
+  }
   writeFileSync(target, buildTopicFileContent(input), 'utf-8');
   updateLineInMemoryMd(join(memoryDir, 'MEMORY.md'), filename, input.description);
 }

--- a/test/memory.test.ts
+++ b/test/memory.test.ts
@@ -387,6 +387,21 @@ describe('updateTopic', () => {
     ).toThrow(/outside/);
     expect(existsSync(join(memoryDir, '..', 'escape.md'))).toBe(false);
   });
+
+  it('refuses to update a missing topic instead of creating a stray file', () => {
+    expect(() =>
+      updateTopic(memoryDir, 'user_ghost.md', {
+        name: 'Ghost',
+        description: 'd',
+        type: 'user',
+        content: 'body',
+      })
+    ).toThrow(/does not exist/);
+    // No file written, and nothing added to the (still-absent) index — update is
+    // strictly an update; creation goes through createTopic (which indexes it).
+    expect(existsSync(join(memoryDir, 'user_ghost.md'))).toBe(false);
+    expect(existsSync(join(memoryDir, 'MEMORY.md'))).toBe(false);
+  });
 });
 
 describe('deleteTopic', () => {


### PR DESCRIPTION
Closes the last small **Robustness** leftover from the audit tracking issue #99.

## The bug
`updateTopic` wrote its target with `writeFileSync` unconditionally, so calling it with a `filename` that doesn't exist **silently created** the file. But `updateLineInMemoryMd` only rewrites an *already-present* index line — it never adds one — so the freshly-created file was left out of `MEMORY.md`: an orphaned, unindexed topic. (`assertWithin` already guarded traversal; this is the remaining half of the #99 item.)

## The fix
Guard with `existsSync` and throw a clear error when the topic is missing. Creation stays `createTopic`'s job — it's the one that indexes the file in `MEMORY.md` and dedupes name→slug collisions. A new unit test asserts the throw *and* that neither the topic file nor `MEMORY.md` gets written.

```
electron/modules/memory-writer.ts | 7 +++++++
test/memory.test.ts               | 15 +++++++++++++++
```

## On the sibling #99 item (transcript virtualization)
Already handled in `main` via `content-visibility: auto` + `contain-intrinsic-size` on `.cl-turn` (`src/index.css`, added after the issue was filed). That's the right fit for this component: it lets Chromium skip layout/paint of off-screen turns **without unmounting them**, so native Ctrl+F, the CSS Custom Highlight API ranges, the scroll-spy `IntersectionObserver` and the auto-scroll `ResizeObserver` all keep working — a windowing library would break them by removing off-screen turns from the DOM. So there's nothing left to build there; the #99 checkbox is just stale.

## Testing
- `npm run typecheck` — clean
- `npm test` — 316 passed / 3 skipped (incl. the new `updateTopic` test)
- `npm run lint` — 0 errors (13 pre-existing warnings in untouched files)
- `npm run build` — succeeds

Refs #99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B6tz4zBhpWGS981KRnofSe)_