### PR TITLE
fix(windows): resolve terminal session id and show project basenames

### DIFF
--- a/electron/modules/terminal-manager.ts
+++ b/electron/modules/terminal-manager.ts
@@ -15,6 +15,8 @@
 // error on first use instead of crashing the main process at boot.
 
 import { randomUUID } from 'crypto';
+import { existsSync } from 'fs';
+import { win32 as pathWin32 } from 'path';
 import type { IPty } from 'node-pty';
 
 export interface TerminalCallbacks {
@@ -34,15 +36,54 @@ export interface CreateTerminalOptions {
   rows?: number;
 }
 
+// Image extensions node-pty/CreateProcess can launch directly (a PE binary).
+// A `.cmd`/`.bat` shim is a script, not a PE image, so it must be run via cmd.exe.
+const DIRECT_EXEC_EXTS = new Set(['.EXE', '.COM']);
+
+/**
+ * Find `claude` on the Windows PATH, honoring PATHEXT (same resolution order as
+ * `where claude`: PATH dir first, then extension). Returns the resolved absolute
+ * path and whether it is a directly-launchable image (`.exe`/`.com`) versus a
+ * shim (`.cmd`/`.bat`) that needs a cmd.exe wrapper. Injectable for tests.
+ */
+export function findClaudeOnWindowsPath(
+  env: NodeJS.ProcessEnv = process.env,
+  exists: (p: string) => boolean = existsSync
+): { path: string; direct: boolean } | null {
+  const pathVar = env.Path ?? env.PATH ?? '';
+  const pathExt = (env.PATHEXT ?? '.COM;.EXE;.BAT;.CMD').split(';').filter(Boolean);
+  // Windows semantics regardless of the host OS (win32-only fn; keeps unit tests
+  // deterministic on a Linux/macOS CI runner): `;` PATH delimiter, `\` joins.
+  for (const dir of pathVar.split(pathWin32.delimiter).filter(Boolean)) {
+    for (const ext of pathExt) {
+      const candidate = pathWin32.join(dir, `claude${ext}`);
+      if (exists(candidate)) {
+        return { path: candidate, direct: DIRECT_EXEC_EXTS.has(ext.toUpperCase()) };
+      }
+    }
+  }
+  return null;
+}
+
 // Build the executable + args to launch the interactive `claude` CLI in a PTY.
-// Windows installs the CLI as the `claude.cmd` batch shim, and node-pty spawns
-// through CreateProcess, which cannot launch a `.cmd`/`.bat` directly (it is not
-// a PE executable → "File not found"). Route it through cmd.exe — `cmd /c claude
-// …` resolves the shim on PATH and runs it inside the same ConPTY, so the CLI
-// still gets the pseudo-console for its TUI. On POSIX the binary is exec'd
-// directly. Pure + exported so it is unit/integration testable on its own.
-export function resolveClaudeCommand(args: string[] = []): { command: string; args: string[] } {
+// On Windows we PREFER launching the native `claude.exe` directly: node-pty then
+// reports the CLI's OWN pid — the pid the session registry
+// (`~/.claude/sessions/<pid>.json`) is keyed by — so the Lens / Mission Control
+// pid-match resolves this terminal's session (transcript + rail render). The
+// older npm install ships `claude.cmd`, a batch shim node-pty/CreateProcess
+// cannot launch directly (not a PE image → "File not found"); that still routes
+// through cmd.exe (`cmd /c claude …`, resolved on PATH, same ConPTY for the TUI),
+// where the reported pid is the cmd.exe wrapper's — the registry misses it and
+// the renderer falls back to matching by cwd (see TerminalMissionControl). On
+// POSIX the binary is exec'd directly. Pure + exported so it is unit/integration
+// testable on its own; the PATH lookup is injectable.
+export function resolveClaudeCommand(
+  args: string[] = [],
+  find: typeof findClaudeOnWindowsPath = findClaudeOnWindowsPath
+): { command: string; args: string[] } {
   if (process.platform === 'win32') {
+    const resolved = find();
+    if (resolved?.direct) return { command: resolved.path, args };
     return { command: process.env.ComSpec || 'cmd.exe', args: ['/c', 'claude', ...args] };
   }
   return { command: 'claude', args };
@@ -81,11 +122,11 @@ export function createTerminal(
     terminals.delete(id);
     callbacks.onExit(exitCode);
   });
-  // On POSIX the pid is the CLI process itself (spawned directly), which the
+  // On POSIX — and on Windows when the native `claude.exe` was launched directly
+  // (see resolveClaudeCommand) — the pid IS the CLI process itself, which the
   // renderer matches against the active-sessions registry to pin this session.
-  // On Windows it is the cmd.exe shim wrapping `claude` (see terminal:create),
-  // so the registry-by-pid match misses; the renderer falls back to the resumed
-  // session id there.
+  // Only a legacy `claude.cmd` install still wraps in cmd.exe, so the pid is the
+  // shim's; there the renderer falls back to matching by cwd.
   return { id, pid: term.pid };
 }
 

--- a/src/components/project/chat/MessageBubble.tsx
+++ b/src/components/project/chat/MessageBubble.tsx
@@ -379,7 +379,7 @@ function FileChipCluster({ files, max = 10 }: { files: TouchedFile[]; max?: numb
   return (
     <div className="cl-turn-files">
       {shown.map((f, i) => {
-        const name = f.path.split('/').pop() ?? f.path
+        const name = f.path.split(/[\\/]/).pop() ?? f.path
         return (
           <span
             key={i}
@@ -396,7 +396,7 @@ function FileChipCluster({ files, max = 10 }: { files: TouchedFile[]; max?: numb
       {overflow > 0 && (
         <span
           className="cl-file-chip cl-file-chip--more"
-          data-file={distinct.slice(max).map(f => f.path.split('/').pop()).join('\n')}
+          data-file={distinct.slice(max).map(f => f.path.split(/[\\/]/).pop()).join('\n')}
         >
           +{overflow}
         </span>

--- a/src/components/project/chat/MessageBubble.tsx
+++ b/src/components/project/chat/MessageBubble.tsx
@@ -379,7 +379,7 @@ function FileChipCluster({ files, max = 10 }: { files: TouchedFile[]; max?: numb
   return (
     <div className="cl-turn-files">
       {shown.map((f, i) => {
-        const name = f.path.split(/[\\/]/).pop() ?? f.path
+        const name = f.path.split(/[\\/]/).filter(Boolean).pop() ?? f.path
         return (
           <span
             key={i}
@@ -396,7 +396,7 @@ function FileChipCluster({ files, max = 10 }: { files: TouchedFile[]; max?: numb
       {overflow > 0 && (
         <span
           className="cl-file-chip cl-file-chip--more"
-          data-file={distinct.slice(max).map(f => f.path.split(/[\\/]/).pop()).join('\n')}
+          data-file={distinct.slice(max).map(f => f.path.split(/[\\/]/).filter(Boolean).pop()).join('\n')}
         >
           +{overflow}
         </span>

--- a/src/components/project/chat/atoms.tsx
+++ b/src/components/project/chat/atoms.tsx
@@ -48,6 +48,10 @@ export function LiveInTerminalBadge() {
 }
 
 export function PathChip({ path }: { path: string }) {
+  // NB: do NOT .filter(Boolean) here — the leading empty segment of an absolute
+  // POSIX path ("/a/b" → ["", "a", "b"]) is what reconstructs the leading slash
+  // in `dir` below. Split on both separators only, so a Windows path still yields
+  // the file name.
   const parts = path.split(/[\\/]/)
   const file = parts.pop() ?? path
   const dir = parts.join('/') || '/'

--- a/src/components/project/chat/atoms.tsx
+++ b/src/components/project/chat/atoms.tsx
@@ -48,7 +48,7 @@ export function LiveInTerminalBadge() {
 }
 
 export function PathChip({ path }: { path: string }) {
-  const parts = path.split('/')
+  const parts = path.split(/[\\/]/)
   const file = parts.pop() ?? path
   const dir = parts.join('/') || '/'
   return (

--- a/src/components/project/chat/graph/buildGraph.ts
+++ b/src/components/project/chat/graph/buildGraph.ts
@@ -59,13 +59,13 @@ export type TimelineModel = {
 
 function shortenPath(path: string, max = 36): string {
   if (path.length <= max) return path
-  const parts = path.split(/[\\/]/)
+  const parts = path.split(/[\\/]/).filter(Boolean)
   const tail = parts[parts.length - 1] ?? path
   return tail.length <= max ? `…/${tail}` : `${tail.slice(0, max - 1)}…`
 }
 
 function fileExt(path: string): string {
-  const tail = path.split(/[\\/]/).pop() ?? ''
+  const tail = path.split(/[\\/]/).filter(Boolean).pop() ?? ''
   const idx = tail.lastIndexOf('.')
   return idx > 0 ? tail.slice(idx + 1).toLowerCase() : ''
 }

--- a/src/components/project/chat/graph/buildGraph.ts
+++ b/src/components/project/chat/graph/buildGraph.ts
@@ -59,13 +59,13 @@ export type TimelineModel = {
 
 function shortenPath(path: string, max = 36): string {
   if (path.length <= max) return path
-  const parts = path.split('/')
+  const parts = path.split(/[\\/]/)
   const tail = parts[parts.length - 1] ?? path
   return tail.length <= max ? `…/${tail}` : `${tail.slice(0, max - 1)}…`
 }
 
 function fileExt(path: string): string {
-  const tail = path.split('/').pop() ?? ''
+  const tail = path.split(/[\\/]/).pop() ?? ''
   const idx = tail.lastIndexOf('.')
   return idx > 0 ? tail.slice(idx + 1).toLowerCase() : ''
 }

--- a/src/components/project/mcp/McpServerDetailView.tsx
+++ b/src/components/project/mcp/McpServerDetailView.tsx
@@ -21,7 +21,7 @@ function ProjectRow({
   cost?: ProjectCost
   onSelect?: (p: Project) => void
 }) {
-  const name = path.split('/').pop() ?? path
+  const name = path.split(/[\\/]/).filter(Boolean).pop() ?? path
   const initial = (name[0] ?? '?').toUpperCase()
   const tokens = formatTokens(cost?.totalTokens ?? 0)
   const clickable = !!(project && onSelect)

--- a/src/components/project/overview/GlobalHomeView.tsx
+++ b/src/components/project/overview/GlobalHomeView.tsx
@@ -151,7 +151,9 @@ export function GlobalHomeView({
           </div>
           <div className="cl-proc-list">
             {procs.map(p => {
-              const name = p.cwd.split('/').pop() ?? p.cwd
+              // Split on both separators so a Windows cwd (backslashes) yields the
+              // folder name, not the whole path.
+              const name = p.cwd.split(/[\\/]/).filter(Boolean).pop() ?? p.cwd
               const proj = projectByPath.get(p.cwd)
               return (
                 <button key={p.pid} type="button" className="cl-proc"

--- a/src/components/project/terminal/TerminalMissionControl.tsx
+++ b/src/components/project/terminal/TerminalMissionControl.tsx
@@ -37,6 +37,16 @@ import { SessionOutline } from './SessionOutline';
  * immediately until then.
  */
 
+/** Compare two absolute paths tolerantly: registry `cwd` (from the CLI) and the
+ *  project realPath can differ in slash direction and drive-letter case on
+ *  Windows. Normalize both to forward slashes, drop a trailing slash, and
+ *  compare case-insensitively (Windows/macOS filesystems are case-preserving
+ *  but case-insensitive; a Linux collision on case alone is not worth the risk). */
+function samePath(a: string, b: string): boolean {
+  const norm = (p: string) => p.replace(/[\\/]+/g, '/').replace(/\/$/, '').toLowerCase();
+  return norm(a) === norm(b);
+}
+
 const RAIL_DEFAULT = 432;
 const RAIL_MIN = 380;
 const RAIL_MAX = 560;
@@ -297,8 +307,20 @@ export function TerminalMissionControl({
   // Until then (or on CLI < 2.x) fall back to the resumed id. The registry wins
   // once available: `--resume` may mint a fresh session id.
   const { data: activeSessions } = useActiveSessions();
-  const registrySessionId =
-    (ptyPid && activeSessions?.find(s => s.pid === ptyPid && s.sessionId)?.sessionId) || null;
+  const registrySessionId = useMemo(() => {
+    if (!ptyPid || !activeSessions) return null;
+    // Primary: the PTY's pid IS the CLI's pid (POSIX, and Windows native
+    // claude.exe launched directly) — the registry is keyed by it.
+    const byPid = activeSessions.find(s => s.pid === ptyPid && s.sessionId);
+    if (byPid) return byPid.sessionId;
+    // Fallback for a legacy Windows `claude.cmd` install: the PTY pid is the
+    // cmd.exe wrapper, never in the registry, so the pid match can't work. Match
+    // this pane's cwd instead — but only when it is UNAMBIGUOUS (exactly one live
+    // session in this folder): with a second `claude` running here (e.g. an
+    // external terminal) we bail rather than pin the wrong session.
+    const inCwd = activeSessions.filter(s => s.sessionId && samePath(s.cwd, project.realPath));
+    return inCwd.length === 1 ? inCwd[0].sessionId : null;
+  }, [ptyPid, activeSessions, project.realPath]);
   // Latch the resolved id. The CLI rewrites `~/.claude/sessions/<pid>.json` on
   // every heartbeat; a (debounced) registry read landing mid-write transiently
   // drops our entry, so `registrySessionId` flaps to null — which would null out

--- a/src/tabs/LiveMonitor.tsx
+++ b/src/tabs/LiveMonitor.tsx
@@ -8,7 +8,7 @@ import { projectDisplayName } from '../components/project/shared/projectName'
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function getArg(input: Record<string, unknown>): string {
-  if (input.file_path) return '…/' + String(input.file_path).split('/').slice(-2).join('/')
+  if (input.file_path) return '…/' + String(input.file_path).split(/[\\/]/).slice(-2).join('/')
   if (input.command)   return String(input.command).slice(0, 48)
   if (input.pattern)   return String(input.pattern).slice(0, 48)
   if (input.query)     return String(input.query).slice(0, 48)
@@ -16,7 +16,7 @@ function getArg(input: Record<string, unknown>): string {
 }
 
 function shortPath(p: string): string {
-  return '/' + p.split('/').filter(Boolean).slice(-2).join('/')
+  return '/' + p.split(/[\\/]/).filter(Boolean).slice(-2).join('/')
 }
 
 // ─── Componente principale ────────────────────────────────────────────────────

--- a/src/tabs/LiveMonitor.tsx
+++ b/src/tabs/LiveMonitor.tsx
@@ -8,7 +8,7 @@ import { projectDisplayName } from '../components/project/shared/projectName'
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function getArg(input: Record<string, unknown>): string {
-  if (input.file_path) return '…/' + String(input.file_path).split(/[\\/]/).slice(-2).join('/')
+  if (input.file_path) return '…/' + String(input.file_path).split(/[\\/]/).filter(Boolean).slice(-2).join('/')
   if (input.command)   return String(input.command).slice(0, 48)
   if (input.pattern)   return String(input.pattern).slice(0, 48)
   if (input.query)     return String(input.query).slice(0, 48)

--- a/test/terminal-command.test.ts
+++ b/test/terminal-command.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { resolveClaudeCommand } from '../electron/modules/terminal-manager';
+import { resolveClaudeCommand, findClaudeOnWindowsPath } from '../electron/modules/terminal-manager';
 
 // resolveClaudeCommand branches on process.platform; stub it so both branches are
 // exercised on any runner (the integration test then proves the real spawn works
@@ -32,7 +32,12 @@ describe('resolveClaudeCommand', () => {
     process.env.ComSpec = 'C:\\Windows\\System32\\cmd.exe';
     // node-pty/CreateProcess cannot launch claude.cmd directly: it must go through
     // cmd.exe, never named as the bare `.cmd` (which fails with "File not found").
-    const resolved = resolveClaudeCommand(['--resume', 'abc']);
+    // Force the shim branch (inject a .cmd resolution) so the test is independent
+    // of whatever `claude` happens to be on the runner's real PATH.
+    const resolved = resolveClaudeCommand(['--resume', 'abc'], () => ({
+      path: 'C:\\npm\\claude.cmd',
+      direct: false,
+    }));
     expect(resolved.command).toBe('C:\\Windows\\System32\\cmd.exe');
     expect(resolved.args).toEqual(['/c', 'claude', '--resume', 'abc']);
   });
@@ -40,6 +45,66 @@ describe('resolveClaudeCommand', () => {
   it('falls back to cmd.exe when ComSpec is unset on Windows', () => {
     setPlatform('win32');
     delete process.env.ComSpec;
-    expect(resolveClaudeCommand().command).toBe('cmd.exe');
+    // Force the .cmd branch (no directly-launchable claude.exe on PATH).
+    expect(resolveClaudeCommand([], () => null).command).toBe('cmd.exe');
+  });
+
+  it('launches the native claude.exe directly on Windows so the pid matches the registry', () => {
+    setPlatform('win32');
+    // A native install resolves claude to a real PE image: node-pty must spawn it
+    // directly (pid == CLI pid == session-registry key), not wrap it in cmd.exe.
+    const find = () => ({ path: 'C:\\Users\\me\\.local\\bin\\claude.exe', direct: true });
+    expect(resolveClaudeCommand(['--resume', 'abc'], find)).toEqual({
+      command: 'C:\\Users\\me\\.local\\bin\\claude.exe',
+      args: ['--resume', 'abc'],
+    });
+  });
+
+  it('wraps a .cmd shim in cmd.exe even when found on PATH (not a PE image)', () => {
+    setPlatform('win32');
+    process.env.ComSpec = 'C:\\Windows\\System32\\cmd.exe';
+    const find = () => ({ path: 'C:\\npm\\claude.cmd', direct: false });
+    expect(resolveClaudeCommand(['--resume', 'abc'], find)).toEqual({
+      command: 'C:\\Windows\\System32\\cmd.exe',
+      args: ['/c', 'claude', '--resume', 'abc'],
+    });
+  });
+});
+
+describe('findClaudeOnWindowsPath', () => {
+  // PATHEXT extensions are conventionally upper-case (`.EXE`), so the built
+  // candidate is `claude.EXE`; the real Windows filesystem is case-insensitive
+  // and resolves it to the on-disk `claude.exe`. The mock mirrors that.
+  const ciExists = (present: string[]) => {
+    const lower = new Set(present.map(p => p.toLowerCase()));
+    return (p: string) => lower.has(p.toLowerCase());
+  };
+
+  it('resolves claude.exe as directly launchable, honoring PATH+PATHEXT order', () => {
+    const env = { PATH: 'C:\\a;C:\\b', PATHEXT: '.COM;.EXE;.BAT;.CMD' } as NodeJS.ProcessEnv;
+    const res = findClaudeOnWindowsPath(env, ciExists(['C:\\b\\claude.exe']));
+    expect(res?.direct).toBe(true);
+    expect(res?.path.toLowerCase()).toBe('c:\\b\\claude.exe');
+  });
+
+  it('flags a .cmd shim as needing a wrapper', () => {
+    const env = { PATH: 'C:\\a', PATHEXT: '.EXE;.CMD' } as NodeJS.ProcessEnv;
+    const res = findClaudeOnWindowsPath(env, ciExists(['C:\\a\\claude.cmd']));
+    expect(res?.direct).toBe(false);
+    expect(res?.path.toLowerCase()).toBe('c:\\a\\claude.cmd');
+  });
+
+  it('prefers an earlier PATH dir even when a later dir has a direct exe', () => {
+    // where.exe semantics: PATH-dir order dominates, extension order breaks ties
+    // within a dir. A .cmd in the first dir wins over a .exe in the second.
+    const env = { PATH: 'C:\\a;C:\\b', PATHEXT: '.EXE;.CMD' } as NodeJS.ProcessEnv;
+    const res = findClaudeOnWindowsPath(env, ciExists(['C:\\a\\claude.cmd', 'C:\\b\\claude.exe']));
+    expect(res?.path.toLowerCase()).toBe('c:\\a\\claude.cmd');
+    expect(res?.direct).toBe(false);
+  });
+
+  it('returns null when claude is not on PATH', () => {
+    const env = { PATH: 'C:\\a', PATHEXT: '.EXE' } as NodeJS.ProcessEnv;
+    expect(findClaudeOnWindowsPath(env, () => false)).toBeNull();
   });
 });


### PR DESCRIPTION
Two Windows-only display bugs surfaced by native (claude.exe) sessions.

1. Terminal/Lens & Mission Control showed nothing for a session opened in the embedded terminal. The session id was discovered by matching the PTY's pid against the live-session registry (~/.claude/sessions/<pid>.json), but on Windows the terminal always launched the CLI via `cmd /c claude`, so node-pty reported the cmd.exe wrapper's pid while the registry is keyed by the child claude.exe pid — the match never succeeded. A new session (no resume id) then had no session id at all, blanking both Lens and the rail.

   Fix: resolveClaudeCommand now resolves `claude` on PATH honoring PATHEXT and launches a directly-executable image (.exe/.com) itself, so the PTY pid IS the CLI pid the registry uses. Legacy npm installs (claude.cmd, not a PE image) still route through cmd.exe; for those the renderer adds an unambiguous cwd fallback (match the single live session in this folder).

2. Home "Live processes" (and several other spots) showed the full path instead of the project/file name, because the basename was taken by splitting on "/" only — Windows paths use "\". Split on both separators everywhere it displays a basename (GlobalHomeView, McpServerDetailView, MessageBubble file chips, PathChip, buildGraph, LiveMonitor); POSIX behavior is preserved.

Added unit tests for findClaudeOnWindowsPath and the resolveClaudeCommand branches (direct exe vs cmd.exe shim). typecheck + lint clean.

Claude-Session: https://claude.ai/code/session_01Xy9UfoRkniQ1rbqjdVeKyT