### PR TITLE
chore: add local app test driver

### DIFF
--- a/.claude/skills/run-app/SKILL.md
+++ b/.claude/skills/run-app/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: run-app
+description: Launch and drive the ClaudeLens Electron app (mock data) via a Playwright REPL to verify UI changes or take screenshots.
+---
+
+Drive ClaudeLens with the REPL at `.claude/skills/run-app/driver.mjs`.
+Default launch uses `SCREENSHOT_MODE` (mock fixtures from
+`electron/screenshotFixtures.ts` — no real `~/.claude/` reads); `launch real`
+uses real data.
+
+## Setup (from repo root)
+
+```bash
+npx tsc -p tsconfig.electron.json          # build main/preload
+npx vite --port 5173 &                     # renderer dev server
+```
+
+## Run
+
+Interactive: `node .claude/skills/run-app/driver.mjs`
+
+For agents, wrap in tmux and poll the prompt:
+
+```bash
+tmux new-session -d -s cl -x 200 -y 50
+tmux send-keys -t cl 'cd <repo> && node .claude/skills/run-app/driver.mjs' Enter
+timeout 20 bash -c 'until tmux capture-pane -t cl -p | grep -q "driver>"; do sleep 0.2; done'
+tmux send-keys -t cl 'launch' Enter
+timeout 60 bash -c 'until tmux capture-pane -t cl -p | grep -q "launched:"; do sleep 0.2; done'
+tmux send-keys -t cl 'ss home' Enter
+```
+
+Screenshots land in `/tmp/claudelens-shots/` (override: `SCREENSHOT_DIR`).
+**Always open and look at the screenshots** — a blank frame means launch failed.
+Quit with `quit` and kill the Vite process when done.
+
+## Commands
+
+| command | effect |
+|---|---|
+| `launch [real]` | start app (mock data; `real` = real `~/.claude/`) |
+| `ss [name]` | screenshot → `$SCREENSHOT_DIR/<name>.png` |
+| `click-text <text>` | DOM-click button/link/card by text (exact, then substring) |
+| `click <css>` / `wait <css>` | DOM-click / wait for selector |
+| `text [css]` | print innerText (body if omitted) |
+| `eval <js>` | evaluate in page, print JSON |
+| `theme [light\|dark]` | force `data-theme` |
+| `quit` | close app and exit |
+
+## Gotchas
+
+- Clicks go through `page.evaluate(el.click())`, not coordinates — reliable
+  with the app's custom chrome. Navigation is client-side state (no router):
+  reach views by clicking like a user (e.g. `click-text webapp` →
+  `click-text Teams` → `click-text Open team`).
+- The window needs ~2.5s after `domcontentloaded` (baked into `launch`);
+  give another ~1s after each navigation click before screenshotting.
+- On Linux add xvfb (`xvfb-run -a node …`); `--no-sandbox` is already applied.

