### PR TITLE
chore: ignore local architecture document

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ npm-debug.log*
 .claude/settings.local.json
 .claude/worktrees/
 
+# Local working documents
+docs/ClaudeLens_Architecture_Guide_IT.docx
+
 # Editor
 .idea/
 *.swp


### PR DESCRIPTION
## What changed

- ignores the local Italian architecture-guide DOCX by its exact path

## Why

The working document should remain local and must not be accidentally committed with repository changes.

## Impact

No application or build behavior changes. The ignore is intentionally file-specific.

