### PR TITLE
fix(home): make the live-session row navigable before the first message

### DIFF
--- a/src/components/project/overview/GlobalHomeView.tsx
+++ b/src/components/project/overview/GlobalHomeView.tsx
@@ -18,6 +18,7 @@ import { McpServerGrid } from '../mcp/McpServerGrid';
 import { usePinnedProjects } from '../../../hooks/usePinnedProjects';
 import { PinIcon } from '../shared/SearchPopover';
 import { projectDisplayName } from '../shared/projectName';
+import { provisionalProjectHash } from '../shared/projectHash';
 
 type Project = { hash: string; realPath: string };
 
@@ -173,13 +174,24 @@ export function GlobalHomeView({
               // Split on both separators so a Windows cwd (backslashes) yields the
               // folder name, not the whole path.
               const name = p.cwd.split(/[\\/]/).filter(Boolean).pop() ?? p.cwd;
-              const proj = projectByPath.get(p.cwd);
+              // A session opened in a fresh directory is registered as live
+              // before Claude Code writes anything under `~/.claude/projects/`,
+              // so the cwd has no entry here yet. Falling back to a provisional
+              // project keeps the row navigable — its `realPath` comes straight
+              // from the registry, so everything the project view reads off the
+              // real cwd works; the history-backed parts are simply empty until
+              // the first message. Without it the row was silently inert, which
+              // read as a dead click.
+              const proj = projectByPath.get(p.cwd) ?? {
+                hash: provisionalProjectHash(p.cwd),
+                realPath: p.cwd,
+              };
               return (
                 <button
                   key={p.pid}
                   type="button"
                   className="cl-proc"
-                  onClick={() => proj && onSelectProject(proj)}
+                  onClick={() => onSelectProject(proj)}
                 >
                   <span className="led" />
                   <span className="pid">PID {p.pid}</span>

--- a/src/components/project/shared/projectHash.ts
+++ b/src/components/project/shared/projectHash.ts
@@ -1,0 +1,21 @@
+// Claude Code keeps a project's history in `~/.claude/projects/<hash>/`, where
+// the hash is the absolute cwd with its separators folded to '-'. The main
+// process never guesses that mapping backwards: it reads the authoritative cwd
+// out of a transcript (`resolveRealPath`), which is why every project the
+// renderer gets from `memory:listProjects` carries a trustworthy `realPath`.
+//
+// A session that has not written a transcript yet has no folder at all — the
+// CLI creates `~/.claude/projects/<hash>/` only on the first message, while it
+// registers the live session (with its cwd) at launch. Such a project exists
+// only in the session registry, so there is no hash to look up and nothing on
+// disk the hash could point at.
+//
+// `provisionalProjectHash` mints a disposable key for exactly that window, so
+// the project can be opened instead of being an inert row. It must survive
+// `assertValidHash` in the main process (no path separators), hence the fold of
+// '/' and '\'. It is deliberately NOT treated as correct: the exact folding
+// rule for a Windows drive letter is unverified here, and `reconcileProject`
+// swaps the whole project for the real entry as soon as the folder appears.
+export function provisionalProjectHash(cwd: string): string {
+  return cwd.replace(/[/\\:.]/g, '-');
+}

--- a/src/tabs/ProjectOverview.tsx
+++ b/src/tabs/ProjectOverview.tsx
@@ -70,6 +70,7 @@ import {
 import { GlobalHomeView } from '../components/project/overview/GlobalHomeView';
 import { DuplicateProjectsView } from '../components/project/overview/DuplicateProjectsNotice';
 import { ProjectSubtabs } from '../components/project/overview/ProjectSubtabs';
+import { provisionalProjectHash } from '../components/project/shared/projectHash';
 import { SettingsView, SettingsGearIcon } from '../components/project/settings/SettingsView';
 import { NotificationToaster } from '../components/NotificationToaster';
 
@@ -120,6 +121,17 @@ function sectionFromView(v: View): ProjectSection {
   }
 }
 
+// Re-point a view at the same project under its real identity. Views carry
+// their own copy of the project, so swapping only `selected` would leave a
+// subtab reading the provisional hash.
+function reprojectView(v: View, project: Project): View {
+  if (!('project' in v) || !v.project || v.project.realPath !== project.realPath) return v;
+  if (v.project.hash === project.hash) return v;
+  // Spreading a discriminated union widens `type` to the union of literals, so
+  // TS can't see this stays the same variant; the discriminant is untouched.
+  return { ...v, project } as View;
+}
+
 function viewForSection(section: ProjectSection, project: Project): View {
   switch (section) {
     case 'sessions':
@@ -150,10 +162,32 @@ function viewForSection(section: ProjectSection, project: Project): View {
 }
 
 export default function ProjectOverview() {
-  const [selected, setSelected] = useState<Project | null>(null);
+  const [selectedRaw, setSelected] = useState<Project | null>(null);
   const [scope, setScope] = useState<'global' | 'project'>('global');
-  const [view, setView] = useState<View>({ type: 'global-home' });
+  const [viewRaw, setView] = useState<View>({ type: 'global-home' });
   const [projectToDelete, setProjectToDelete] = useState<Project | null>(null);
+
+  const { data: projects } = useMemoryProjects();
+
+  // A project opened from a live session that had not written a transcript yet
+  // carries a provisional hash (see `provisionalProjectHash`). The moment
+  // Claude Code creates its folder, the watcher refreshes this list with the
+  // authoritative entry — matched by `realPath`, the field the registry gives
+  // us verbatim — so read through to it instead of staying pinned to a key that
+  // points nowhere. Derived rather than synced into state: the swap has to be
+  // visible on the render that first sees the real entry, and a setState in an
+  // effect would only re-render into it a beat later.
+  const selected = useMemo(() => {
+    if (!selectedRaw || !projects) return selectedRaw;
+    const real = projects.find(p => p.realPath === selectedRaw.realPath);
+    return real && real.hash !== selectedRaw.hash ? real : selectedRaw;
+  }, [selectedRaw, projects]);
+  // Views hold their own copy of the project, so the same swap has to reach the
+  // open subtab — otherwise it would keep querying the provisional hash.
+  const view = useMemo(
+    () => (selected ? reprojectView(viewRaw, selected) : viewRaw),
+    [viewRaw, selected]
+  );
 
   // Anonymous: report which section is opened (view type only — no project,
   // session, or path data). Deduped per app run inside reportViewOpened.
@@ -161,7 +195,6 @@ export default function ProjectOverview() {
     reportViewOpened(view.type);
   }, [view.type]);
 
-  const { data: projects } = useMemoryProjects();
   const { data: costSummary } = useCostSummary();
   const { data: globalSkills = [] } = useGlobalSkills();
   const { data: scopedSkills = [] } = useAllSkills(selected?.realPath ?? null);
@@ -325,12 +358,13 @@ export default function ProjectOverview() {
   // "Open session" from a notification toast: deep-link straight into the exact
   // session (the unified Terminal↔Lens view, defaulting to read-only Lens — the
   // same teleport as Mission Control), mirroring SearchPopover's onSelectSession.
-  // Resolve the project by its working dir; fall back to deriving the hash from
-  // the cwd (the `/`→`-` convention) when it isn't in the cache yet. Without a
-  // session id, fall back to the project's sessions list.
+  // Resolve the project by its working dir; fall back to a provisional hash
+  // when it isn't in the cache yet (the previous inline `/`→`-` replace left a
+  // Windows cwd full of backslashes, which the main process rejects outright).
+  // Without a session id, fall back to the project's sessions list.
   function openSessionFromNotification(cwd: string, sessionId: string) {
     const project = projects?.find(p => p.realPath === cwd) ?? {
-      hash: cwd.replace(/\//g, '-'),
+      hash: provisionalProjectHash(cwd),
       realPath: cwd,
     };
     setSelected(project);

--- a/test/project-hash.test.ts
+++ b/test/project-hash.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { provisionalProjectHash } from '../src/components/project/shared/projectHash';
+
+describe('provisionalProjectHash', () => {
+  it('folds a POSIX cwd the way Claude Code names its project folder', () => {
+    expect(provisionalProjectHash('/Users/foo/Projects/Bar')).toBe('-Users-foo-Projects-Bar');
+  });
+
+  it('folds dots, which the folder name collapses too', () => {
+    expect(provisionalProjectHash('/Users/foo/Projects/SARA2.0')).toBe(
+      '-Users-foo-Projects-SARA2-0'
+    );
+  });
+
+  // The main process rejects any hash carrying a path separator (assertValidHash),
+  // so a Windows cwd has to come out fully folded or every query for that project
+  // fails outright instead of reading empty.
+  it('leaves no path separator in a Windows cwd', () => {
+    const hash = provisionalProjectHash('C:\\Users\\foo\\Projects\\Bar');
+    expect(hash).not.toMatch(/[/\\]/);
+    expect(hash).toBe('C--Users-foo-Projects-Bar');
+  });
+
+  it('leaves no path separator in a UNC cwd', () => {
+    expect(provisionalProjectHash('\\\\server\\share\\proj')).not.toMatch(/[/\\]/);
+  });
+});


### PR DESCRIPTION
## The bug

Open Claude Code in a directory it has never seen and the new project shows up on the ClaudeLens home — but clicking it does nothing. It only becomes clickable after you send at least one message.

## Cause

Verified live on 2.1.226 (a PTY session parked at the prompt, nothing sent):

1. `~/.claude/sessions/<pid>.json` is written **at launch** — pid, `sessionId`, `cwd`, `status: "idle"`
2. `~/.claude/projects/<hash>/` and its `.jsonl` appear **only on the first message**

So in that window the project exists solely in the session registry: it renders in the home "Live processes" section, while `memory:listProjects` (the folders under `~/.claude/projects`) has never heard of it. The row's handler was

```tsx
const proj = projectByPath.get(p.cwd);          // realPath-keyed, built from that list
onClick={() => proj && onSelectProject(proj)}   // miss → short-circuit → dead click
```

Sending a message created the folder, `resolveRealPath` read the authoritative cwd from the `.jsonl`, the lookup matched and the row came alive — which is why this read as Windows-specific instead of the general case it is.

## Fix

- **The row always navigates.** It falls back to a provisional project whose `realPath` comes verbatim from the registry, so everything the project view reads off the real cwd (CLAUDE.md, config, project skills/agents, rules) works immediately; only the history-backed parts are empty, which is the truth.
- **The provisional identity is disposable.** No folder exists yet, so no hash is "correct" — `provisionalProjectHash` just folds `/`, `\`, `:` and `.` to `-`. `selected` and `view` are now derived from raw state: when the watcher refreshes the list with the real entry, it is matched by `realPath` and read through to, and `reprojectView` applies the same swap to the project a view carries so an open subtab stops querying the stale key. Derived rather than synced in an effect, so the swap lands on the render that first sees the real entry (and it keeps `react-hooks/set-state-in-effect` happy).
- **Windows deep-link fixed in passing.** The notification handler derived its hash with `cwd.replace(/\//g, '-')`, which leaves backslashes — and `assertValidHash` in the main process rejects any hash carrying a separator, so every query for that project failed outright. It now shares the helper.

## Notes

No write guard was needed: `useCreateTopic` has no caller, so the UI offers no way to create a memory topic and nothing can materialize a folder under a provisional hash. The remaining hash-based writes edit topics that already exist — which a project with no folder cannot have.

Reads degrade to empty on a missing folder (they glob a directory that isn't there), so the provisional project view is blank, not broken.

## Verification

`format:check`, `typecheck`, `lint` (`--max-warnings 0`) and `test` (623 pass, incl. 4 new cases pinning that no path separator survives a Windows/UNC cwd) are green. UI behavior still needs a manual pass on Windows: open a fresh directory, click the live row before typing anything, then send a message and confirm the sessions appear in the already-open view (that is the reconciliation firing).