### PR TITLE
chore(claude): enable GitHub plugin in project settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "github@claude-plugins-official": true
+  }
+}


### PR DESCRIPTION
## What changed

- enables the GitHub plugin in the project-scoped Claude configuration

## Why

Repository agents can use the shared GitHub integration without requiring an additional local configuration change.

## Validation

- configuration reviewed as an isolated project-scoped change
- full local CI-equivalent checks passed on the complete change stack

