### PR TITLE
redesign(chat,terminal): move to glass-island visual language

### DIFF
--- a/src/components/project/chat/ChatView.tsx
+++ b/src/components/project/chat/ChatView.tsx
@@ -71,11 +71,10 @@ export function ChatView({
    *  embedded transcript to a turn. Null while unmounted / Terminal mode. */
   jumpToTurnRef?: React.MutableRefObject<((n: number) => void) | null>;
   /** Rendered inside the unified Terminal/Lens view: drop the own TopBar (the
-   *  unified frame provides chrome + the Terminal↔Lens switch), the right-edge
-   *  minimap (the Mission Control rail is the companion surface) and the
-   *  composer — this surface is read-only, the live session belongs to the
-   *  terminal's PTY. The floating control pill stays — it anchors to the chat
-   *  column. */
+   *  unified frame provides chrome + the Terminal↔Lens switch) and the composer
+   *  — this surface is read-only, the live session belongs to the terminal's
+   *  PTY. The floating control pill and the left TURNS capsule stay — they
+   *  anchor to the chat column. */
   embedded?: boolean;
 }) {
   const {
@@ -665,14 +664,13 @@ export function ChatView({
           onRemove={highlightLayer.removeCurrent}
         />
 
-        {!embedded && (
-          <FocusMinimap
-            items={minimapItems}
-            active={activeTurn}
-            matches={matchesFilter}
-            onJump={jumpToTurn}
-          />
-        )}
+        <FocusMinimap
+          items={minimapItems}
+          active={activeTurn}
+          matches={matchesFilter}
+          onJump={jumpToTurn}
+        />
+
 
         {controlPill(true)}
       </div>

--- a/src/components/project/chat/FocusMinimap.tsx
+++ b/src/components/project/chat/FocusMinimap.tsx
@@ -1,17 +1,32 @@
 import { useEffect, useRef, useState } from 'react';
 import type { CSSProperties } from 'react';
-import { MinimapItem, TurnDescriptor } from './utils';
+import { MinimapItem, TurnDescriptor, TurnVariant } from './utils';
 
-/** Right-edge timeline minimap (Focus layout). A hairline vertical track with
- *  one proportionally-placed dot per message turn — accent-coloured & larger for
- *  Claude/agent turns, muted & small for user turns. Labels surface on hover only
- *  so the chrome stays out of the way; click jumps, active dot is emphasised.
+/** Turn navigator capsule (design "2a · Isole di vetro") — a vertical glass pill
+ *  floating at the LEFT edge of the reading column. Top-to-bottom: a rotated
+ *  "TURNS" label, one tick bar per message turn (width/colour encode the turn
+ *  kind: wide ink for prompts, slim for Claude, tinted for agents/skills/…),
+ *  the active turn as a numbered accent circle (the scroll-spy cursor), and the
+ *  total turn count at the foot. Labels surface on hover only; click jumps.
  *
- *  Adaptive ruler: the track height is measured live, so when a session has many
- *  turns the per-dot spacing shrinks. Dot diameters and accent/active rings scale
- *  with that spacing (one dot per turn is always kept) — at high density the rail
- *  reads as a fine, evenly-gapped ruler instead of a crowded blob; at low density
- *  the dots stay full-size. */
+ *  Adaptive ruler: ticks are positioned proportionally inside a track whose
+ *  height grows with the turn count but is capped by the available viewport
+ *  height — a long session compresses into a fine ruler instead of overflowing. */
+
+/** Tick width per turn kind — prompts are landmarks, Claude turns are the grain. */
+function tickWidth(variant: TurnVariant): number {
+  if (variant === 'user') return 14;
+  if (variant === 'claude') return 9;
+  if (variant === 'notification') return 10;
+  return 12; // agent / skill / command / question / plan
+}
+
+/** Tick colour: regular conversation turns stay muted (the design's grey grain);
+ *  special turns (agent, skill, plan, …) keep their identity tint. */
+function tickColor(it: MinimapItem): string {
+  return it.variant === 'user' || it.variant === 'claude' ? 'var(--cl-ink-4)' : it.color;
+}
+
 export function FocusMinimap({
   items,
   active,
@@ -23,64 +38,65 @@ export function FocusMinimap({
   matches: (d: TurnDescriptor) => boolean;
   onJump: (n: number) => void;
 }) {
-  const trackRef = useRef<HTMLDivElement | null>(null);
-  const [trackH, setTrackH] = useState(0);
+  const railRef = useRef<HTMLElement | null>(null);
+  const [railH, setRailH] = useState(0);
 
   useEffect(() => {
-    const el = trackRef.current;
+    const el = railRef.current;
     if (!el) return;
-    const ro = new ResizeObserver(entries => setTrackH(entries[0].contentRect.height));
+    const ro = new ResizeObserver(entries => setRailH(entries[0].contentRect.height));
     ro.observe(el);
-    setTrackH(el.getBoundingClientRect().height);
+    setRailH(el.getBoundingClientRect().height);
     return () => ro.disconnect();
   }, []);
 
   if (items.length === 0) return null;
 
-  // Density factor t: 0 = cramped, 1 = roomy. The threshold is the *effective*
-  // dot width including its ring — a full accent dot is 9px + 3px ring/side = 15px,
-  // so we only reach full size once the gap clears ~18px; below that, dots and
-  // rings shrink so a visible gap always remains. Until the track is measured we
-  // assume roomy so dots never flash tiny on first paint.
-  const clamp01 = (x: number) => Math.max(0, Math.min(1, x));
-  const spacing = trackH > 0 && items.length > 1 ? trackH / (items.length - 1) : Infinity;
-  const t = clamp01((spacing - 3) / (18 - 3));
-  const lerp = (a: number, b: number, f = t) => +(a + (b - a) * f).toFixed(2);
-  // Rings are the main source of the "solid blob": only fade them in once the
-  // track is genuinely roomy (t > 0.5), so dense views stay ring-free dots.
-  const tr = clamp01((t - 0.5) * 2);
-  const railVars = {
-    '--dot': `${lerp(2, 7)}px`,
-    '--dot-accent': `${lerp(2.5, 9)}px`,
-    '--dot-active': `${lerp(7, 11)}px`, // floored at 7px so the cursor stays legible
-    '--ring': `${lerp(0, 3, tr)}px`,
-    '--ring-active': `${lerp(1, 3, tr)}px`,
-  } as CSSProperties;
+  // Capsule chrome (label + count + paddings/gaps) ≈ 96px; the track takes the
+  // rest. Preferred spacing is 12px per turn (the design's airy few-turn look),
+  // compressed down to whatever fits when the session is long.
+  const availableTrack = Math.max(60, railH - 96);
+  const trackH = Math.min(availableTrack, Math.max(48, (items.length - 1) * 12));
 
   return (
-    <nav className="cl-focus-rail" aria-label="Turn index">
-      <div ref={trackRef} className="cl-focus-rail-track" style={railVars}>
-        {items.map((it, i) => {
-          const top = items.length <= 1 ? 50 : (i / (items.length - 1)) * 100;
-          return (
-            <button
-              key={it.n}
-              type="button"
-              className="cl-focus-dot"
-              style={{ top: `${top}%`, '--c': it.color } as CSSProperties}
-              data-accent={it.variant !== 'user' || undefined}
-              data-active={active === it.n || undefined}
-              data-dim={!matches(it) || undefined}
-              onClick={() => onJump(it.n)}
-              title={`${String(it.n).padStart(2, '0')} · ${it.label} · ${it.time}`}
-              aria-label={`Jump to turn ${it.n}, ${it.label}`}
-            >
-              <span className="lbl">
-                {String(it.n).padStart(2, '0')} {it.label}
-              </span>
-            </button>
-          );
-        })}
+    <nav className="cl-focus-rail" aria-label="Turn index" ref={railRef}>
+      <div className="cl-turns-capsule">
+        <span className="cl-turns-cap-label" aria-hidden>
+          TURNS
+        </span>
+        <div className="cl-focus-rail-track" style={{ height: trackH }}>
+          {items.map((it, i) => {
+            const top = items.length <= 1 ? 50 : (i / (items.length - 1)) * 100;
+            const isActive = active === it.n;
+            const style = {
+              top: `${top}%`,
+              '--c': isActive ? undefined : tickColor(it),
+              '--w': isActive ? undefined : `${tickWidth(it.variant)}px`,
+            } as CSSProperties;
+            return (
+              <button
+                key={it.n}
+                type="button"
+                className={isActive ? 'cl-focus-current' : 'cl-focus-tick'}
+                style={style}
+                data-accent={(!isActive && it.variant !== 'user' && it.variant !== 'claude') || undefined}
+                data-dim={!matches(it) || undefined}
+                onClick={() => onJump(it.n)}
+                title={`${String(it.n).padStart(2, '0')} · ${it.label} · ${it.time}`}
+                aria-label={`Jump to turn ${it.n}, ${it.label}`}
+                aria-current={isActive ? 'true' : undefined}
+              >
+                {isActive && it.n}
+                <span className="lbl">
+                  {String(it.n).padStart(2, '0')} {it.label}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+        <span className="cl-turns-total" aria-label={`${items.length} turns`}>
+          {items.length}
+        </span>
       </div>
     </nav>
   );

--- a/src/components/project/terminal/MissionRail.tsx
+++ b/src/components/project/terminal/MissionRail.tsx
@@ -32,16 +32,17 @@ import { fmtCost, fmt } from '../utils';
  * The scrolling Mission Control rail beside the unified Terminal/Lens view.
  *
  * Not a flat tool feed (the TUI already prints every `⏺ Bash…` line — repeating
- * it would be a mirror), but the session's *meaningful units*, laid out as a
- * "bento" of cards (design: the "Chat display variants exploration", 03 · Bento):
- * a pinned vitals band of gauge cards — CONTEXT WINDOW ("how full is my
- * context?"), SPEND (cost + cache-savings ring) and TASKS (done/total ring) —
- * then a scrolling flow of AGENTS (violet card, rows click → full transcript),
- * SKILLS (pills, click → output), file CHANGES **grouped by repo area** with
- * proportional diff bars, the detailed TASKS list, and ENVIRONMENT (the session's
- * read-only setup from the SDK init — permission mode + capability counts, plus
- * any failed MCP). Empty sections are dropped; if everything is empty the rail
- * says so in one line.
+ * it would be a mirror), but the session's *meaningful units*, laid out as
+ * floating **glass islands** (design: "Chat UI variants", 2a · Isole di vetro):
+ * a borderless rail over a soft accent aura, with a pinned vitals band — the
+ * CONTEXT WINDOW island ("how full is my context?", conic aura + big %) and one
+ * vitals island pairing SPEND (cost + cache-savings ring) and TASKS (done/total
+ * ring) — then a scrolling flow of AGENTS (violet island, rows click → full
+ * transcript), SKILLS (pills, click → output), file CHANGES **grouped by repo
+ * area** with proportional diff bars, the detailed TASKS list, and ENVIRONMENT
+ * (a slim glass pill with the session's read-only setup from the SDK init —
+ * permission mode + capability counts — plus any failed MCP). Empty sections
+ * are dropped; if everything is empty the rail says so in one line.
  *
  * All of it derives from data the watcher already refreshes
  * (`sessions:chat`, `sessions:subagents`, `tasks:project`, `sessions:project`),
@@ -187,6 +188,18 @@ function groupByArea(changes: FileChange[], realPath: string): AreaGroup[] {
 
 /* ── presentational atoms ─────────────────────────────────────────────── */
 
+/** One floating glass island (design 2a) — the rail's card primitive. */
+const islandCard: CSSProperties = {
+  position: 'relative',
+  border: '1px solid var(--cl-glass-edge-top)',
+  borderRadius: 20,
+  padding: '15px 19px',
+  background: 'var(--cl-glass-bg)',
+  boxShadow: 'inset 0 1px 0 var(--cl-glass-highlight), var(--cl-glass-lift)',
+  WebkitBackdropFilter: 'blur(20px) saturate(1.8)',
+  backdropFilter: 'blur(20px) saturate(1.8)',
+};
+
 /** +N −N, tabular. */
 function DiffNum({
   added,
@@ -253,20 +266,16 @@ function RailBar({ added, removed, max = 56 }: { added: number; removed: number;
   );
 }
 
-/** Sticky section eyebrow: LABEL  n ───────── extra. */
+/** Island section eyebrow: LABEL  n ───────── extra. */
 function RailEyebrow({ label, n, extra }: { label: string; n?: ReactNode; extra?: ReactNode }) {
   return (
     <div
       className="font-mono"
       style={{
-        position: 'sticky',
-        top: 0,
-        zIndex: 3,
-        background: 'var(--cl-paper)',
         display: 'flex',
         alignItems: 'baseline',
         gap: 8,
-        padding: '14px 0 8px',
+        padding: '0 0 8px',
       }}
     >
       <span
@@ -334,9 +343,19 @@ function EnvironmentSection({ init }: { init: InitInfo | null }) {
   ].filter(c => c.n > 0);
   return (
     <>
-      <RailEyebrow label="ENVIRONMENT" />
-      {/* permission mode + capability counts */}
-      <div className="flex items-center" style={{ gap: 10, flexWrap: 'wrap', paddingBottom: 6 }}>
+      {/* slim env pill — permission mode + capability counts */}
+      <div
+        className="flex items-center"
+        style={{
+          gap: 10,
+          borderRadius: 999,
+          padding: '10px 16px',
+          background: 'var(--cl-glass-bg)',
+          border: '1px solid var(--cl-glass-edge-top)',
+          WebkitBackdropFilter: 'blur(18px) saturate(1.7)',
+          backdropFilter: 'blur(18px) saturate(1.7)',
+        }}
+      >
         <span
           className="font-mono"
           style={{
@@ -344,10 +363,10 @@ function EnvironmentSection({ init }: { init: InitInfo | null }) {
             fontWeight: 700,
             letterSpacing: '0.12em',
             padding: '3px 8px',
-            borderRadius: 6,
+            borderRadius: 999,
             color: danger ? 'var(--cl-on-accent)' : 'var(--cl-ink-2)',
-            background: danger ? 'var(--cl-danger)' : 'var(--cl-paper-2)',
-            border: `1px solid ${danger ? 'var(--cl-danger)' : 'var(--cl-line)'}`,
+            background: danger ? 'var(--cl-danger)' : 'var(--cl-glass-bg-strong)',
+            border: `1px solid ${danger ? 'var(--cl-danger)' : 'var(--cl-glass-edge-top)'}`,
           }}
           title="Resolved permission mode for this session"
         >
@@ -365,52 +384,50 @@ function EnvironmentSection({ init }: { init: InitInfo | null }) {
         ))}
       </div>
       {/* Only broken MCP connections earn a row — the one actionable MCP signal. */}
-      {failedMcp.map(s => (
-        <div
-          key={s.name}
-          className="flex items-center gap-2.5"
-          style={{ padding: '5px 0', borderBottom: '1px solid var(--cl-line-soft)' }}
-          title={`MCP server "${s.name}" failed to connect`}
-        >
-          <span
-            aria-hidden
-            className="shrink-0"
-            style={{ width: 7, height: 7, borderRadius: '50%', background: 'var(--cl-danger)' }}
-          />
-          <span
-            className="font-mono truncate min-w-0"
-            style={{ fontSize: 11.5, color: 'var(--cl-ink-2)' }}
-          >
-            {s.name}
-          </span>
-          <span
-            className="font-mono ml-auto shrink-0"
-            style={{ fontSize: 9, letterSpacing: '0.1em', color: 'var(--cl-danger)' }}
-          >
-            MCP FAILED
-          </span>
+      {failedMcp.length > 0 && (
+        <div style={{ ...islandCard, padding: '8px 16px' }}>
+          {failedMcp.map(s => (
+            <div
+              key={s.name}
+              className="flex items-center gap-2.5"
+              style={{ padding: '5px 0' }}
+              title={`MCP server "${s.name}" failed to connect`}
+            >
+              <span
+                aria-hidden
+                className="shrink-0"
+                style={{ width: 7, height: 7, borderRadius: '50%', background: 'var(--cl-danger)' }}
+              />
+              <span
+                className="font-mono truncate min-w-0"
+                style={{ fontSize: 11.5, color: 'var(--cl-ink-2)' }}
+              >
+                {s.name}
+              </span>
+              <span
+                className="font-mono ml-auto shrink-0"
+                style={{ fontSize: 9, letterSpacing: '0.1em', color: 'var(--cl-danger)' }}
+              >
+                MCP FAILED
+              </span>
+            </div>
+          ))}
         </div>
-      ))}
+      )}
     </>
   );
 }
 
-/* ── Bento mosaic (variant 03) ────────────────────────────────────────────
- * The rail's headline is a bento of cards adapted from the "Chat display
- * variants exploration" design (03 · Bento): a full-width CONTEXT WINDOW card,
- * a SPEND + TASKS gauge pair, then full-width AGENTS and SKILLS cards. The
- * gauges are pinned (vitals stay visible while the detail below scrolls); the
- * AGENTS/SKILLS cards keep the rail's interactivity (rows open a transcript /
- * skill output). The file-CHANGES section is kept below the bento, restyled. */
+/* ── Glass islands (variant 2a) ───────────────────────────────────────────
+ * The rail's headline is a stack of floating glass islands from the "Chat UI
+ * variants" design (2a · Isole di vetro): a full-width CONTEXT WINDOW island
+ * with a conic aura, one vitals island pairing the SPEND and TASKS gauges,
+ * then full-width AGENTS and SKILLS islands. The vitals are pinned (they stay
+ * visible while the detail below scrolls); the AGENTS/SKILLS islands keep the
+ * rail's interactivity (rows open a transcript / skill output). The
+ * file-CHANGES and TASKS sections live in their own islands below. */
 
-const bentoCard: CSSProperties = {
-  border: '1px solid var(--cl-line)',
-  borderRadius: 14,
-  padding: '15px 16px',
-  background: 'var(--cl-paper)',
-};
-
-/** Ring gauge (the bento's spend/tasks donut). `pct` 0–100 fills the ring;
+/** Ring gauge (the vitals island's spend/tasks donut). `pct` 0–100 fills the ring;
  *  `label` is the centred caption. r=19 → circumference ≈ 119.4. */
 function Donut({
   pct,
@@ -457,20 +474,32 @@ function Donut({
   );
 }
 
-/** Full-width CONTEXT WINDOW card — striped fill, "used · left · total" footer. */
+/** Full-width CONTEXT WINDOW island — conic aura, big %, glowing fill, and a
+ *  "used · left · total" footer. */
 function ContextCard({ ctx }: { ctx: ContextState | null }) {
   const pct = ctx?.pct ?? 0;
   const danger = !!ctx && pct >= 90;
+  const barColor = danger ? 'var(--cl-danger)' : 'var(--cl-accent)';
   return (
-    <div
-      style={{
-        ...bentoCard,
-        gridColumn: '1 / -1',
-        background:
-          'radial-gradient(70% 120% at 100% 0%, var(--cl-accent-soft), transparent 60%), var(--cl-paper)',
-      }}
-    >
-      <div className="flex items-baseline justify-between">
+    <div style={{ ...islandCard, padding: '18px 19px', overflow: 'hidden' }}>
+      {/* conic aura bleeding in from the top-right corner */}
+      <div
+        aria-hidden
+        style={{
+          position: 'absolute',
+          top: -70,
+          right: -60,
+          width: 190,
+          height: 190,
+          borderRadius: '50%',
+          background:
+            'conic-gradient(from 0deg, transparent, color-mix(in oklch, var(--cl-accent) 30%, transparent), transparent 60%)',
+          filter: 'blur(18px)',
+          opacity: 0.8,
+          pointerEvents: 'none',
+        }}
+      />
+      <div className="flex items-baseline justify-between" style={{ position: 'relative' }}>
         <span
           className="font-mono"
           style={{ fontSize: 9, letterSpacing: '0.2em', color: 'var(--cl-ink-4)' }}
@@ -479,41 +508,46 @@ function ContextCard({ ctx }: { ctx: ContextState | null }) {
         </span>
         <span
           style={{
-            font: '700 24px/1 var(--font-sans)',
-            letterSpacing: '-0.02em',
+            font: '700 40px/1 var(--font-sans)',
+            letterSpacing: '-0.035em',
             fontVariantNumeric: 'tabular-nums',
             color: danger ? 'var(--cl-danger)' : 'var(--cl-ink)',
           }}
         >
           {ctx ? pct : '—'}
-          <span style={{ fontSize: 13, color: 'var(--cl-ink-3)' }}>%</span>
+          <span style={{ fontSize: 16, color: 'var(--cl-ink-3)' }}>%</span>
         </span>
       </div>
       <div
         style={{
-          marginTop: 11,
-          height: 14,
-          borderRadius: 4,
-          background: 'var(--cl-paper-3)',
-          border: '1px solid var(--cl-line)',
+          position: 'relative',
+          marginTop: 12,
+          height: 12,
+          borderRadius: 999,
+          background: 'var(--cl-glass-bg-strong)',
+          border: '1px solid var(--cl-glass-edge-top)',
           overflow: 'hidden',
+          boxShadow: 'inset 0 1px 2px var(--cl-glass-shadow)',
         }}
       >
         <div
           style={{
             width: `${pct}%`,
             height: '100%',
+            borderRadius: 999,
             transition: 'width 0.4s ease',
             background: danger
               ? 'var(--cl-danger)'
-              : 'repeating-linear-gradient(90deg, var(--cl-accent) 0 7px, color-mix(in oklch, var(--cl-accent) 55%, var(--cl-paper)) 7px 10px)',
+              : 'linear-gradient(90deg, color-mix(in oklch, var(--cl-accent) 70%, white), var(--cl-accent))',
+            boxShadow: `0 0 10px color-mix(in oklch, ${barColor} 60%, transparent)`,
           }}
         />
       </div>
       <div
         className="font-mono"
         style={{
-          marginTop: 8,
+          position: 'relative',
+          marginTop: 9,
           fontSize: 9.5,
           fontVariantNumeric: 'tabular-nums',
           color: 'var(--cl-ink-4)',
@@ -531,7 +565,8 @@ function ContextCard({ ctx }: { ctx: ContextState | null }) {
   );
 }
 
-/** Compact gauge card (SPEND / TASKS) — donut left, stacked caption right. */
+/** One half of the vitals island (SPEND / TASKS) — donut left, stacked caption
+ *  right. `divided` adds the hairline that splits the island in two. */
 function GaugeCard({
   donut,
   label,
@@ -539,6 +574,7 @@ function GaugeCard({
   valueColor,
   sub,
   subColor,
+  divided = false,
 }: {
   donut: ReactNode;
   label: string;
@@ -546,9 +582,18 @@ function GaugeCard({
   valueColor: string;
   sub: string;
   subColor: string;
+  divided?: boolean;
 }) {
   return (
-    <div style={{ ...bentoCard, display: 'flex', alignItems: 'center', gap: 14 }}>
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        minWidth: 0,
+        ...(divided ? { borderLeft: '1px solid var(--cl-line-soft)', paddingLeft: 16 } : {}),
+      }}
+    >
       {donut}
       <div className="min-w-0">
         <div
@@ -559,7 +604,7 @@ function GaugeCard({
         </div>
         <div
           style={{
-            font: '700 21px/1 var(--font-sans)',
+            font: '700 19px/1 var(--font-sans)',
             fontVariantNumeric: 'tabular-nums',
             color: valueColor,
             marginTop: 4,
@@ -625,7 +670,7 @@ function OpenDefGlyph() {
   );
 }
 
-/** One agent row inside the AGENTS bento card. The row opens the full transcript
+/** One agent row inside the AGENTS island. The row opens the full transcript
  *  (when one exists on disk); a trailing button deep-links to the agent's
  *  definition when its `subagent_type` resolves to a known agent.
  *
@@ -764,7 +809,7 @@ function AgentRow({
   );
 }
 
-/** Full-width AGENTS card — violet-tinted, header cluster + interactive rows. */
+/** Full-width AGENTS island — violet-tinted glass, header cluster + interactive rows. */
 function AgentsCard({
   agents,
   agentDefOf,
@@ -780,11 +825,10 @@ function AgentsCard({
   return (
     <div
       style={{
-        ...bentoCard,
-        marginTop: 14,
+        ...islandCard,
         padding: '14px 16px',
-        borderColor: 'var(--cl-violet-soft)',
-        background: 'color-mix(in oklch, var(--cl-violet-soft) 28%, var(--cl-paper))',
+        borderColor: 'color-mix(in oklch, var(--cl-violet-soft) 55%, var(--cl-glass-edge-top))',
+        background: 'color-mix(in oklch, var(--cl-violet-soft) 26%, var(--cl-glass-bg))',
       }}
     >
       <div className="flex items-center" style={{ gap: 10, marginBottom: 4 }}>
@@ -889,7 +933,7 @@ function SkillPill({
   );
 }
 
-/** Full-width SKILLS card — a wrap of pills. */
+/** Full-width SKILLS island — a wrap of pills. */
 function SkillsCard({
   skills,
   onOpenTool,
@@ -900,7 +944,7 @@ function SkillsCard({
   onOpenSkillDef: (skill: Skill) => void;
 }) {
   return (
-    <div style={{ ...bentoCard, marginTop: 14, padding: '14px 16px' }}>
+    <div style={{ ...islandCard, padding: '14px 16px' }}>
       <div
         className="font-mono"
         style={{ fontSize: 9, letterSpacing: '0.18em', color: 'var(--cl-ink-4)', marginBottom: 11 }}
@@ -1080,12 +1124,14 @@ export function MissionRail({
   const empty =
     agents.length === 0 && skills.length === 0 && changes.length === 0 && tasks.length === 0;
 
+  // Borderless rail (design 2a): the islands float over a paper-2 canvas with a
+  // soft accent aura bleeding in from the top-right corner.
   const railWrap: CSSProperties = {
     width,
     flexShrink: 0,
     position: 'relative',
-    borderLeft: '1px solid var(--cl-line)',
-    background: 'var(--cl-paper)',
+    background:
+      'radial-gradient(60% 34% at 85% 0%, color-mix(in oklch, var(--cl-accent-soft) 55%, transparent), transparent 70%), var(--cl-paper-2)',
     display: 'flex',
     flexDirection: 'column',
     minHeight: 0,
@@ -1209,19 +1255,24 @@ export function MissionRail({
         <span
           aria-hidden
           className={liveStatus === 'busy' ? 'cl-run-dot' : liveStatus ? 'cl-live-dot' : undefined}
-          style={{
-            width: 7,
-            height: 7,
-            borderRadius: '50%',
-            background:
+          style={(() => {
+            const c =
               liveStatus === 'busy'
                 ? 'var(--cl-violet)'
                 : liveStatus === 'waiting'
                   ? 'var(--cl-accent)'
                   : liveStatus
                     ? 'var(--cl-ok)'
-                    : 'var(--cl-ink-4)',
-          }}
+                    : 'var(--cl-ink-4)';
+            return {
+              width: 7,
+              height: 7,
+              borderRadius: '50%',
+              background: c,
+              // the design's glowing status LED — unlit when the session is offline
+              boxShadow: liveStatus ? `0 0 8px ${c}` : undefined,
+            };
+          })()}
         />
         <span
           className="font-mono"
@@ -1273,51 +1324,68 @@ export function MissionRail({
         </button>
       </div>
 
-      {/* Bento vitals — CONTEXT + SPEND + TASKS gauges, pinned above the flow */}
+      {/* pinned vitals — the CONTEXT island + one SPEND/TASKS island above the flow */}
       <div
         className="shrink-0"
         style={{
-          borderTop: '1.5px solid var(--cl-ink)',
-          borderBottom: '1px solid var(--cl-line)',
           display: 'grid',
-          gridTemplateColumns: '1fr 1fr',
           gap: 12,
-          padding: '16px 22px',
+          padding: '2px 20px 14px',
         }}
       >
         <ContextCard ctx={ctx} />
-        <GaugeCard
-          donut={<Donut pct={savingsPct} color="var(--cl-ok)" label={`${savingsPct}%`} />}
-          label="SPEND"
-          value={summary ? fmtCost(summary.estimatedCost) : '—'}
-          valueColor="var(--cl-accent-ink)"
-          sub={savings > 0 ? `cache −${fmtCost(savings)}` : 'cache savings'}
-          subColor="var(--cl-ok)"
-        />
-        <GaugeCard
-          donut={
-            <Donut
-              pct={tasks.length > 0 ? Math.round((doneTasks / tasks.length) * 100) : 0}
-              color="var(--cl-ink)"
-              label={tasks.length > 0 ? `${doneTasks}/${tasks.length}` : '—'}
-            />
-          }
-          label="TASKS"
-          value={tasks.length > 0 ? `${Math.round((doneTasks / tasks.length) * 100)}%` : '—'}
-          valueColor="var(--cl-ink)"
-          sub={
-            runningTasks > 0
-              ? `${runningTasks} running`
-              : tasks.length > 0
-                ? `${tasks.length - doneTasks} left`
-                : 'no tasks yet'
-          }
-          subColor="var(--cl-ink-4)"
-        />
+        <div
+          style={{
+            ...islandCard,
+            display: 'grid',
+            gridTemplateColumns: '1fr 1fr',
+            gap: 16,
+          }}
+        >
+          <GaugeCard
+            donut={<Donut pct={savingsPct} color="var(--cl-ok)" label={`${savingsPct}%`} />}
+            label="SPEND"
+            value={summary ? fmtCost(summary.estimatedCost) : '—'}
+            valueColor="var(--cl-accent-ink)"
+            sub={savings > 0 ? `cache −${fmtCost(savings)}` : 'cache savings'}
+            subColor="var(--cl-ok)"
+          />
+          <GaugeCard
+            donut={
+              <Donut
+                pct={tasks.length > 0 ? Math.round((doneTasks / tasks.length) * 100) : 0}
+                color="var(--cl-ink)"
+                label={tasks.length > 0 ? `${doneTasks}/${tasks.length}` : '—'}
+              />
+            }
+            label="TASKS"
+            value={tasks.length > 0 ? `${Math.round((doneTasks / tasks.length) * 100)}%` : '—'}
+            valueColor="var(--cl-ink)"
+            sub={
+              runningTasks > 0
+                ? `${runningTasks} running`
+                : tasks.length > 0
+                  ? `${tasks.length - doneTasks} left`
+                  : 'no tasks yet'
+            }
+            subColor="var(--cl-ink-4)"
+            divided
+          />
+        </div>
       </div>
 
-      {/* scrolling flow */}
-      <div style={{ flex: 1, minHeight: 0, overflowY: 'auto', padding: '0 22px 22px' }}>
+      {/* scrolling flow — a stack of islands */}
+      <div
+        style={{
+          flex: 1,
+          minHeight: 0,
+          overflowY: 'auto',
+          padding: '0 20px 20px',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 12,
+        }}
+      >
         {!sessionId && (
           <p className="cl-transcript-state">Waiting for the CLI session to register…</p>
         )}
@@ -1332,7 +1400,7 @@ export function MissionRail({
           </p>
         )}
 
-        {/* AGENTS — bento card, rows → transcript, trailing button → definition */}
+        {/* AGENTS — glass island, rows → transcript, trailing button → definition */}
         {agents.length > 0 && (
           <AgentsCard
             agents={agents}
@@ -1342,14 +1410,14 @@ export function MissionRail({
           />
         )}
 
-        {/* SKILLS — bento card, pills → output / definition / tool call */}
+        {/* SKILLS — glass island, pills → output / definition / tool call */}
         {skills.length > 0 && (
           <SkillsCard skills={skills} onOpenTool={onOpenTool} onOpenSkillDef={onOpenSkillDef} />
         )}
 
-        {/* CHANGES — grouped by repo area (comfortable) or a flat list (compact) */}
+        {/* CHANGES island — grouped by repo area (comfortable) or a flat list (compact) */}
         {changes.length > 0 && (
-          <>
+          <section style={{ ...islandCard, padding: '14px 16px' }}>
             <RailEyebrow
               label="CHANGES"
               n={changes.length}
@@ -1381,12 +1449,12 @@ export function MissionRail({
                     {g.files.map(renderFileRow)}
                   </div>
                 ))}
-          </>
+          </section>
         )}
 
-        {/* TASKS */}
+        {/* TASKS island */}
         {tasks.length > 0 && (
-          <>
+          <section style={{ ...islandCard, padding: '14px 16px' }}>
             <RailEyebrow label="TASKS" n={`${doneTasks}/${tasks.length}`} />
             {tasks.map(t => {
               // Extra detail the dedicated Tasks page shows: live activeForm,
@@ -1526,10 +1594,10 @@ export function MissionRail({
                 </div>
               );
             })}
-          </>
+          </section>
         )}
 
-        {/* ENVIRONMENT — read-only session setup, kept below the bento + changes */}
+        {/* ENVIRONMENT — slim glass pill with the read-only session setup */}
         <EnvironmentSection init={init} />
       </div>
     </aside>

--- a/src/index.css
+++ b/src/index.css
@@ -2822,162 +2822,253 @@ body {
   filter: saturate(0.4);
 }
 
-/* ── V2 "Outline + Focus" chat content alignment ────────────────────────
-   The reading column drops the continuous left rail/spine, pulls the role
-   orb inline into each turn header, and closes the header row with a
-   trailing hairline rule — matching the design's center Focus column. The
-   article measure tightens and timestamps fall away (the model tag stays). */
+/* ── "Isole di vetro" (design 2a) — glass-island message stream ─────────
+   Each turn is a floating glass card in a 48px-guttered grid: the rail keeps
+   the role avatar (32px rounded tile) with the turn number beneath it; the
+   body is a translucent island — assistant cards carry a soft accent aura in
+   the top-right corner. Timestamps ride the right edge of the in-card header.
+   Command / skill / question / plan / notification turns keep flat bodies
+   (their content is already its own card). */
 .cl-chat-reading .cl-transcript-inner::before {
   display: none; /* no continuous timeline spine */
 }
 .cl-chat-reading .cl-transcript-inner {
-  max-width: 880px;
+  max-width: 920px;
   margin: 0 auto;
   padding: 30px 24px 140px;
 }
 .cl-chat-reading .cl-turn {
-  grid-template-columns: minmax(0, 1fr);
+  grid-template-columns: 48px minmax(0, 1fr);
   gap: 0;
+  margin-bottom: 18px;
 }
-/* the rail collapses to just the orb, pulled inline at the header's left */
 .cl-chat-reading .cl-turn-rail {
-  position: absolute;
-  left: 0;
-  top: 1px;
-  flex-direction: row;
-  padding-top: 0;
-  align-self: auto;
+  padding-top: 14px;
+  gap: 7px;
 }
-.cl-chat-reading .cl-turn-index,
 .cl-chat-reading .cl-turn-spine {
   display: none;
 }
 .cl-chat-reading .cl-turn-orb {
-  width: 20px;
-  height: 20px;
-  border-radius: 6px;
-  font-size: 9.5px;
+  width: 32px;
+  height: 32px;
+  border-radius: 10px;
+  font-size: 12px;
 }
+/* every island shows who's speaking — continuation turns keep their avatar */
+.cl-chat-reading .cl-turn--continuation .cl-turn-orb {
+  opacity: 1;
+  pointer-events: auto;
+}
+.cl-chat-reading .cl-turn--continuation .cl-turn-index {
+  visibility: visible;
+}
+.cl-chat-reading .cl-turn--continuation .cl-turn-rail {
+  padding-top: 14px;
+}
+.cl-chat-reading .cl-turn--tool-only {
+  margin-top: 0;
+}
+/* flat turns (command / skill / question / plan / notification) align their
+   content with the island tops */
 .cl-chat-reading .cl-turn-body {
-  padding-top: 0;
+  padding: 12px 0 0;
 }
+/* the glass island — conversation turns only */
+.cl-chat-reading .cl-turn--user .cl-turn-body,
+.cl-chat-reading .cl-turn--claude .cl-turn-body,
+.cl-chat-reading .cl-turn--agent .cl-turn-body {
+  padding: 15px 20px 16px;
+  border-radius: 18px;
+  border: 1px solid var(--cl-glass-edge-top);
+  background: var(--cl-glass-bg);
+  box-shadow:
+    inset 0 1px 0 var(--cl-glass-highlight),
+    var(--cl-glass-lift);
+  -webkit-backdrop-filter: blur(18px) saturate(1.7);
+  backdrop-filter: blur(18px) saturate(1.7);
+}
+/* assistant islands carry the soft accent aura in the top-right corner */
+.cl-chat-reading .cl-turn--claude .cl-turn-body,
+.cl-chat-reading .cl-turn--agent .cl-turn-body {
+  background:
+    radial-gradient(
+      55% 90% at 100% 0%,
+      color-mix(in oklch, var(--cl-accent-soft) 80%, transparent),
+      transparent 60%
+    ),
+    var(--cl-glass-bg);
+}
+/* header inside the island */
 .cl-chat-reading .cl-turn-head {
-  position: relative;
-  padding-left: 28px; /* clear the inline orb */
-  min-height: 20px;
-  margin-bottom: 14px;
+  min-height: 0;
+  margin-bottom: 10px;
 }
 .cl-chat-reading .cl-turn-who {
-  font-size: 10px;
-  letter-spacing: 0.16em;
+  font-size: 10.5px;
+  letter-spacing: 0.08em;
 }
-/* drop the timestamp + its separator; keep the model tag (no leading dot) */
-.cl-chat-reading .cl-turn-head time,
-.cl-chat-reading .cl-turn-head .cl-turn-sep:not(.cl-turn-sep--model),
-.cl-chat-reading .cl-turn-sep--model {
+/* CLAUDE wordmark — accent gradient text (agent turns keep their own tint) */
+.cl-chat-reading .cl-turn--claude .cl-turn-who {
+  background: linear-gradient(90deg, var(--cl-accent-ink), var(--cl-accent));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+/* timestamp rides the right edge of the header; the separator dots fall away */
+.cl-chat-reading .cl-turn-sep {
   display: none;
 }
-/* trailing hairline rule closes the header row */
-.cl-chat-reading .cl-turn-head::after {
-  content: '';
-  flex: 1;
-  height: 1px;
-  min-width: 24px;
-  margin-left: 10px;
-  background: var(--cl-line);
+.cl-chat-reading .cl-turn-head time {
+  order: 90;
+  margin-left: auto;
 }
-.cl-chat-reading .cl-turn--continuation .cl-turn-head::after {
-  display: none;
+.cl-chat-reading .cl-turn-copy {
+  order: 91;
+  margin-left: 0;
 }
-/* neutralise the auto-margins that would eat the hairline; the hover actions
-   float over the right end of the rule instead of pushing it out */
-.cl-chat-reading .cl-turn-copy,
+.cl-chat-reading .cl-turn-export {
+  order: 92;
+}
 .cl-chat-reading .cl-turn-tool-count {
   margin-left: 0;
 }
-.cl-chat-reading .cl-turn-copy,
-.cl-chat-reading .cl-turn-export {
-  position: absolute;
-  top: 0;
-  background: var(--cl-paper);
+/* header pills go glassy inside the island */
+.cl-chat-reading .cl-turn-tools-hidden-badge {
+  background: var(--cl-glass-bg);
+  border-color: var(--cl-glass-edge-top);
 }
-.cl-chat-reading .cl-turn-export {
-  right: 0;
+/* file chips → small glass pills (the design's MD chips) */
+.cl-chat-reading .cl-turn-files {
+  margin-top: 12px;
+  gap: 6px;
 }
-.cl-chat-reading .cl-turn-copy {
-  right: 24px;
+.cl-chat-reading .cl-file-chip {
+  gap: 4px;
+  padding: 3px 8px;
+  background: var(--cl-glass-bg);
+  border: 1px solid var(--cl-glass-edge-top);
+}
+/* standalone "tools hidden" rows align with the island column */
+.cl-chat-reading .cl-turn-tools-hidden {
+  margin: 0 0 18px 48px;
 }
 
-/* right-edge minimap timeline — a hairline track with proportional dots */
+/* left-edge turn navigator — the "TURNS" glass capsule (design 2a): rotated
+   label on top, one tick bar per turn, the active turn as a numbered accent
+   circle, the total count at the foot. Ticks are positioned proportionally in
+   a track whose height adapts to the turn count (see FocusMinimap.tsx). */
 .cl-focus-rail {
   position: absolute;
   top: 0;
-  right: 0;
+  left: 0;
   bottom: 0;
-  width: 46px;
+  width: 64px;
   display: flex;
+  align-items: center;
   justify-content: center;
   padding: 64px 0 104px;
   pointer-events: none;
   z-index: 12;
 }
+.cl-turns-capsule {
+  pointer-events: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  max-height: 100%;
+  padding: 14px 9px;
+  border-radius: 999px;
+  background: var(--cl-glass-bg);
+  border: 1px solid var(--cl-glass-edge-top);
+  box-shadow:
+    inset 0 1px 0 var(--cl-glass-highlight),
+    var(--cl-glass-lift);
+  -webkit-backdrop-filter: blur(20px) saturate(1.8);
+  backdrop-filter: blur(20px) saturate(1.8);
+}
+.cl-turns-cap-label {
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+  font: 700 8px var(--font-mono);
+  letter-spacing: 0.14em;
+  color: var(--cl-ink-4);
+}
+.cl-turns-total {
+  font: 600 8.5px var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  color: var(--cl-ink-4);
+}
 .cl-focus-rail-track {
   position: relative;
-  width: 2px;
-  border-radius: 2px;
-  background: var(--cl-line);
-  pointer-events: auto;
-  /* Adaptive ruler sizes — set inline by FocusMinimap from the measured
-     per-dot spacing; these are the roomy (low-density) fallbacks. */
-  --dot: 7px;
-  --dot-accent: 9px;
-  --dot-active: 11px;
-  --ring: 3px;
-  --ring-active: 3px;
+  width: 24px;
+  flex: 0 1 auto;
 }
-.cl-focus-dot {
+/* one tick bar per turn — width/colour set inline (--w/--c) by the component */
+.cl-focus-tick {
   position: absolute;
   left: 50%;
-  width: var(--dot);
-  height: var(--dot);
+  width: var(--w, 10px);
+  height: 3px;
   padding: 0;
   border: 0;
-  border-radius: 50%;
-  background: var(--c);
+  border-radius: 2px;
+  background: var(--c, var(--cl-ink-4));
+  opacity: 0.4;
   transform: translate(-50%, -50%);
   cursor: pointer;
   transition:
-    width 0.12s,
-    height 0.12s,
-    box-shadow 0.18s,
-    opacity 0.2s;
+    opacity 0.15s,
+    width 0.12s;
 }
-/* Invisible hit area keeps tiny high-density dots easy to hover/click. */
-.cl-focus-dot::before {
+.cl-focus-tick[data-accent] {
+  opacity: 0.62;
+}
+.cl-focus-tick:hover {
+  opacity: 0.9;
+}
+.cl-focus-tick[data-dim] {
+  opacity: 0.14;
+}
+/* Invisible hit area keeps dense ticks easy to hover/click. */
+.cl-focus-tick::before {
   content: '';
   position: absolute;
   left: 50%;
   top: 50%;
-  width: 16px;
-  height: 16px;
+  width: 26px;
+  height: 14px;
   transform: translate(-50%, -50%);
 }
-.cl-focus-dot[data-accent] {
-  width: var(--dot-accent);
-  height: var(--dot-accent);
-  box-shadow: 0 0 0 var(--ring) color-mix(in oklch, var(--c) 18%, transparent);
-}
-.cl-focus-dot[data-active] {
-  width: var(--dot-active);
-  height: var(--dot-active);
-  box-shadow: 0 0 0 var(--ring-active) color-mix(in oklch, var(--c) 30%, transparent);
-}
-.cl-focus-dot[data-dim] {
-  opacity: 0.3;
-}
-.cl-focus-dot .lbl {
+/* the active turn — numbered accent circle, the scroll-spy cursor */
+.cl-focus-current {
   position: absolute;
-  right: calc(100% + 10px);
+  left: 50%;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: 0;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transform: translate(-50%, -50%);
+  background: var(--cl-accent);
+  color: var(--cl-on-accent);
+  font: 700 9.5px var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  box-shadow:
+    0 0 0 3px color-mix(in oklch, var(--cl-accent) 25%, transparent),
+    0 4px 10px -3px color-mix(in oklch, var(--cl-accent) 60%, transparent);
+  cursor: pointer;
+  z-index: 2;
+}
+/* hover label — to the right of the capsule */
+.cl-focus-tick .lbl,
+.cl-focus-current .lbl {
+  position: absolute;
+  left: calc(100% + 14px);
   top: 50%;
   transform: translateY(-50%);
   white-space: nowrap;
@@ -2993,8 +3084,10 @@ body {
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.15s;
+  z-index: 3;
 }
-.cl-focus-dot:hover .lbl {
+.cl-focus-tick:hover .lbl,
+.cl-focus-current:hover .lbl {
   opacity: 1;
 }
 
@@ -3032,14 +3125,14 @@ body {
   bottom: 184px;
 }
 /* Embedded Lens (Terminal ↔ Lens split): no composer (so `data-composer` is
-   absent) and no minimap — the mission rail lives in its own flex column. Clip
-   any horizontal overflow so a turn can never bleed under the rail, and let the
-   reading column run wider since there's no minimap gutter to reserve. */
+   absent) — the mission rail lives in its own flex column. Clip any horizontal
+   overflow so a turn can never bleed under the rail; the reading column keeps
+   a slightly wider run but leaves the left gutter for the TURNS capsule. */
 .cl-chat-workspace--focus:not([data-composer]) .cl-chat-feed {
   overflow-x: hidden;
 }
 .cl-chat-workspace--focus:not([data-composer]) .cl-chat-reading {
-  width: 90%;
+  width: 86%;
 }
 .cl-composer {
   position: absolute;
@@ -4038,7 +4131,8 @@ body {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .cl-focus-dot,
+  .cl-focus-tick,
+  .cl-focus-current,
   .cl-pill-filter,
   .cl-pill-more,
   .cl-pill-dock,
@@ -8667,7 +8761,8 @@ button.cl-task-group-head:disabled {
     transparent 100%
   );
 }
-:root[data-theme='dark'] .cl-focus-dot .lbl {
+:root[data-theme='dark'] .cl-focus-tick .lbl,
+:root[data-theme='dark'] .cl-focus-current .lbl {
   box-shadow: 0 8px 20px -8px oklch(0 0 0 / 0.6);
 }
 


### PR DESCRIPTION
## What changed

- moves chat and Mission Control surfaces to the glass-island visual language
- refines the focus minimap and terminal rail hierarchy
- updates the shared styling needed by those surfaces

## Why

The chat and terminal experience needed a more coherent visual hierarchy and a consistent operational surface.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`
- `git diff --check`