--- a/.claude/skills/run-app/driver.mjs
+++ b/.claude/skills/run-app/driver.mjs
@@ -1,0 +1,129 @@
+/* global console, document, process */
+
+// REPL driver for ClaudeLens: launches the Electron app (SCREENSHOT_MODE mock
+// data by default) and exposes stdin commands for agents/humans to drive the UI.
+// Prereqs: `npx tsc -p tsconfig.electron.json` done and Vite running on :5173.
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import * as readline from 'node:readline';
+import { pathToFileURL } from 'node:url';
+
+const APP_DIR = path.resolve(import.meta.dirname, '../../..');
+const SHOT_DIR = process.env.SCREENSHOT_DIR || '/tmp/claudelens-shots';
+fs.mkdirSync(SHOT_DIR, { recursive: true });
+
+const { _electron: electron } = (
+  await import(pathToFileURL(path.join(APP_DIR, 'node_modules/playwright-core/index.js')))
+).default;
+
+const electronBin =
+  process.platform === 'darwin'
+    ? path.join(APP_DIR, 'node_modules/electron/dist/Electron.app/Contents/MacOS/Electron')
+    : path.join(APP_DIR, 'node_modules/electron/dist/electron');
+
+let app = null;
+let page = null;
+
+const COMMANDS = {
+  async launch(mode) {
+    if (app) return console.log('already launched');
+    app = await electron.launch({
+      executablePath: electronBin,
+      args: process.platform === 'linux' ? ['--no-sandbox', APP_DIR] : [APP_DIR],
+      env: { ...process.env, ...(mode === 'real' ? {} : { SCREENSHOT_MODE: 'true' }) },
+      timeout: 30_000,
+    });
+    page = await app.firstWindow();
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.waitForLoadState('domcontentloaded');
+    await page.waitForTimeout(2500);
+    console.log('launched:', page.url());
+  },
+  async ss(name) {
+    const f = path.join(SHOT_DIR, `${name || 'ss-' + Date.now()}.png`);
+    await page.screenshot({ path: f });
+    console.log('shot:', f);
+  },
+  // DOM click (not coordinates): exact text match first, then substring.
+  async 'click-text'(text) {
+    const r = await page.evaluate(t => {
+      const els = [...document.querySelectorAll('button, a, [role="button"], .cl-tile, [class*=card]')];
+      const el = els.find(e => e.textContent?.trim() === t) ?? els.find(e => e.textContent?.includes(t));
+      if (!el) return 'NOT_FOUND';
+      el.click();
+      return 'OK:' + el.tagName;
+    }, text);
+    console.log('click-text', JSON.stringify(text), '→', r);
+  },
+  async click(sel) {
+    const r = await page.evaluate(s => {
+      const el = document.querySelector(s);
+      if (!el) return 'NOT_FOUND';
+      el.click();
+      return 'OK';
+    }, sel);
+    console.log('click', sel, '→', r);
+  },
+  async wait(sel) {
+    try {
+      await page.waitForSelector(sel, { timeout: 10_000 });
+      console.log('found:', sel);
+    } catch {
+      console.log('TIMEOUT:', sel);
+    }
+  },
+  async text(sel) {
+    console.log(
+      await page.evaluate(s => (s ? document.querySelector(s) : document.body)?.innerText ?? '(null)', sel || null)
+    );
+  },
+  async eval(expr) {
+    try {
+      console.log(JSON.stringify(await page.evaluate(expr)));
+    } catch (e) {
+      console.log('ERROR:', e.message);
+    }
+  },
+  async theme(t) {
+    await page.evaluate(v => document.documentElement.setAttribute('data-theme', v), t || 'dark');
+    console.log('theme:', t || 'dark');
+  },
+  async quit() {
+    if (app) await app.close().catch(() => {});
+    app = null;
+    page = null;
+  },
+  help() {
+    console.log('commands:', Object.keys(COMMANDS).join(', '));
+  },
+};
+
+// Raw fd read: Electron steals process.stdin otherwise.
+const stdin = fs.createReadStream(null, { fd: fs.openSync('/dev/stdin', 'r') });
+const rl = readline.createInterface({ input: stdin, output: process.stdout, prompt: 'driver> ' });
+rl.on('line', async line => {
+  const [cmd, ...rest] = line.trim().split(/\s+/);
+  const fn = COMMANDS[cmd];
+  if (!cmd) return rl.prompt();
+  if (!fn) console.log('unknown:', cmd, '— try: help');
+  else if (cmd !== 'launch' && cmd !== 'help' && cmd !== 'quit' && !page) console.log('ERROR: launch first');
+  else {
+    try {
+      await fn(rest.join(' '));
+    } catch (e) {
+      console.log('ERROR:', e.message);
+    }
+  }
+  if (cmd === 'quit') {
+    rl.close();
+    process.exit(0);
+  }
+  rl.prompt();
+});
+rl.on('close', async () => {
+  await COMMANDS.quit();
+  process.exit(0);
+});
+
+console.log('ClaudeLens driver — "launch" to start, "help" for commands');
+rl.prompt();


### PR DESCRIPTION
## What changed

- adds a project skill for launching ClaudeLens with screenshot fixtures
- adds a Playwright-based interactive Electron driver for navigation, screenshots, text inspection, and theme switching

## Why

UI changes need a repeatable local verification path that does not depend on personal Claude data.

## Validation

- `npm run lint`
- driver globals declared for both Node and page-evaluation contexts
- full local CI-equivalent checks passed on the complete change stack

