### PR TITLE
fix(workflows): resolve run script from launching session and fix phase index basis

### DIFF
--- a/electron/modules/workflows-reader.ts
+++ b/electron/modules/workflows-reader.ts
@@ -460,9 +460,11 @@ export async function getWorkflowRun(
         fallbackMtimeMs: safeMtimeMs(candidate),
       });
       if (!detail) continue;
-      // Script fallback: if not inlined, read the .js from scripts/.
+      // Script fallback: if not inlined, read the .js from the LAUNCHING
+      // session's scripts/ (detail.sessionId, from scriptPath) — on a
+      // resumed/forked run the state JSON dir (dirName) is a different session.
       if (detail.script === null && detail.scriptPath) {
-        const scriptFile = join(projectPath, dirName, 'workflows', 'scripts', basename(detail.scriptPath));
+        const scriptFile = join(projectPath, detail.sessionId, 'workflows', 'scripts', basename(detail.scriptPath));
         try {
           assertWithin(projectPath, scriptFile);
           detail.script = await readFile(scriptFile, 'utf-8');

--- a/src/components/project/workflows/WorkflowRunDetailView.tsx
+++ b/src/components/project/workflows/WorkflowRunDetailView.tsx
@@ -110,12 +110,15 @@ function RunBody({
       arr.push(a)
       byPhase.set(a.phaseIndex, arr)
     }
+    // Phase indices seen live are 1-based; detect the basis once from the data
+    // (a 1-based run never keys an agent at 0). A per-phase get(i+1) ?? get(i)
+    // probe would steal the next phase's agents on 0-based data and drop
+    // phase 0's rows entirely.
+    const base = byPhase.has(0) ? 0 : 1
     const out: { title: string; detail?: string; agents: WorkflowAgentRow[] }[] = []
     run.phases.forEach((p, i) => {
-      // Phase indices seen live are 1-based; tolerate 0-based too.
-      const agents = byPhase.get(i + 1) ?? byPhase.get(i) ?? []
-      byPhase.delete(i + 1)
-      byPhase.delete(i)
+      const agents = byPhase.get(i + base) ?? []
+      byPhase.delete(i + base)
       out.push({ title: p.title, detail: p.detail, agents })
     })
     const leftover = [...byPhase.values()].flat()
@@ -136,15 +139,17 @@ function RunBody({
           {run.args && <span className="cl-wf-args cl-mono">{run.args}</span>}
         </div>
         {run.summary && <p className="cl-wf-dhead-summary">{run.summary}</p>}
-        <div className="cl-wf-dhead-meta cl-mono">
-          <span>{fmtDate(new Date(run.startTime).toISOString())}</span>
-          {run.taskId && (
-            <>
-              <span className="sep">·</span>
-              <span>task {run.taskId}</span>
-            </>
-          )}
-        </div>
+        {(run.startTime > 0 || run.taskId) && (
+          <div className="cl-wf-dhead-meta cl-mono">
+            {run.startTime > 0 && <span>{fmtDate(new Date(run.startTime).toISOString())}</span>}
+            {run.taskId && (
+              <>
+                {run.startTime > 0 && <span className="sep">·</span>}
+                <span>task {run.taskId}</span>
+              </>
+            )}
+          </div>
+        )}
         <div className="cl-wf-statgrid">
           <StatChip label="Agents" value={String(run.agentCount)} />
           {run.errorAgentCount > 0 && <StatChip label="Errored" value={String(run.errorAgentCount)} accent />}
@@ -312,6 +317,12 @@ function AgentRow({
             <div className="cl-wf-preview">
               <span className="lbl cl-mono">prompt</span>
               <pre className="cl-wf-pre cl-mono">{agent.promptPreview}</pre>
+            </div>
+          )}
+          {agent.resultPreview && (
+            <div className="cl-wf-preview">
+              <span className="lbl cl-mono">result</span>
+              <pre className="cl-wf-pre cl-mono">{agent.resultPreview}</pre>
             </div>
           )}
           {canDrill && (


### PR DESCRIPTION
## Summary

Fixes for the workflow run detail view and its reader:

- The fallback workflow script is now read from the launching session's `scripts/` directory (`detail.sessionId`): on resumed/forked runs the directory containing the state JSON belongs to a different session, so the script lookup missed.
- The 0/1-based basis of phase indices is detected once from the data; the previous per-phase probe stole agents from the next phase on 0-based data.
- The meta row is hidden when `startTime`/`taskId` are missing.
- Added a per-agent result preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJsnGuJgrZaoX32C8uuXKx