### PR TITLE
fix(watcher): validate data:changed scopes against a Map, not a prototype-bearing object

### DIFF
--- a/electron/modules/workflows-reader.ts
+++ b/electron/modules/workflows-reader.ts
@@ -1,5 +1,4 @@
 import { readdir, readFile, stat } from 'fs/promises';
-import { existsSync } from 'fs';
 import { basename, join } from 'path';
 import { assertWithin } from '../utils';
 
@@ -332,6 +331,16 @@ async function safeMtimeMs(path: string): Promise<number> {
   }
 }
 
+/** Async existsSync — the sync one blocks the main process event loop. */
+async function exists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // Public API
 // ──────────────────────────────────────────────────────────────────────────
@@ -455,7 +464,8 @@ export async function getWorkflowRun(
     } catch {
       continue;
     }
-    if (!existsSync(candidate)) continue;
+    // No existence probe: a missing file makes the readFile below throw, which
+    // the catch already turns into "try the next dir" — one syscall, not two.
     try {
       const detail = parseRunFile(JSON.parse(await readFile(candidate, 'utf-8')), {
         projectPath,
@@ -491,7 +501,10 @@ export async function getWorkflowRun(
     } catch {
       continue;
     }
-    if (!existsSync(transcriptDir)) continue;
+    // Load-bearing, unlike the probe above: readOrphanAgentIds swallows a
+    // missing dir into [], so without this every session dir would yield a
+    // bogus degraded detail instead of falling through to "not found".
+    if (!(await exists(transcriptDir))) continue;
     const orphanAgentIds = await readOrphanAgentIds(transcriptDir);
     const name = await recoverNameFromScript(
       join(projectPath, dirName, 'workflows', 'scripts'),

--- a/src/hooks/dataChangeScopes.ts
+++ b/src/hooks/dataChangeScopes.ts
@@ -1,0 +1,49 @@
+// Renderer half of the scoped `data:changed` protocol: the main process tags
+// each watcher event with the namespaces the changed path can affect
+// (electron/modules/data-change-scope.ts), and this table says which React
+// Query keys each namespace owns. An event only invalidates the groups it can
+// have touched — an append to a live chat's transcript has no reason to re-read
+// skills, agents or plugins (#148).
+//
+// Pure, so the payload handling is unit-tested without a DOM.
+
+// A Map, not an object literal: the scope names arrive over IPC and are used to
+// look the group up, and `'constructor' in {}` is true through the prototype
+// chain — an object would validate that scope and then hand the caller a
+// function to iterate (TypeError). A Map has no prototype keys to inherit.
+export const SCOPE_KEYS = new Map<string, string[]>([
+  ['sessions', ['sessions:project', 'sessions:chat', 'sessions:subagents', 'sessions:subagentTranscript']],
+  ['cost', ['cost:summary', 'cost:project']],
+  ['plans', ['plans:project']],
+  ['tasks', ['tasks:project']],
+  ['teams', ['teams:project', 'teams:detail']],
+  ['workflows', ['workflows:project', 'workflows:run']],
+  ['studio', ['studio:all', 'studio:blueprint']],
+  ['plugins', ['plugins:all']],
+  ['memory', ['memory:projects', 'memory:project']],
+  ['claudeMd', ['claudeMd:hierarchy', 'claudeMd:global']],
+  ['rules', ['rules:project']],
+  ['skills', ['skills:global', 'skills:all']],
+  ['agents', ['agents:global', 'agents:project']],
+  ['mcp', ['mcp:global']],
+])
+
+export const ALL_SCOPES = [...SCOPE_KEYS.keys()]
+
+/**
+ * The scopes to invalidate for one `data:changed` payload.
+ *
+ * Anything we cannot fully vouch for — absent, not an array, or carrying a
+ * single unknown entry — falls back to every scope, which is what the hook did
+ * before it was scoped at all. Never narrow on a signal we don't understand: a
+ * silently stale view is the worse failure.
+ */
+export function scopesFromPayload(scopes: unknown): string[] {
+  if (!Array.isArray(scopes)) return ALL_SCOPES;
+  return scopes.every(s => SCOPE_KEYS.has(s as string)) ? (scopes as string[]) : ALL_SCOPES;
+}
+
+/** The query keys owned by a scope; empty for an unknown one. */
+export function keysForScope(scope: string): string[] {
+  return SCOPE_KEYS.get(scope) ?? [];
+}

--- a/src/hooks/useIPC.ts
+++ b/src/hooks/useIPC.ts
@@ -1,5 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useEffect } from 'react'
+import { keysForScope, scopesFromPayload } from './dataChangeScopes'
 
 import type {
   MemoryTopic,
@@ -1075,29 +1076,6 @@ export function useDeleteProject() {
   })
 }
 
-// The filesystem-backed queries, grouped by the scope the main process derives
-// from the changed path (electron/modules/data-change-scope.ts). An event only
-// invalidates the groups it can have touched: an append to a live chat's
-// transcript has no reason to re-read skills, agents or plugins.
-const SCOPE_KEYS: Record<string, string[]> = {
-  sessions: ['sessions:project', 'sessions:chat', 'sessions:subagents', 'sessions:subagentTranscript'],
-  cost: ['cost:summary', 'cost:project'],
-  plans: ['plans:project'],
-  tasks: ['tasks:project'],
-  teams: ['teams:project', 'teams:detail'],
-  workflows: ['workflows:project', 'workflows:run'],
-  studio: ['studio:all', 'studio:blueprint'],
-  plugins: ['plugins:all'],
-  memory: ['memory:projects', 'memory:project'],
-  claudeMd: ['claudeMd:hierarchy', 'claudeMd:global'],
-  rules: ['rules:project'],
-  skills: ['skills:global', 'skills:all'],
-  agents: ['agents:global', 'agents:project'],
-  mcp: ['mcp:global'],
-}
-
-const ALL_SCOPES = Object.keys(SCOPE_KEYS)
-
 export function useDataChangedRefetch() {
   const qc = useQueryClient()
 
@@ -1114,17 +1092,13 @@ export function useDataChangedRefetch() {
       const scopes = pending
       pending = new Set()
       for (const scope of scopes) {
-        for (const key of SCOPE_KEYS[scope] ?? []) {
+        for (const key of keysForScope(scope)) {
           qc.invalidateQueries({ queryKey: [key] })
         }
       }
     }
     const unsubscribe = window.electronAPI.onDataChanged(scopes => {
-      // An absent or unrecognized payload means "unknown": invalidate
-      // everything, as the previous version always did. Never narrow on a
-      // signal we don't fully understand — a stale view is the worse failure.
-      const known = Array.isArray(scopes) && scopes.every(s => s in SCOPE_KEYS)
-      for (const scope of known ? scopes : ALL_SCOPES) pending.add(scope)
+      for (const scope of scopesFromPayload(scopes)) pending.add(scope)
       if (timer) clearTimeout(timer)
       timer = setTimeout(flush, 200)
     })

--- a/test/data-change-scopes.test.ts
+++ b/test/data-change-scopes.test.ts
@@ -1,0 +1,80 @@
+import {
+  scopesFromPayload,
+  keysForScope,
+  SCOPE_KEYS,
+  ALL_SCOPES,
+} from '../src/hooks/dataChangeScopes';
+import { scopesForPath, type DataScope } from '../electron/modules/data-change-scope';
+import { join } from 'path';
+
+describe('scopesFromPayload', () => {
+  it('passes a fully recognized payload through untouched', () => {
+    expect(scopesFromPayload(['sessions', 'cost'])).toEqual(['sessions', 'cost']);
+  });
+
+  it('falls back to every scope when the payload is absent or not an array', () => {
+    expect(scopesFromPayload(undefined)).toEqual(ALL_SCOPES);
+    expect(scopesFromPayload(null)).toEqual(ALL_SCOPES);
+    expect(scopesFromPayload('sessions')).toEqual(ALL_SCOPES);
+    expect(scopesFromPayload({ 0: 'sessions' })).toEqual(ALL_SCOPES);
+  });
+
+  it('falls back to every scope when a single entry is unknown', () => {
+    // Narrowing on a payload we don't fully understand would leave a view
+    // silently stale — the worse failure.
+    expect(scopesFromPayload(['sessions', 'not-a-scope'])).toEqual(ALL_SCOPES);
+    expect(scopesFromPayload([42])).toEqual(ALL_SCOPES);
+  });
+
+  it('does not accept Object.prototype keys as scopes', () => {
+    // The regression this module exists for: with a plain object lookup table,
+    // `'constructor' in table` is true, so the payload validated and the caller
+    // then tried to iterate a function.
+    for (const proto of ['constructor', 'toString', 'hasOwnProperty', '__proto__']) {
+      expect(SCOPE_KEYS.has(proto)).toBe(false);
+      expect(scopesFromPayload([proto])).toEqual(ALL_SCOPES);
+      expect(keysForScope(proto)).toEqual([]);
+    }
+  });
+
+  it('returns no keys for an unknown scope', () => {
+    expect(keysForScope('nope')).toEqual([]);
+  });
+});
+
+describe('scope table vs the main-process classifier', () => {
+  const CLAUDE = join('/Users', 'tester', '.claude');
+  const PROJECT = join(CLAUDE, 'projects', '-Users-tester-app');
+
+  it('has a key group for every scope the classifier can emit', () => {
+    // Guards the split brain: a new DataScope in the main process with no entry
+    // here would silently invalidate nothing.
+    const emitted = new Set<DataScope>();
+    for (const p of [
+      join(PROJECT, 'a.jsonl'),
+      join(PROJECT, 'a', 'subagents', 'agent-1.jsonl'),
+      join(PROJECT, 'a', 'workflows', 'wf.json'),
+      join(CLAUDE, 'tasks', 'a', '1.json'),
+      join(CLAUDE, 'plans', 'p.md'),
+      join(CLAUDE, 'teams', 't', 'config.json'),
+      join(CLAUDE, 'workflows', 'w.js'),
+      join(CLAUDE, 'plugins', 'installed_plugins.json'),
+    ]) {
+      for (const s of scopesForPath(p, CLAUDE) ?? []) emitted.add(s);
+    }
+    expect(emitted.size).toBeGreaterThan(0);
+    for (const scope of emitted) {
+      expect(keysForScope(scope).length).toBeGreaterThan(0);
+    }
+  });
+
+  it('never maps two scopes onto the same query key', () => {
+    const seen = new Map<string, string>();
+    for (const [scope, keys] of SCOPE_KEYS) {
+      for (const key of keys) {
+        expect(seen.has(key), `${key} claimed by both ${seen.get(key)} and ${scope}`).toBe(false);
+        seen.set(key, scope);
+      }
+    }
+  });
+});


### PR DESCRIPTION
Follow-up to #164, plus the two hardening details PR #162 got right and mine didn't.

## The bug

The scope → query-key table added in #164 was a plain object literal, and the IPC payload was validated with `s in SCOPE_KEYS`. `'constructor' in {}` is **true** through the prototype chain, so a payload of `['constructor']` passed validation and the flush loop then tried to iterate a function:

```
TypeError: function is not iterable (cannot read property Symbol(Symbol.iterator))
```

Only reachable from our own main process, so not a security hole — but the guard was simply wrong, and it was the one place the renderer trusts an IPC payload.

## The fix

Moves the table and the payload handling into a new pure module `src/hooks/dataChangeScopes.ts` — `SCOPE_KEYS` as a **Map** (no prototype keys to inherit), plus `scopesFromPayload` and `keysForScope`. Behaviour is unchanged: an absent, non-array or partially unknown payload still falls back to every scope.

Extracting it also makes the payload logic unit-testable: the vitest environment is `node` with no jsdom, so the hook itself can't be exercised, but the pure part now can.

Also replaces the last two `existsSync` calls in `workflows-reader.getWorkflowRun` with an async `exists` helper, and drops the redundant one before `readFile` — a missing file already falls into the catch that moves to the next dir, so that was two syscalls doing one job. The second probe is load-bearing and is kept (async): `readOrphanAgentIds` swallows a missing dir into `[]`, so without it every session dir would yield a bogus degraded detail instead of falling through to "not found".

## Tests

`test/data-change-scopes.test.ts` (7 tests):
- the prototype-key regression, over `constructor` / `toString` / `hasOwnProperty` / `__proto__`
- the fallback cases: absent, `null`, a bare string, an array-like object, one unknown entry, a non-string entry
- every scope the main-process classifier can actually emit has a non-empty key group (guards the split brain between the two modules)
- no query key is claimed by two scopes

`npm test` 501 passed / 3 skipped · `npm run typecheck` clean · `npm run lint` 0 errors, 13 pre-existing warnings.
