### PR TITLE
fix: guard main process against stalled reads on dataless (iCloud) files

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -19,6 +19,7 @@ import {
   writeClaudeMdFile,
 } from './modules/claude-md-reader';
 import { readProjectRules } from './modules/rules-reader';
+import { readTextFile } from './modules/safe-fs';
 import { readChatSessionViaSdk, readSubagentTranscriptViaSdk } from './modules/session-reader';
 import { readSessionSubagentsViaSdk } from './modules/subagents-reader';
 import { getSessionArtifacts, deleteSessionArtifacts } from './modules/session-deleter';
@@ -512,7 +513,7 @@ ipcMain.handle('cost:getByProject', async (_event, hash: string) => {
 
 ipcMain.handle('claudeMd:getGlobal', async () => {
   try {
-    return ok(readGlobalClaudeMd(CLAUDE_DIR));
+    return ok(await readGlobalClaudeMd(CLAUDE_DIR));
   } catch (e) {
     return err(e);
   }
@@ -520,7 +521,7 @@ ipcMain.handle('claudeMd:getGlobal', async () => {
 
 ipcMain.handle('claudeMd:getHierarchy', async (_event, realPath: string) => {
   try {
-    return ok(getClaudeMdHierarchy(realPath));
+    return ok(await getClaudeMdHierarchy(realPath));
   } catch (e) {
     return err(e);
   }
@@ -600,9 +601,8 @@ function resolveSkillFile(skillPath: string, relPath: string): string {
 
 ipcMain.handle('skills:readFile', async (_event, skillPath: string, relPath: string) => {
   try {
-    const fs = require('fs') as typeof import('fs');
     const safePath = resolveSkillFile(skillPath, relPath);
-    return ok(fs.readFileSync(safePath, 'utf-8'));
+    return ok(await readTextFile(safePath));
   } catch (e) {
     return err(e);
   }
@@ -1013,7 +1013,7 @@ ipcMain.handle('rules:getByProject', async (_event, realPath: string) => {
 
 ipcMain.handle('skills:getGlobal', async () => {
   try {
-    return ok(getGlobalSkills());
+    return ok(await getGlobalSkills());
   } catch (e) {
     return err(e);
   }
@@ -1021,7 +1021,7 @@ ipcMain.handle('skills:getGlobal', async () => {
 
 ipcMain.handle('skills:getAll', async (_event, realPath: string) => {
   try {
-    return ok(getAllSkills(realPath));
+    return ok(await getAllSkills(realPath));
   } catch (e) {
     return err(e);
   }
@@ -1029,7 +1029,7 @@ ipcMain.handle('skills:getAll', async (_event, realPath: string) => {
 
 ipcMain.handle('agents:getGlobal', async () => {
   try {
-    return ok(getGlobalAgents());
+    return ok(await getGlobalAgents());
   } catch (e) {
     return err(e);
   }
@@ -1037,7 +1037,7 @@ ipcMain.handle('agents:getGlobal', async () => {
 
 ipcMain.handle('agents:getByProject', async (_event, realPath: string) => {
   try {
-    return ok(getProjectAgents(realPath));
+    return ok(await getProjectAgents(realPath));
   } catch (e) {
     return err(e);
   }
@@ -1045,7 +1045,7 @@ ipcMain.handle('agents:getByProject', async (_event, realPath: string) => {
 
 ipcMain.handle('plugins:getAll', async () => {
   try {
-    return ok(getInstalledPlugins());
+    return ok(await getInstalledPlugins());
   } catch (e) {
     return err(e);
   }

--- a/electron/modules/agents-reader.ts
+++ b/electron/modules/agents-reader.ts
@@ -1,6 +1,7 @@
-import { readFileSync, existsSync, readdirSync } from 'fs';
+import { existsSync, readdirSync } from 'fs';
 import { join, basename } from 'path';
 import { CLAUDE_DIR } from '../utils';
+import { readTextFile } from './safe-fs';
 import { parseFrontmatter, getString } from './frontmatter';
 import { AGENT_FIELDS, parseFields } from './entity-fields';
 
@@ -66,11 +67,11 @@ function parseAgentMarkdown(content: string): { frontmatter: AgentFrontmatter; b
  * read. Shared by `readAgentsFromDir` and the plugin reader (which resolves
  * explicit, declared agent paths rather than scanning).
  */
-export function readAgentFile(filePath: string, scope: 'global' | 'project' | 'plugin'): Agent | null {
+export async function readAgentFile(filePath: string, scope: 'global' | 'project' | 'plugin'): Promise<Agent | null> {
   if (!existsSync(filePath)) return null;
   const fileName = basename(filePath);
   try {
-    const rawContent = readFileSync(filePath, 'utf-8');
+    const rawContent = await readTextFile(filePath);
     const { frontmatter, body } = parseAgentMarkdown(rawContent);
     const missingRequired = REQUIRED_AGENT_FIELDS.filter(f => !frontmatter[f]);
     return {
@@ -102,31 +103,29 @@ export function readAgentFile(filePath: string, scope: 'global' | 'project' | 'p
   }
 }
 
-export function readAgentsFromDir(dir: string, scope: 'global' | 'project' | 'plugin'): Agent[] {
+export async function readAgentsFromDir(dir: string, scope: 'global' | 'project' | 'plugin'): Promise<Agent[]> {
   if (!existsSync(dir)) return [];
-  const agents: Agent[] = [];
 
   try {
     const entries = readdirSync(dir, { withFileTypes: true });
-    for (const entry of entries) {
-      if (entry.isFile() && entry.name.endsWith('.md')) {
-        const agent = readAgentFile(join(dir, entry.name), scope);
-        if (agent) agents.push(agent);
-      }
-    }
+    const agents = await Promise.all(
+      entries
+        .filter(entry => entry.isFile() && entry.name.endsWith('.md'))
+        .map(entry => readAgentFile(join(dir, entry.name), scope)),
+    );
+    return agents.filter((a): a is Agent => a !== null);
   } catch (e) {
     console.error(`Errore leggendo agents da ${dir}: ${e}`);
+    return [];
   }
-
-  return agents;
 }
 
-export function getGlobalAgents(): Agent[] {
+export function getGlobalAgents(): Promise<Agent[]> {
   const agentsDir = join(CLAUDE_DIR, 'agents');
   return readAgentsFromDir(agentsDir, 'global');
 }
 
-export function getProjectAgents(realProjectPath: string): Agent[] {
+export function getProjectAgents(realProjectPath: string): Promise<Agent[]> {
   const agentsDir = join(realProjectPath, '.claude', 'agents');
   return readAgentsFromDir(agentsDir, 'project');
 }

--- a/electron/modules/claude-md-reader.ts
+++ b/electron/modules/claude-md-reader.ts
@@ -1,6 +1,7 @@
-import { readFileSync, existsSync, readdirSync, writeFileSync, mkdirSync } from 'fs';
+import { existsSync, readdirSync, writeFileSync, mkdirSync } from 'fs';
 import { basename, dirname, join } from 'path';
 import { CLAUDE_DIR } from '../utils';
+import { readTextFile } from './safe-fs';
 
 export interface ClaudeMdLayer {
   scope: 'global' | 'project' | 'local' | 'subdir';
@@ -12,23 +13,24 @@ export interface ClaudeMdHierarchy {
   layers: ClaudeMdLayer[];
 }
 
-export function readGlobalClaudeMd(claudeDir: string): string | undefined {
+export async function readGlobalClaudeMd(claudeDir: string): Promise<string | undefined> {
   const globalPath = join(claudeDir, 'CLAUDE.md');
   if (!existsSync(globalPath)) return undefined;
 
   try {
-    return readFileSync(globalPath, 'utf-8');
+    return await readTextFile(globalPath);
   } catch (error) {
     console.error(`Errore leggendo CLAUDE.md globale: ${error}`);
     return undefined;
   }
 }
 
-function tryRead(filePath: string): string | undefined {
+async function tryRead(filePath: string): Promise<string | undefined> {
   if (!existsSync(filePath)) return undefined;
   try {
-    return readFileSync(filePath, 'utf-8');
-  } catch {
+    return await readTextFile(filePath);
+  } catch (error) {
+    console.error(`Errore leggendo ${filePath}: ${error}`);
     return undefined;
   }
 }
@@ -72,30 +74,30 @@ export function writeClaudeMdFile(filePath: string, content: string): void {
   writeFileSync(filePath, content, 'utf-8');
 }
 
-export function getClaudeMdHierarchy(realPath: string): ClaudeMdHierarchy {
+export async function getClaudeMdHierarchy(realPath: string): Promise<ClaudeMdHierarchy> {
   const claudeDir = CLAUDE_DIR;
   const layers: ClaudeMdLayer[] = [];
 
   // 1. Global
-  const globalContent = tryRead(join(claudeDir, 'CLAUDE.md'));
+  const globalContent = await tryRead(join(claudeDir, 'CLAUDE.md'));
   if (globalContent !== undefined) {
     layers.push({ scope: 'global', filePath: join(claudeDir, 'CLAUDE.md'), content: globalContent });
   }
 
   // 2. Project root
-  const projectContent = tryRead(join(realPath, 'CLAUDE.md'));
+  const projectContent = await tryRead(join(realPath, 'CLAUDE.md'));
   if (projectContent !== undefined) {
     layers.push({ scope: 'project', filePath: join(realPath, 'CLAUDE.md'), content: projectContent });
   }
 
   // 3. Local override
-  const localContent = tryRead(join(realPath, 'CLAUDE.local.md'));
+  const localContent = await tryRead(join(realPath, 'CLAUDE.local.md'));
   if (localContent !== undefined) {
     layers.push({ scope: 'local', filePath: join(realPath, 'CLAUDE.local.md'), content: localContent });
   }
 
   // 4. .claude/CLAUDE.md nel progetto
-  const subdirContent = tryRead(join(realPath, '.claude', 'CLAUDE.md'));
+  const subdirContent = await tryRead(join(realPath, '.claude', 'CLAUDE.md'));
   if (subdirContent !== undefined) {
     layers.push({ scope: 'subdir', filePath: join(realPath, '.claude', 'CLAUDE.md'), content: subdirContent });
   }
@@ -105,7 +107,7 @@ export function getClaudeMdHierarchy(realPath: string): ClaudeMdHierarchy {
   for (const filePath of allClaudeMdFiles) {
     // Salta i file già aggiunti
     if (!layers.some(l => l.filePath === filePath)) {
-      const content = tryRead(filePath);
+      const content = await tryRead(filePath);
       if (content !== undefined) {
         layers.push({ scope: 'subdir', filePath, content });
       }

--- a/electron/modules/config-reader.ts
+++ b/electron/modules/config-reader.ts
@@ -1,5 +1,8 @@
 import os from 'os';
+import { existsSync } from 'fs';
+import { join } from 'path';
 import { resolveClaudeExecutablePath } from '../utils';
+import { readTextFile, withTimeout } from './safe-fs';
 
 // Reads the *effective* Claude Code configuration through the official Agent SDK
 // (`@anthropic-ai/claude-agent-sdk`) instead of hand-parsing the settings files.
@@ -52,6 +55,30 @@ export interface EffectiveConfig {
 }
 
 const INIT_TIMEOUT_MS = 30_000;
+// resolveSettings has no abort mechanism of its own: reading the settings
+// cascade of a project on iCloud can hang forever on a dataless file, leaving
+// the config views (and the chat composer) stuck loading. Cap it.
+const SETTINGS_TIMEOUT_MS = 10_000;
+const PROBE_TIMEOUT_MS = 5_000;
+
+// resolveSettings reads the project files with SYNC fs, so a stalled read (a
+// dataless iCloud file whose materialization hangs) blocks the whole main
+// process — no JS timeout can interrupt it (verified live: a 10s Promise.race
+// fired only after the sync read returned at ~32s). Probe the same files
+// asynchronously first: a successful probe also materializes them, and a
+// failed one lets us skip the SDK calls instead of freezing the app.
+async function probeUnreadableFile(dir: string): Promise<string | null> {
+  const candidates = [
+    join(dir, 'CLAUDE.md'),
+    join(dir, 'CLAUDE.local.md'),
+    join(dir, '.claude', 'settings.json'),
+    join(dir, '.claude', 'settings.local.json'),
+  ].filter(f => existsSync(f));
+  const results = await Promise.all(
+    candidates.map(f => readTextFile(f, PROBE_TIMEOUT_MS).then(() => null, () => f)),
+  );
+  return results.find(f => f !== null) ?? null;
+}
 
 async function loadSdk() {
   return import('@anthropic-ai/claude-agent-sdk');
@@ -113,6 +140,23 @@ async function captureInit(sdk: Sdk, cwd: string): Promise<InitInfo | null> {
 
 export async function readEffectiveConfig(cwd?: string): Promise<EffectiveConfig> {
   const dir = cwd && cwd.length ? cwd : os.homedir();
+
+  const stuck = await probeUnreadableFile(dir);
+  if (stuck) {
+    const msg =
+      `Cannot read ${stuck}: the file exists but its content is not available on disk ` +
+      `(likely evicted by iCloud and not downloading). Open or download the file, then retry.`;
+    return {
+      cwd: dir,
+      init: null,
+      initError: msg,
+      effective: {},
+      provenance: {},
+      sources: [],
+      settingsError: msg,
+    };
+  }
+
   const sdk = await loadSdk();
 
   let effective: Record<string, unknown> = {};
@@ -120,7 +164,11 @@ export async function readEffectiveConfig(cwd?: string): Promise<EffectiveConfig
   let sources: SettingsSourceEntry[] = [];
   let settingsError: string | null = null;
   try {
-    const resolved = await sdk.resolveSettings({ cwd: dir });
+    const resolved = await withTimeout(
+      sdk.resolveSettings({ cwd: dir }),
+      SETTINGS_TIMEOUT_MS,
+      `resolveSettings timed out after ${SETTINGS_TIMEOUT_MS}ms — a settings file may not be materialized (iCloud/network path): ${dir}`,
+    );
     effective = (resolved.effective as Record<string, unknown>) ?? {};
     provenance = Object.fromEntries(
       Object.entries(resolved.provenance ?? {}).map(([k, v]) => [

--- a/electron/modules/plugins-reader.ts
+++ b/electron/modules/plugins-reader.ts
@@ -124,16 +124,14 @@ function readMarketplaceEntry(installPath: string, pluginName: string): Marketpl
 }
 
 /** Resolve declared skill dirs (each containing SKILL.md) relative to installPath. */
-function readDeclaredSkills(installPath: string, rels: string[]): Skill[] {
-  return rels
-    .map(rel => readSkillDir(join(installPath, rel), 'plugin'))
-    .filter((s): s is Skill => s !== null);
+async function readDeclaredSkills(installPath: string, rels: string[]): Promise<Skill[]> {
+  const skills = await Promise.all(rels.map(rel => readSkillDir(join(installPath, rel), 'plugin')));
+  return skills.filter((s): s is Skill => s !== null);
 }
 
-function readDeclaredAgents(installPath: string, rels: string[]): Agent[] {
-  return rels
-    .map(rel => readAgentFile(join(installPath, rel), 'plugin'))
-    .filter((a): a is Agent => a !== null);
+async function readDeclaredAgents(installPath: string, rels: string[]): Promise<Agent[]> {
+  const agents = await Promise.all(rels.map(rel => readAgentFile(join(installPath, rel), 'plugin')));
+  return agents.filter((a): a is Agent => a !== null);
 }
 
 function readDeclaredCommands(installPath: string, rels: string[]): PluginCommand[] {
@@ -156,7 +154,7 @@ function readDeclaredCommands(installPath: string, rels: string[]): PluginComman
  * Agents nested inside a skill (`skills/<skill>/agents/*.md`) are NOT surfaced — they
  * are internal helpers of that skill, not independently invocable plugin agents.
  */
-export function getInstalledPlugins(): InstalledPlugin[] {
+export async function getInstalledPlugins(): Promise<InstalledPlugin[]> {
   const installed = readJson<{
     plugins?: Record<string, InstalledEntry[]>;
   }>(join(PLUGINS_DIR, 'installed_plugins.json'));
@@ -192,11 +190,11 @@ export function getInstalledPlugins(): InstalledPlugin[] {
       author: manifest.author,
       repo,
       skills: declared?.skills
-        ? readDeclaredSkills(installPath, declared.skills)
-        : readSkillsFromDir(join(installPath, 'skills'), 'plugin'),
+        ? await readDeclaredSkills(installPath, declared.skills)
+        : await readSkillsFromDir(join(installPath, 'skills'), 'plugin'),
       agents: declared?.agents
-        ? readDeclaredAgents(installPath, declared.agents)
-        : readAgentsFromDir(join(installPath, 'agents'), 'plugin'),
+        ? await readDeclaredAgents(installPath, declared.agents)
+        : await readAgentsFromDir(join(installPath, 'agents'), 'plugin'),
       commands: declared?.commands
         ? readDeclaredCommands(installPath, declared.commands)
         : readPluginCommands(installPath),

--- a/electron/modules/rules-reader.ts
+++ b/electron/modules/rules-reader.ts
@@ -1,5 +1,5 @@
-import { readFileSync } from 'fs';
 import { join, basename } from 'path';
+import { readTextFile } from './safe-fs';
 import { glob } from 'glob';
 import { parseFrontmatter, getStringArray } from './frontmatter';
 
@@ -29,7 +29,7 @@ export async function readProjectRules(realProjectPath: string): Promise<RuleFil
 
     for (const filePath of files) {
       try {
-        const content = readFileSync(filePath, 'utf-8');
+        const content = await readTextFile(filePath);
         const paths = extractFrontmatterPaths(content);
 
         rules.push({

--- a/electron/modules/safe-fs.ts
+++ b/electron/modules/safe-fs.ts
@@ -1,0 +1,43 @@
+import { promises as fsp } from 'fs';
+
+const DEFAULT_TIMEOUT_MS = 5000;
+
+/**
+ * Read a text file without ever blocking the main process. Project paths can
+ * live on iCloud Drive / network volumes: a dataless (evicted) file makes the
+ * kernel materialize it on first read, which can stall for a long time and
+ * fail with ECANCELED — a readFileSync there freezes the whole app. The async
+ * read stalls at most a libuv worker thread, and the timeout caps how long a
+ * caller waits before treating the file as unreadable.
+ */
+export async function readTextFile(
+  filePath: string,
+  timeoutMs: number = DEFAULT_TIMEOUT_MS,
+): Promise<string> {
+  return withTimeout(
+    fsp.readFile(filePath, 'utf-8'),
+    timeoutMs,
+    `Read timed out after ${timeoutMs}ms (file not materialized?): ${filePath}`,
+  );
+}
+
+/**
+ * Cap any promise whose underlying work may touch stalled files (e.g. the Agent
+ * SDK resolving the settings cascade of a project on iCloud). Rejects with
+ * `message` after `timeoutMs`; the underlying work is not cancelled.
+ */
+export async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  message: string,
+): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/electron/modules/skills-reader.ts
+++ b/electron/modules/skills-reader.ts
@@ -1,6 +1,7 @@
-import { readFileSync, existsSync, readdirSync, statSync } from 'fs';
+import { existsSync, readdirSync, statSync } from 'fs';
 import { join, basename, relative, extname, sep } from 'path';
 import { CLAUDE_DIR } from '../utils';
+import { readTextFile } from './safe-fs';
 import { parseFrontmatter } from './frontmatter';
 import { SKILL_FIELDS, parseFields } from './entity-fields';
 
@@ -177,11 +178,11 @@ export function parseSkillMarkdown(content: string): {
  * to read. Shared by `readSkillsFromDir` and the plugin reader (which resolves
  * explicit, declared skill paths rather than scanning).
  */
-export function readSkillDir(skillDir: string, scope: 'global' | 'project' | 'plugin'): Skill | null {
+export async function readSkillDir(skillDir: string, scope: 'global' | 'project' | 'plugin'): Promise<Skill | null> {
   const skillMarkdownPath = join(skillDir, 'SKILL.md');
   if (!existsSync(skillMarkdownPath)) return null;
   try {
-    const rawContent = readFileSync(skillMarkdownPath, 'utf-8');
+    const rawContent = await readTextFile(skillMarkdownPath);
     const { frontmatter, body } = parseSkillMarkdown(rawContent);
     return {
       name: basename(skillDir),
@@ -206,40 +207,38 @@ export function readSkillDir(skillDir: string, scope: 'global' | 'project' | 'pl
   }
 }
 
-export function readSkillsFromDir(dir: string, scope: 'global' | 'project' | 'plugin'): Skill[] {
+export async function readSkillsFromDir(dir: string, scope: 'global' | 'project' | 'plugin'): Promise<Skill[]> {
   if (!existsSync(dir)) return [];
-
-  const skills: Skill[] = [];
 
   try {
     const entries = readdirSync(dir, { withFileTypes: true });
-
-    for (const entry of entries) {
-      if (entry.isDirectory()) {
-        const skill = readSkillDir(join(dir, entry.name), scope);
-        if (skill) skills.push(skill);
-      }
-    }
+    const skills = await Promise.all(
+      entries
+        .filter(entry => entry.isDirectory())
+        .map(entry => readSkillDir(join(dir, entry.name), scope)),
+    );
+    return skills.filter((s): s is Skill => s !== null);
   } catch (error) {
     console.error(`Errore leggendo skills da ${dir}: ${error}`);
+    return [];
   }
-
-  return skills;
 }
 
-export function getGlobalSkills(): Skill[] {
+export function getGlobalSkills(): Promise<Skill[]> {
   const skillsDir = join(CLAUDE_DIR, 'skills');
   return readSkillsFromDir(skillsDir, 'global');
 }
 
-export function getProjectSkills(realProjectPath: string): Skill[] {
+export function getProjectSkills(realProjectPath: string): Promise<Skill[]> {
   const skillsDir = join(realProjectPath, '.claude', 'skills');
   return readSkillsFromDir(skillsDir, 'project');
 }
 
-export function getAllSkills(realProjectPath: string): Skill[] {
-  const projectSkills = getProjectSkills(realProjectPath);
-  const globalSkills = getGlobalSkills();
+export async function getAllSkills(realProjectPath: string): Promise<Skill[]> {
+  const [projectSkills, globalSkills] = await Promise.all([
+    getProjectSkills(realProjectPath),
+    getGlobalSkills(),
+  ]);
 
   // Project skills hanno priorità, quindi filtriamo i global skills con lo stesso nome
   const projectNames = new Set(projectSkills.map(s => s.name));

--- a/test/entity-writers.test.ts
+++ b/test/entity-writers.test.ts
@@ -63,13 +63,13 @@ describe('createSkill (issue #58)', () => {
   // Regression: a description with a colon (or '#') used to be written into the
   // YAML frontmatter unquoted, making js-yaml throw on read and silently drop
   // the WHOLE block — the skill came back with no description/tools/model.
-  it('round-trips a description containing YAML metacharacters', () => {
+  it('round-trips a description containing YAML metacharacters', async () => {
     const description = 'Use this skill when: editing, fixing, or building # the deck';
     createSkill(
       { name: 'tricky', content: 'Body', description, model: 'sonnet', allowedTools: ['Read', 'Bash'] },
       proj
     );
-    const skill = readSkillDir(join(proj, '.claude', 'skills', 'tricky'), 'project');
+    const skill = await readSkillDir(join(proj, '.claude', 'skills', 'tricky'), 'project');
     expect(skill).not.toBeNull();
     expect(skill!.description).toBe(description);
     expect(skill!.model).toBe('sonnet');
@@ -108,13 +108,13 @@ describe('createAgent (issue #58)', () => {
   // Regression: agent descriptions almost always contain a colon ("Use this
   // agent when X: ..."). Written unquoted, the frontmatter failed to parse and
   // the agent read back with every field missing (flagged invalid in the UI).
-  it('round-trips a description containing YAML metacharacters', () => {
+  it('round-trips a description containing YAML metacharacters', async () => {
     const description = 'Use this agent when the user asks: features, hooks # and more';
     const filePath = createAgent(
       { name: 'guide', content: 'Body', description, model: 'opus', color: 'blue', allowedTools: ['Read', 'Grep'] },
       proj
     );
-    const agent = readAgentFile(filePath, 'project');
+    const agent = await readAgentFile(filePath, 'project');
     expect(agent).not.toBeNull();
     expect(agent!.missingRequired).toEqual([]);
     expect(agent!.description).toBe(description);
@@ -125,9 +125,9 @@ describe('createAgent (issue #58)', () => {
 
   // A model/version-like string must stay a string, not be coerced to a number
   // on read (js-yaml would parse a bare 4.8 as a float).
-  it('keeps a numeric-looking scalar a string after round-trip', () => {
+  it('keeps a numeric-looking scalar a string after round-trip', async () => {
     const filePath = createAgent({ name: 'numish', content: 'b', description: 'x', model: '4.8' }, proj);
-    const agent = readAgentFile(filePath, 'project');
+    const agent = await readAgentFile(filePath, 'project');
     expect(agent!.model).toBe('4.8');
   });
 });
@@ -137,41 +137,41 @@ describe('createAgent (issue #58)', () => {
 // re-canonicalization. An unquoted description containing ': ' or '#' used to
 // break the YAML on read and drop the whole frontmatter.
 describe('edit round-trip via renderer serializer', () => {
-  it('skill: preserves a description with a colon and #', () => {
+  it('skill: preserves a description with a colon and #', async () => {
     createSkill({ name: 'edit-skill', content: 'Body', description: 'old', model: 'sonnet' }, proj);
     const dir = join(proj, '.claude', 'skills', 'edit-skill');
-    const skill = readSkillDir(dir, 'project')!;
+    const skill = (await readSkillDir(dir, 'project'))!;
     const description = 'Use this skill when: editing, fixing # or building the deck';
     const raw = serializeSkill(asSkill(skill), skill.content, {
       description,
       options: readOptions(asRecord(skill), SKILL_OPTION_DEFS),
     });
     writeFileSync(join(dir, 'SKILL.md'), raw, 'utf-8');
-    const reread = readSkillDir(dir, 'project')!;
+    const reread = (await readSkillDir(dir, 'project'))!;
     expect(reread.description).toBe(description);
     expect(reread.model).toBe('sonnet');
   });
 
-  it('agent: preserves a description with a colon and keeps a numeric-looking model a string', () => {
+  it('agent: preserves a description with a colon and keeps a numeric-looking model a string', async () => {
     const filePath = createAgent(
       { name: 'edit-agent', content: 'Body', description: 'old', model: '4.8', color: 'blue' },
       proj
     );
-    const agent = readAgentFile(filePath, 'project')!;
+    const agent = (await readAgentFile(filePath, 'project'))!;
     const description = 'Use this agent when the user asks: X # and Y';
     const raw = serializeAgent(asAgent(agent), agent.content, {
       description,
       options: readOptions(asRecord(agent), AGENT_OPTION_DEFS),
     });
     writeFileSync(filePath, raw, 'utf-8');
-    const reread = readAgentFile(filePath, 'project')!;
+    const reread = (await readAgentFile(filePath, 'project'))!;
     expect(reread.missingRequired).toEqual([]);
     expect(reread.description).toBe(description);
     expect(reread.model).toBe('4.8');
     expect(reread.color).toBe('blue');
   });
 
-  it('skill: an edit preserves an unmodeled hooks block', () => {
+  it('skill: an edit preserves an unmodeled hooks block', async () => {
     const dir = join(proj, '.claude', 'skills', 'hooked');
     mkdirSync(dir, { recursive: true });
     const original = [
@@ -185,7 +185,7 @@ describe('edit round-trip via renderer serializer', () => {
       'Body',
     ].join('\n');
     writeFileSync(join(dir, 'SKILL.md'), original, 'utf-8');
-    const skill = readSkillDir(dir, 'project')!;
+    const skill = (await readSkillDir(dir, 'project'))!;
     expect(skill.hooks).toBeDefined();
 
     const raw = serializeSkill(asSkill(skill), skill.content, {
@@ -193,7 +193,7 @@ describe('edit round-trip via renderer serializer', () => {
       options: readOptions(asRecord(skill), SKILL_OPTION_DEFS),
     });
     writeFileSync(join(dir, 'SKILL.md'), raw, 'utf-8');
-    const reread = readSkillDir(dir, 'project')!;
+    const reread = (await readSkillDir(dir, 'project'))!;
     expect(reread.description).toBe('new desc');
     expect(reread.hooks).toBeDefined();
     expect(JSON.stringify(reread.hooks)).toContain('PreToolUse');


### PR DESCRIPTION
## Summary

Dataless iCloud Drive files stall synchronous `readFileSync` calls (the read blocks on materialization and can fail with ECANCELED), freezing the Electron main process.

- New `electron/modules/safe-fs.ts`: async text read with a timeout guard.
- Converted the readers that scan project paths to async reads: `agents-reader`, `skills-reader`, `claude-md-reader`, `plugins-reader`, `rules-reader`.
- `config-reader`: async probe with timeout before `resolveSettings()` so a stalled file cannot block the effective-config read.
- `electron/main.ts`: IPC handlers now await the async readers.
- Tests updated to the new async signatures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJsnGuJgrZaoX32C8uuXKx