### PR TITLE
Fix Mission Control context percentage for Claude Opus 5

### DIFF
--- a/src/components/project/terminal/MissionRail.tsx
+++ b/src/components/project/terminal/MissionRail.tsx
@@ -13,7 +13,7 @@ import {
   useSessionSubagents,
 } from '../../../hooks/useIPC';
 import type { Agent, Skill } from '../../../hooks/useIPC';
-import type { ActiveSession, ChatMessage, InitInfo, TeamSummary } from '../../../types';
+import type { ActiveSession, InitInfo, TeamSummary } from '../../../types';
 import { fmtRelative, liveLeadSession, memberColor, minutesSince, teamLabel } from '../teams/utils';
 import {
   buildProcessedMessages,
@@ -29,6 +29,8 @@ import {
 import { FileIcon } from '../chat/fileIcons';
 import { QueryError } from '../../QueryError';
 import { fmtCost, fmt } from '../utils';
+import { deriveContext } from './context-window';
+import type { ContextState } from './context-window';
 
 /**
  * The scrolling Mission Control rail beside the unified Terminal/Lens view.
@@ -58,39 +60,10 @@ const EDIT_TOOLS = new Set(['Edit', 'Write', 'MultiEdit', 'NotebookEdit']);
 const RAIL_MIN = 380;
 const RAIL_MAX = 560;
 
-/** A 1M-context variant, detected by the `[1m]`/`1m` marker on the model id or
- *  the raw `model` setting (e.g. `opus[1m]`). */
-function isOneMillion(model: string | undefined): boolean {
-  return !!model && /\[1m\]|\b1m\b/i.test(model);
-}
-
 /** Compact token count for the gauge: 156_312 → "156k", 1_240_000 → "1.2M". */
 function kTok(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   return `${Math.round(n / 1000)}k`;
-}
-
-type ContextState = { used: number; max: number; pct: number };
-
-/** CONTEXT occupancy from the latest assistant turn's usage (input + both cache
- *  tiers ≈ the prompt size sent). The transcript records only the bare model id
- *  (`claude-opus-4-8`); the 1M window is opt-in and visible only in the raw `model`
- *  setting (`opus[1m]`, from useEffectiveConfig), so trust either marker — and bump
- *  to 1M anyway if usage already exceeds 200k. */
-function deriveContext(
-  messages: ChatMessage[] | undefined,
-  rawModel: string | undefined
-): ContextState | null {
-  if (!messages) return null;
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const m = messages[i];
-    if (m.role !== 'assistant' || !m.usage) continue;
-    const used = m.usage.inputTokens + m.usage.cacheReadTokens + m.usage.cacheWriteTokens;
-    const oneM = isOneMillion(m.model) || isOneMillion(rawModel) || used > 200_000;
-    const max = oneM ? 1_000_000 : 200_000;
-    return { used, max, pct: Math.min(100, Math.round((used / max) * 100)) };
-  }
-  return null;
 }
 
 function lines(s: unknown): number {

--- a/src/components/project/terminal/context-window.ts
+++ b/src/components/project/terminal/context-window.ts
@@ -1,0 +1,31 @@
+import type { ChatMessage } from '../../../types';
+
+export type ContextState = { used: number; max: number; pct: number };
+
+const ONE_MILLION_DEFAULT_MODELS = [/^claude-opus-5(?:$|-)/i];
+
+/** Whether a resolved model id or raw model setting selects a 1M context window. */
+export function isOneMillion(model: string | undefined): boolean {
+  if (!model) return false;
+  return (
+    /\[1m\]|\b1m\b/i.test(model) || ONE_MILLION_DEFAULT_MODELS.some(pattern => pattern.test(model))
+  );
+}
+
+/** CONTEXT occupancy from the latest assistant turn's prompt usage. */
+export function deriveContext(
+  messages: ChatMessage[] | undefined,
+  rawModel: string | undefined
+): ContextState | null {
+  if (!messages) return null;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (message.role !== 'assistant' || !message.usage) continue;
+    const used =
+      message.usage.inputTokens + message.usage.cacheReadTokens + message.usage.cacheWriteTokens;
+    const oneMillion = isOneMillion(message.model) || isOneMillion(rawModel) || used > 200_000;
+    const max = oneMillion ? 1_000_000 : 200_000;
+    return { used, max, pct: Math.min(100, Math.round((used / max) * 100)) };
+  }
+  return null;
+}

--- a/test/context-window.test.ts
+++ b/test/context-window.test.ts
@@ -1,0 +1,48 @@
+import { deriveContext, isOneMillion } from '../src/components/project/terminal/context-window';
+import type { ChatMessage } from '../src/types';
+
+function assistant(model: string, used: number): ChatMessage {
+  return {
+    uuid: 'assistant',
+    role: 'assistant',
+    timestamp: '2026-07-29T00:00:00.000Z',
+    model,
+    content: [{ type: 'text', text: 'Done' }],
+    usage: {
+      inputTokens: 2,
+      outputTokens: 58,
+      cacheReadTokens: 0,
+      cacheWriteTokens: used - 2,
+    },
+  };
+}
+
+describe('Mission Control context window', () => {
+  it('recognizes Claude Opus 5 as a native 1M-context model', () => {
+    expect(isOneMillion('claude-opus-5')).toBe(true);
+    expect(isOneMillion('claude-opus-5-20260724')).toBe(true);
+  });
+
+  it('calculates the Opus 5 percentage against 1M before usage crosses 200k', () => {
+    expect(deriveContext([assistant('claude-opus-5', 49_061)], 'opus')).toEqual({
+      used: 49_061,
+      max: 1_000_000,
+      pct: 5,
+    });
+  });
+
+  it('preserves explicit 1M markers and the 200k fallback', () => {
+    expect(deriveContext([assistant('claude-sonnet-4-5', 50_000)], 'sonnet[1m]')?.max).toBe(
+      1_000_000
+    );
+    expect(deriveContext([assistant('claude-sonnet-4-5', 200_001)], 'sonnet')?.max).toBe(1_000_000);
+  });
+
+  it('keeps unmarked models below 200k on the standard context window', () => {
+    expect(deriveContext([assistant('claude-haiku-4-5', 50_000)], 'haiku')).toEqual({
+      used: 50_000,
+      max: 200_000,
+      pct: 25,
+    });
+  });
+});


### PR DESCRIPTION
## What changed

- recognize `claude-opus-5` as a native 1M-context model in Mission Control
- move the context-window calculation into a small pure helper
- add regression coverage for the observed 49,061-token session, which must display 5% rather than 25%
- preserve explicit `[1m]` detection, the over-200k fallback, and the standard 200k behavior for unmarked models

## Root cause

Mission Control selected the 1M denominator only when a model string contained an explicit `1m` marker or usage had already crossed 200k. New transcripts resolve the model as `claude-opus-5`, while the effective setting is the alias `opus`, so early turns were incorrectly divided by 200k.

## Impact

Terminal and Lens now report the correct context-window percentage for Opus 5 from the first turn, rather than correcting themselves only after the prompt exceeds 200k tokens.

## Validation

- `npm test` — 531 passed, 3 skipped
- `npm run typecheck`
- `npm run lint` — 0 errors (13 existing warnings)
- `npm run build`
- focused regression test — 4 passed
- Prettier check passes for both newly added files

The repository-wide Prettier check still reports the existing formatting baseline across 172 files; no unrelated formatting was changed.