### PR TITLE
perf(utils): resolve a project cwd from the head of the transcript

### DIFF
--- a/electron/utils.ts
+++ b/electron/utils.ts
@@ -1,4 +1,13 @@
-import { readdirSync, readFileSync, statSync, realpathSync, existsSync } from 'fs';
+import {
+  readdirSync,
+  readFileSync,
+  statSync,
+  realpathSync,
+  existsSync,
+  openSync,
+  readSync,
+  closeSync,
+} from 'fs';
 import { dirname, join, resolve, sep } from 'path';
 import os from 'os';
 
@@ -130,20 +139,64 @@ export function resolveRealPath(projectsDir: string, hash: string): string {
   return hashToPath(hash);
 }
 
+// Il `cwd` sta nel primo record `user` del transcript, che nella pratica cade
+// entro i primi KB: leggere l'intero .jsonl per estrarlo costa quanto il file
+// (misurato: 6 MB -> 15 ms e +12 MB di heap transitorio per la stringa e lo
+// split, per progetto, in sincrono sul main process all'avvio). Leggiamo prima
+// una testa di 64 KB; il file intero resta il fallback perché quel primo record
+// può essere enorme (un messaggio utente con un incolla grosso) e portare il
+// `cwd` oltre il chunk — nel campione locale ~5% dei transcript, worst case
+// 1,4 MB. Senza fallback quei progetti ricadrebbero sul lossy `hashToPath`.
+const CWD_HEAD_BYTES = 64 * 1024;
+
+function findCwdInJsonl(content: string): string | null {
+  for (const line of content.split('\n')) {
+    if (!line) continue;
+    const idx = line.indexOf('"cwd"');
+    if (idx === -1) continue;
+    try {
+      const obj = JSON.parse(line);
+      if (typeof obj.cwd === 'string' && isAbsolutePath(obj.cwd)) return obj.cwd;
+    } catch {
+      // riga malformata, continua
+    }
+  }
+  return null;
+}
+
 function readCwdFromJsonl(filePath: string): string | null {
+  let fd: number | undefined;
+  let readWholeFile = false;
   try {
-    const content = readFileSync(filePath, 'utf-8');
-    for (const line of content.split('\n')) {
-      if (!line) continue;
-      const idx = line.indexOf('"cwd"');
-      if (idx === -1) continue;
+    fd = openSync(filePath, 'r');
+    const buf = Buffer.allocUnsafe(CWD_HEAD_BYTES);
+    const n = readSync(fd, buf, 0, CWD_HEAD_BYTES, 0);
+    readWholeFile = n < CWD_HEAD_BYTES;
+    const chunk = buf.subarray(0, n).toString('utf-8');
+    // Se il chunk non è tutto il file l'ultima riga è troncata a metà: scartarla
+    // evita un JSON.parse fallito su un record in realtà valido. Tagliare
+    // sull'ultimo '\n' scarta anche l'eventuale carattere UTF-8 spezzato dal
+    // confine del buffer ('\n' non compare mai dentro una sequenza multi-byte).
+    const complete = readWholeFile ? chunk : chunk.slice(0, chunk.lastIndexOf('\n') + 1);
+    const fromHead = findCwdInJsonl(complete);
+    if (fromHead) return fromHead;
+  } catch {
+    // testa illeggibile: ritenta con la lettura piena, che ha il suo catch
+  } finally {
+    if (fd !== undefined) {
       try {
-        const obj = JSON.parse(line);
-        if (typeof obj.cwd === 'string' && isAbsolutePath(obj.cwd)) return obj.cwd;
+        closeSync(fd);
       } catch {
-        // riga malformata, continua
+        // il descrittore resta chiuso dal GC, non c'è recupero utile
       }
     }
+  }
+
+  // La testa era già tutto il file: rileggerlo non troverebbe nulla di nuovo.
+  if (readWholeFile) return null;
+
+  try {
+    return findCwdInJsonl(readFileSync(filePath, 'utf-8'));
   } catch {
     // file illeggibile
   }

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,6 +1,15 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
 import { join } from 'path';
-import { isAbsolutePath, validateEntityName, assertWithin, isValidSessionId } from '../electron/utils';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync } from 'fs';
+import { tmpdir } from 'os';
+import {
+  isAbsolutePath,
+  validateEntityName,
+  assertWithin,
+  isValidSessionId,
+  resolveRealPath,
+  invalidateCwdCache,
+} from '../electron/utils';
 
 describe('isAbsolutePath', () => {
   it('accepts POSIX absolute paths', () => {
@@ -73,5 +82,85 @@ describe('isValidSessionId (issue #57)', () => {
     expect(isValidSessionId('not-a-uuid')).toBe(false);
     expect(isValidSessionId('')).toBe(false);
     expect(isValidSessionId(undefined)).toBe(false);
+  });
+});
+
+describe('resolveRealPath (cwd extraction)', () => {
+  const root = mkdtempSync(join(tmpdir(), 'cl-resolve-'));
+  let n = 0;
+
+  // Preambolo realistico: le prime righe del transcript non portano il cwd.
+  const PREAMBLE = [
+    JSON.stringify({ type: 'mode', mode: 'default' }),
+    JSON.stringify({ type: 'permission-mode', permissionMode: 'default' }),
+    JSON.stringify({ type: 'file-history-snapshot', snapshot: {} }),
+  ].join('\n');
+
+  /** Scrive un progetto con i file dati (in ordine di mtime crescente) e ne torna l'hash. */
+  function project(files: string[]): string {
+    const hash = `-tmp-fake-project-${n++}`;
+    const dir = join(root, hash);
+    mkdirSync(dir, { recursive: true });
+    files.forEach((content, i) => {
+      const full = join(dir, `s${i}.jsonl`);
+      writeFileSync(full, content);
+      // mtime crescente: l'ultimo file è il più recente, quello che il reader prova per primo.
+      utimesSync(full, new Date(1_700_000_000_000 + i * 1000), new Date(1_700_000_000_000 + i * 1000));
+    });
+    return hash;
+  }
+
+  beforeEach(() => invalidateCwdCache());
+  afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+  it('reads the cwd from the head of the file', () => {
+    const hash = project([`${PREAMBLE}\n${JSON.stringify({ type: 'user', cwd: '/Users/foo/bar' })}\n`]);
+    expect(resolveRealPath(root, hash)).toBe('/Users/foo/bar');
+  });
+
+  it('still finds a cwd that sits past the 64KB head (huge first record)', () => {
+    // Il primo record utente porta un incolla enorme e il `cwd` cade dopo di
+    // esso: la testa non basta, deve intervenire il fallback a file intero.
+    const huge = JSON.stringify({ type: 'user', text: 'x'.repeat(200_000), cwd: '/Users/foo/huge' });
+    const hash = project([`${PREAMBLE}\n${huge}\n`]);
+    expect(resolveRealPath(root, hash)).toBe('/Users/foo/huge');
+  });
+
+  it('does not mis-parse a record truncated by the head boundary', () => {
+    // Riga senza cwd tagliata a metà dal chunk; il cwd valido la segue. La 'x'
+    // iniziale sfasa di un byte i caratteri a 2 byte che seguono, così il
+    // confine dei 64 KB cade *dentro* una sequenza UTF-8 (verificato: il byte
+    // 65536 è 0xa0, un byte di continuazione) e copre anche quel caso.
+    const straddling = JSON.stringify({ type: 'assistant', text: `x${'à'.repeat(40_000)}` });
+    const hash = project([
+      `${PREAMBLE}\n${straddling}\n${JSON.stringify({ type: 'user', cwd: '/Users/foo/late' })}\n`,
+    ]);
+    expect(resolveRealPath(root, hash)).toBe('/Users/foo/late');
+  });
+
+  it('skips malformed lines and non-absolute cwd values', () => {
+    const hash = project([
+      [
+        PREAMBLE,
+        '{ not json at all "cwd"',
+        JSON.stringify({ type: 'user', cwd: 'relative/path' }),
+        JSON.stringify({ type: 'user', cwd: '/Users/foo/good' }),
+        '',
+      ].join('\n'),
+    ]);
+    expect(resolveRealPath(root, hash)).toBe('/Users/foo/good');
+  });
+
+  it('prefers the most recently modified transcript', () => {
+    const hash = project([
+      `${JSON.stringify({ type: 'user', cwd: '/Users/foo/older' })}\n`,
+      `${JSON.stringify({ type: 'user', cwd: '/Users/foo/newer' })}\n`,
+    ]);
+    expect(resolveRealPath(root, hash)).toBe('/Users/foo/newer');
+  });
+
+  it('falls back to the lossy hash inversion when no transcript carries a cwd', () => {
+    const hash = project([`${PREAMBLE}\n`]);
+    expect(resolveRealPath(root, hash)).toBe(`/${hash.replace(/^-/, '').replace(/-/g, '/')}`);
   });
 });


### PR DESCRIPTION
## Problem

`readCwdFromJsonl` (`electron/utils.ts`) read the entire `.jsonl` synchronously to extract the `cwd`, and `resolveRealPath` calls it for every project in `projects:getAll` — the app's startup path. The cost scaled linearly with the transcript size, on the main process.

Measured on a 6 MB transcript: **15.3 ms and +12.2 MB** of transient heap (the whole file as a JS string, plus the array from `split('\n')`). At the 92 MB transcript size the CLAUDE.md mentions, that extrapolates to ~230 ms of blocked main process and ~190 MB of peak allocation, per project.

## Change

Read a 64 KB head via `openSync`/`readSync`, discarding the last line when the chunk truncates it — cutting at the last `\n` also discards a UTF-8 sequence split by the buffer boundary, since `\n` never appears inside a multi-byte sequence.

The full read stays as a **fallback, and it is a correctness requirement, not a nicety**: the first user record can carry a large paste with `cwd` after it, pushing the key past the chunk. Measured across 374 local transcripts: 294 resolve within 4 KB, 62 between 4 and 64 KB, **18 (4.8%) beyond** — worst case 1.45 MB. Without the fallback those projects would silently degrade to the lossy `hashToPath` inversion.

When the head already covered the whole file, the re-read is skipped.

## Verification

- **Equivalence on real data**: compiled and compared against the previous implementation across all 15 local project dirs — **0 differences**.
- **Perf**: 5.2 ms → 1.9 ms over those 15 projects; on the 6 MB transcript, 15.3 ms / +12.2 MB → **0.2 ms / +0.1 MB**.
- **Tests**: 6 new integration tests over real files in a temp dir (no mocks) — head hit, `cwd` past 64 KB (exercises the fallback), a record truncated at the boundary with a UTF-8 sequence genuinely split (verified: byte 65536 is `0xa0`, a continuation byte), malformed lines and non-absolute `cwd` skipped, newest-transcript precedence, `hashToPath` fallback. Suite: 527 passing (from 521). Typecheck and lint clean.

Honest scope note: on a current-size dataset the saving is ~3 ms and not user-visible. The value is in the tail — keeping startup flat as a project accumulates a large transcript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FLW2iyKLHknKQQqB2FuMVt