### PR TITLE
feat(mission-control): give memory activity its own block in the rail

### DIFF
--- a/src/components/project/CLAUDE.md
+++ b/src/components/project/CLAUDE.md
@@ -88,6 +88,14 @@ Formatter puri (nessuna dipendenza React):
 
 > La lista dei topic della vista `project-memory` è renderizzata da `ProjectView` (`overview/ProjectOverviewContent.tsx`, `section === 'memory'`) con `cl-tile-grid`/`cl-tile`, allineata a Skills/Agents.
 
+**Secondo ingresso — Mission Control:** il rail (`terminal/MissionRail.tsx`) ha un blocco **MEMORY** (`MemoryCard`/`MemoryRow`) che mostra l'**attività di memoria della sessione** — topic letti, creati, revisionati — **estratti da CHANGES**. Il modello dati è puro e unit-tested in `chat/utils.ts` (`buildMemoryActivity` → `MemoryTouch[]` + `indexOps`, con `memoryScopeOf`/`memoryTypeFromFilename`/`memoryTitleFromFilename`/`writeAction`; test in `test/chat-utils.test.ts`). Ragioni delle scelte, tutte verificate sui transcript reali:
+
+- **L'unità è il topic, non il file.** Su disco ricordare un fatto è sempre `Write` di `<slug>.md` **più** `Edit` di `MEMORY.md`: dentro una lista di file diventavano due righe di bookkeeping (`feedback_x.md +12 −0`, `MEMORY.md +1 −1`) che non dicevano mai _cosa_ è stato ricordato. Le operazioni sull'indice degradano a una nota `index MEMORY.md` in coda al blocco; i file di memoria sono esclusi da CHANGES (`isMemoryFile`) per non contarli due volte nei totali di riga
+- **Le letture stanno qui.** Un `Read` su un topic è l'unica traccia visibile di quali memorie hanno informato la sessione. Il recall automatico **non** è visibile: arriva come `<system-reminder>` e non passa da nessun tool (come una `rm` da `Bash`, che non porta `file_path`)
+- **`new` vs `revised` si legge dal tool result** (`File created successfully at:` vs `has been updated`), l'unico posto che lo dice; quando non lo dice l'azione resta `wrote` invece di mentire. Un `Write` batte un `Edit` successivo nel rank (`new > revised > wrote > read`), i topic mutati flottano sopra quelli solo letti
+- **Una riga per topic, niente description in riga.** Il `name` di una memoria è spesso già una frase: stampare nome + description raddoppiava lo stesso fatto e rendeva un blocco di due topic alto come la lista AGENTS. La description vive nel tooltip con il path; niente diff bar (`+12/−0` su una memoria non misura nulla di interessante); il tally nell'eyebrow appare solo oltre 3 topic. Per un `Edit` (che non porta frontmatter) nome/description/tipo arrivano dall'indice su disco via `useMemoryProject`, con fallback sul prefisso del filename — la regola di `memory-reader`
+- Il tag di tipo usa `MEMORY_TYPE_TAG`/`MEMORY_TYPE_TINT` (`chat/utils.ts`): le stesse tinte di `MEMORY_TYPE_STYLE` mappate sui token brand (`--cl-cyan`/`--cl-warn`/`--cl-ok`/`--cl-violet`), encoding di una dimensione dato come `modelColor`, non un accento nuovo
+
 ---
 
 ### `claudemd/`

--- a/src/components/project/chat/utils.ts
+++ b/src/components/project/chat/utils.ts
@@ -1,6 +1,7 @@
 import {
   ChatMessage,
   ChatContentBlock,
+  MemoryTopic,
   SubagentMeta,
   Skill,
   InstalledPlugin,
@@ -865,6 +866,24 @@ export const MEMORY_TYPE_STYLE: Record<MemoryType, { badge: string; label: strin
   },
 };
 
+/** Mono tag + data tint per memory type, for the dense surfaces (Mission
+ *  Control's MEMORY block) where the Tailwind badge above is too heavy. The
+ *  hues mirror `MEMORY_TYPE_STYLE` on the brand tokens — an encoding of a data
+ *  dimension, like `modelColor`, not a new accent. */
+export const MEMORY_TYPE_TAG: Record<MemoryType, string> = {
+  user: 'USER',
+  feedback: 'FDBK',
+  project: 'PROJ',
+  reference: 'REF',
+};
+
+export const MEMORY_TYPE_TINT: Record<MemoryType, string> = {
+  user: 'var(--cl-cyan)',
+  feedback: 'var(--cl-warn)',
+  project: 'var(--cl-ok)',
+  reference: 'var(--cl-violet)',
+};
+
 export function parseMemoryFrontmatter(content: string): ParsedMemory | null {
   const match = content.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
   if (!match) return null;
@@ -882,17 +901,178 @@ export function parseMemoryFrontmatter(content: string): ParsedMemory | null {
 // swallowed unrelated paths that merely have a `memory` segment somewhere below
 // `.claude` — `~/.claude/skills/memory/SKILL.md` was being dressed up as a
 // memory operation, violet tint and all.
-const MEMORY_DIRS = [
-  /\/\.claude\/memory\//, //                  <repo>/.claude/memory/…
-  /\/\.claude\/projects\/[^/]+\/memory\//, // ~/.claude/projects/<hash>/memory/…
+const MEMORY_DIRS: Array<[RegExp, MemoryScope]> = [
+  [/\/\.claude\/memory\//, 'project'], //                <repo>/.claude/memory/…
+  [/\/\.claude\/projects\/[^/]+\/memory\//, 'user'], // ~/.claude/projects/<hash>/memory/…
 ];
+
+/** Which of the two memory directories a path belongs to, or null if neither.
+ *  The distinction is worth keeping: a project-level topic is committed to the
+ *  repo, a user-level one lives only in this machine's history folder. */
+export function memoryScopeOf(path: string): MemoryScope | null {
+  // Normalize backslashes so the check works on Windows paths too
+  const normalized = path.replace(/\\/g, '/');
+  return MEMORY_DIRS.find(([re]) => re.test(normalized))?.[1] ?? null;
+}
 
 export function isMemoryFile(input: Record<string, unknown>): boolean {
   const path = input.file_path as string | undefined;
-  if (!path) return false;
-  // Normalize backslashes so the check works on Windows paths too
-  const normalized = path.replace(/\\/g, '/');
-  return MEMORY_DIRS.some(re => re.test(normalized));
+  return !!path && memoryScopeOf(path) !== null;
+}
+
+/* ── memory activity ──────────────────────────────────────────────────────
+ * A session's memory operations, read as *topics touched* rather than as files
+ * changed. The two are genuinely different units: on disk, remembering one fact
+ * is always a `Write` of `<slug>.md` plus an `Edit` of `MEMORY.md`, so a
+ * file-oriented reading reports two rows of bookkeeping and never says what was
+ * remembered. Reads count too — they are the only visible evidence of which
+ * memories informed the session.
+ *
+ * What this cannot see, by construction: memories recalled automatically (they
+ * arrive as a `<system-reminder>`, not a tool call) and topics deleted with
+ * `rm` (a `Bash` call carries no `file_path`).
+ */
+
+export type MemoryScope = 'user' | 'project';
+
+/** `read` < `wrote` < `revised` < `new` — the strongest one labels the row. */
+export type MemoryAction = 'read' | 'wrote' | 'revised' | 'new';
+
+const ACTION_RANK: Record<MemoryAction, number> = { read: 0, wrote: 1, revised: 2, new: 3 };
+
+export type MemoryTouch = {
+  /** Full path of the topic file — the row's stable identity. */
+  path: string;
+  /** Readable topic name: the frontmatter `name` when a write carried one, else
+   *  the on-disk index, else derived from the filename. */
+  title: string;
+  type: MemoryType;
+  scope: MemoryScope;
+  description: string;
+  /** Every operation on this topic, in transcript order. */
+  items: ToolGroup[];
+  reads: number;
+  writes: number;
+  action: MemoryAction;
+  hasError: boolean;
+};
+
+export type MemoryActivity = {
+  /** Topics touched, mutated ones first, each in order of first appearance. */
+  touches: MemoryTouch[];
+  /** Operations on the `MEMORY.md` index — bookkeeping, not a topic. */
+  indexOps: ToolGroup[];
+};
+
+/** Resolves a topic file to what the on-disk index knows about it — used as the
+ *  fallback for an `Edit`, whose input carries no frontmatter. */
+export type MemoryLookup = (
+  path: string
+) => Pick<MemoryTopic, 'name' | 'description' | 'type'> | undefined;
+
+const MEMORY_TOOLS = new Set(['Read', 'Write', 'Edit', 'MultiEdit']);
+const TYPE_PREFIX: Array<[string, MemoryType]> = [
+  ['feedback_', 'feedback'],
+  ['project_', 'project'],
+  ['reference_', 'reference'],
+];
+
+function basename(path: string): string {
+  return path.replace(/\\/g, '/').split('/').pop() ?? path;
+}
+
+/** `MEMORY.md` is the index, not a topic. */
+export function isMemoryIndex(path: string): boolean {
+  return basename(path) === 'MEMORY.md';
+}
+
+/** `feedback_no_manual_app_launch.md` → `feedback` (memory-reader's own rule:
+ *  the filename prefix is the type when frontmatter doesn't say). */
+export function memoryTypeFromFilename(path: string): MemoryType {
+  const name = basename(path);
+  return TYPE_PREFIX.find(([prefix]) => name.startsWith(prefix))?.[1] ?? 'user';
+}
+
+/** `feedback_no_manual_app_launch.md` → `no-manual-app-launch`, i.e. the slug
+ *  the topic's own frontmatter `name` would carry. */
+export function memoryTitleFromFilename(path: string): string {
+  const name = basename(path).replace(/\.md$/i, '');
+  const stripped = TYPE_PREFIX.reduce(
+    (acc, [prefix]) => (acc.startsWith(prefix) ? acc.slice(prefix.length) : acc),
+    name
+  );
+  return stripped.replace(/_/g, '-');
+}
+
+/** Whether a `Write` created the file or overwrote an existing one — read from
+ *  the tool result, the only place that says. `wrote` when it doesn't (no result
+ *  yet on a live turn, or unrecognised wording): claiming either would lie. */
+export function writeAction(result: string | null | undefined): MemoryAction {
+  if (!result) return 'wrote';
+  if (/file created successfully/i.test(result)) return 'new';
+  if (/has been updated/i.test(result)) return 'revised';
+  return 'wrote';
+}
+
+export function buildMemoryActivity(groups: ToolGroup[], lookup?: MemoryLookup): MemoryActivity {
+  const byPath = new Map<string, MemoryTouch>();
+  const indexOps: ToolGroup[] = [];
+
+  for (const g of groups) {
+    if (!MEMORY_TOOLS.has(g.use.name)) continue;
+    const input = g.use.input as Record<string, unknown>;
+    const path = input.file_path as string | undefined;
+    if (!path) continue;
+    const scope = memoryScopeOf(path);
+    if (!scope) continue;
+    if (isMemoryIndex(path)) {
+      indexOps.push(g);
+      continue;
+    }
+
+    let t = byPath.get(path);
+    if (!t) {
+      const known = lookup?.(path);
+      t = {
+        path,
+        title: known?.name || memoryTitleFromFilename(path),
+        type: known?.type ?? memoryTypeFromFilename(path),
+        scope,
+        description: known?.description ?? '',
+        items: [],
+        reads: 0,
+        writes: 0,
+        action: 'read',
+        hasError: false,
+      };
+      byPath.set(path, t);
+    }
+    t.items.push(g);
+    t.hasError ||= !!g.result?.isError;
+
+    if (g.use.name === 'Read') {
+      t.reads += 1;
+      continue;
+    }
+    t.writes += 1;
+    const action = g.use.name === 'Write' ? writeAction(g.result?.content) : 'revised';
+    if (ACTION_RANK[action] > ACTION_RANK[t.action]) t.action = action;
+
+    // A full `Write` carries the topic's frontmatter, which beats anything the
+    // filename or a stale index can tell us about this session's version.
+    const parsed = typeof input.content === 'string' ? parseMemoryFrontmatter(input.content) : null;
+    if (parsed) {
+      if (parsed.name) t.title = parsed.name;
+      if (parsed.description) t.description = parsed.description;
+      if (parsed.type) t.type = parsed.type;
+    }
+  }
+
+  const all = [...byPath.values()];
+  return {
+    touches: [...all.filter(t => t.writes > 0), ...all.filter(t => t.writes === 0)],
+    indexOps,
+  };
 }
 
 export function resolveToolIcon(name: string, input: Record<string, unknown>): string {

--- a/src/components/project/terminal/MissionRail.tsx
+++ b/src/components/project/terminal/MissionRail.tsx
@@ -5,6 +5,7 @@ import {
   useChatSession,
   useEffectiveConfig,
   useGlobalAgents,
+  useMemoryProject,
   useProjectAgents,
   useProjectTasks,
   useProjectTeams,
@@ -12,16 +13,23 @@ import {
   useSessionList,
   useSessionSubagents,
 } from '../../../hooks/useIPC';
-import type { Agent, Skill } from '../../../hooks/useIPC';
+import type { Agent, MemoryTopic, Skill } from '../../../hooks/useIPC';
 import type { ActiveSession, InitInfo, TeamSummary } from '../../../types';
 import { fmtRelative, liveLeadSession, memberColor, minutesSince, teamLabel } from '../teams/utils';
 import {
+  buildMemoryActivity,
   buildProcessedMessages,
   correlateSessionAgents,
   correlateSessionSkills,
   fileExt,
+  isMemoryFile,
   skillHasViewableOutput,
   AGENT_TOOLS,
+  MEMORY_TYPE_TAG,
+  MEMORY_TYPE_TINT,
+  MemoryAction,
+  MemoryActivity,
+  MemoryTouch,
   ToolGroup,
   SessionAgent,
   SessionSkill,
@@ -925,6 +933,192 @@ function SkillsCard({
   );
 }
 
+/* ── MEMORY island ────────────────────────────────────────────────────── */
+
+const MEMORY_ACTION_LABEL: Record<MemoryAction, string> = {
+  new: 'NEW',
+  revised: 'REVISED',
+  wrote: 'WROTE',
+  read: 'READ',
+};
+
+/** A remembered fact is the rail's one durable outcome — it outlives the session
+ *  — so its label is the only one that takes the accent. A consultation is
+ *  context, not an outcome: muted. */
+const MEMORY_ACTION_TINT: Record<MemoryAction, string> = {
+  new: 'var(--cl-accent-ink)',
+  revised: 'var(--cl-ink-2)',
+  wrote: 'var(--cl-ink-2)',
+  read: 'var(--cl-ink-4)',
+};
+
+/** One topic row in the MEMORY block: a colour-coded type tag, the topic's own
+ *  name, and what happened to it — one line, no rule under it.
+ *
+ *  The description is deliberately NOT printed: a memory's `name` is often
+ *  already a sentence, so name-over-description printed the same fact twice and
+ *  made a two-topic block as tall as the AGENTS list. It rides the tooltip
+ *  instead, with the path. No diff bars either — +12/−0 on a memory file
+ *  measures nothing a reader cares about. */
+function MemoryRow({
+  touch,
+  compact,
+  onOpenTool,
+}: {
+  touch: MemoryTouch;
+  compact: boolean;
+  onOpenTool: (g: ToolGroup) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const many = touch.items.length > 1;
+  const count = touch.writes > 0 ? touch.writes : touch.reads;
+  const tint = MEMORY_TYPE_TINT[touch.type] ?? MEMORY_TYPE_TINT.user;
+
+  return (
+    <div>
+      <button
+        type="button"
+        className="tmc-row w-full text-left grid items-baseline"
+        title={[touch.title, touch.description, touch.path].filter(Boolean).join('\n')}
+        onClick={() => (many ? setOpen(v => !v) : onOpenTool(touch.items[0]))}
+        style={{
+          gridTemplateColumns: '34px minmax(0,1fr) auto',
+          gap: 9,
+          padding: `${compact ? 4 : 5}px 4px`,
+          margin: '0 -4px',
+          borderRadius: 6,
+          cursor: 'pointer',
+        }}
+      >
+        <span
+          className="font-mono"
+          style={{ fontSize: 8.5, fontWeight: 700, letterSpacing: '0.08em', color: tint }}
+        >
+          {MEMORY_TYPE_TAG[touch.type] ?? MEMORY_TYPE_TAG.user}
+        </span>
+        <span
+          className="truncate min-w-0"
+          style={{
+            fontSize: compact ? 11 : 11.5,
+            color: touch.hasError ? 'var(--cl-danger)' : 'var(--cl-ink-2)',
+          }}
+        >
+          {touch.title}
+          {touch.scope === 'project' && (
+            <span className="font-mono" style={{ fontSize: 8.5, color: 'var(--cl-ink-4)' }}>
+              {' '}
+              repo
+            </span>
+          )}
+          {many && <span style={{ color: 'var(--cl-ink-4)' }}> {open ? '▾' : '▸'}</span>}
+        </span>
+        <span
+          className="font-mono shrink-0"
+          style={{
+            fontSize: 8.5,
+            fontWeight: 700,
+            letterSpacing: '0.06em',
+            whiteSpace: 'nowrap',
+            color: touch.hasError ? 'var(--cl-danger)' : MEMORY_ACTION_TINT[touch.action],
+          }}
+        >
+          {touch.hasError ? 'FAILED' : MEMORY_ACTION_LABEL[touch.action]}
+          {count > 1 && <span style={{ fontWeight: 400 }}> ×{count}</span>}
+        </span>
+      </button>
+      {open &&
+        [...touch.items].reverse().map((g, i) => (
+          <button
+            key={g.use.id || i}
+            type="button"
+            className="tmc-row w-full text-left flex items-center gap-2"
+            onClick={() => onOpenTool(g)}
+            style={{ padding: '3px 4px 3px 43px', margin: '0 -4px', fontSize: 10.5 }}
+          >
+            <span style={{ color: 'var(--cl-ink-3)' }}>{g.use.name}</span>
+            {g.result?.isError && (
+              <span className="font-mono" style={{ fontSize: 9, color: 'var(--cl-danger)' }}>
+                ERROR
+              </span>
+            )}
+          </button>
+        ))}
+    </div>
+  );
+}
+
+/** Full-width MEMORY block — the session's memory activity, kept apart from
+ *  CHANGES. On disk a remembered fact is always a `Write` of `<slug>.md` plus an
+ *  `Edit` of `MEMORY.md`, so inside a file list it read as two rows of
+ *  bookkeeping (`feedback_no_manual_app_launch.md +12 −0`, `MEMORY.md +1 −1`)
+ *  that never said what was learned. Reads sit here too: they are the only
+ *  visible trace of which memories informed the session (an automatic recall
+ *  arrives as a `<system-reminder>` and passes through no tool at all). The
+ *  index edits degrade to one muted footnote. */
+function MemoryCard({
+  activity,
+  compact,
+  onOpenTool,
+}: {
+  activity: MemoryActivity;
+  compact: boolean;
+  onOpenTool: (g: ToolGroup) => void;
+}) {
+  const { touches, indexOps } = activity;
+  // Counted per topic, not per operation, so the caption matches the row badges:
+  // a topic both written and read counts once, under its write. Only worth
+  // printing once the rows outgrow a glance — beside two rows reading NEW and
+  // READ, "1 new · 1 read" is the same sentence twice.
+  const tally =
+    touches.length > 3
+      ? (['new', 'revised', 'wrote'] as MemoryAction[])
+          .map(a => ({ a, n: touches.filter(t => t.writes > 0 && t.action === a).length }))
+          .concat([{ a: 'read' as MemoryAction, n: touches.filter(t => t.writes === 0).length }])
+          .filter(x => x.n > 0)
+          .map(x => `${x.n} ${MEMORY_ACTION_LABEL[x.a].toLowerCase()}`)
+          .join(' · ')
+      : '';
+
+  return (
+    <section style={railSection}>
+      <RailEyebrow
+        label="MEMORY"
+        n={touches.length}
+        extra={
+          <span
+            className="font-mono shrink-0"
+            style={{ fontSize: 9, color: 'var(--cl-ink-4)', whiteSpace: 'nowrap' }}
+          >
+            {tally}
+          </span>
+        }
+      />
+      {touches.map(t => (
+        <MemoryRow key={t.path} touch={t} compact={compact} onOpenTool={onOpenTool} />
+      ))}
+      {indexOps.length > 0 && (
+        <button
+          type="button"
+          className="tmc-row w-full text-left font-mono"
+          // Bookkeeping: one click opens the most recent index edit, which is the
+          // only one that reflects the index as it now stands.
+          onClick={() => onOpenTool(indexOps[indexOps.length - 1])}
+          title="MEMORY.md — the index Claude keeps in sync with the topics"
+          style={{
+            padding: '5px 4px 0 43px',
+            margin: '0 -4px',
+            fontSize: 8.5,
+            letterSpacing: '0.04em',
+            color: 'var(--cl-ink-4)',
+          }}
+        >
+          index MEMORY.md{indexOps.length > 1 ? ` ×${indexOps.length}` : ''}
+        </button>
+      )}
+    </section>
+  );
+}
+
 /* ── TEAMS island ─────────────────────────────────────────────────────── */
 
 type TeamRailRow = { team: TeamSummary; lead: ActiveSession | undefined };
@@ -1287,12 +1481,31 @@ export function MissionRail({
     () => correlateSessionSkills(processed, allSkills ?? [], plugins ?? []).reverse(),
     [processed, allSkills, plugins]
   );
+  const ownTools = useMemo(
+    () => processed.flatMap(p => p.toolGroups).filter(g => !AGENT_TOOLS.has(g.use.name)),
+    [processed]
+  );
+  // MEMORY — the session's memory activity, its own block (below). An `Edit` of a
+  // topic carries no frontmatter, so the on-disk index supplies the name and
+  // description; the query is already mounted by the memory views and the
+  // watcher keeps it fresh.
+  const { data: memory } = useMemoryProject(hash);
+  const memoryLookup = useMemo(() => {
+    const byFilename = new Map<string, MemoryTopic>();
+    for (const t of memory?.index ?? []) byFilename.set(t.filename, t);
+    for (const t of memory?.projectLevelIndex ?? []) byFilename.set(t.filename, t);
+    return (path: string) => byFilename.get(path.replace(/\\/g, '/').split('/').pop() ?? path);
+  }, [memory]);
+  const memoryActivity = useMemo(
+    () => buildMemoryActivity(ownTools, memoryLookup),
+    [ownTools, memoryLookup]
+  );
+  // CHANGES excludes the memory files: they are a topic each, not a diff, and
+  // reporting them twice would double-count the session's line totals.
   const changes = useMemo(
     () =>
-      buildFileChanges(
-        processed.flatMap(p => p.toolGroups).filter(g => !AGENT_TOOLS.has(g.use.name))
-      ),
-    [processed]
+      buildFileChanges(ownTools.filter(g => !isMemoryFile(g.use.input as Record<string, unknown>))),
+    [ownTools]
   );
   const areas = useMemo(() => groupByArea(changes, realPath), [changes, realPath]);
   const totals = useMemo(
@@ -1336,6 +1549,7 @@ export function MissionRail({
     agents.length === 0 &&
     skills.length === 0 &&
     changes.length === 0 &&
+    memoryActivity.touches.length === 0 &&
     tasks.length === 0 &&
     projectTeamCount === 0;
 
@@ -1634,6 +1848,12 @@ export function MissionRail({
         {/* SKILLS — pills → output / definition / tool call */}
         {skills.length > 0 && (
           <SkillsCard skills={skills} onOpenTool={onOpenTool} onOpenSkillDef={onOpenSkillDef} />
+        )}
+
+        {/* MEMORY island — topics read/created/revised, ahead of CHANGES: what the
+            session learned reads before what it touched */}
+        {memoryActivity.touches.length > 0 && (
+          <MemoryCard activity={memoryActivity} compact={compact} onOpenTool={onOpenTool} />
         )}
 
         {/* CHANGES island — grouped by repo area (comfortable) or a flat list (compact) */}

--- a/test/chat-utils.test.ts
+++ b/test/chat-utils.test.ts
@@ -17,6 +17,11 @@ import {
   parseAnswersFromResultText,
   isQuestionDismissed,
   isMemoryFile,
+  buildMemoryActivity,
+  memoryScopeOf,
+  memoryTypeFromFilename,
+  memoryTitleFromFilename,
+  writeAction,
   touchedFiles,
 } from '../src/components/project/chat/utils';
 import { ChatMessage, ChatContentBlock, SubagentMeta, Skill, InstalledPlugin } from '../src/types';
@@ -918,5 +923,130 @@ describe('touchedFiles', () => {
       group('MultiEdit', { file_path: '/a/three.py', edits: [] }),
     ] as never);
     expect(files.map(f => f.path)).toEqual(['/a/three.py']);
+  });
+});
+
+describe('memory activity', () => {
+  const MEM = '/Users/t/.claude/projects/-Users-t-app/memory';
+  const op = (name: string, input: Record<string, unknown>, result?: string, isError = false) => ({
+    use: { id: `t-${name}-${input.file_path}`, name, input },
+    result:
+      result === undefined
+        ? null
+        : { type: 'tool_result', toolUseId: 't', content: result, isError },
+  });
+  const frontmatter = (name: string, description: string, type: string, body = 'the fact') =>
+    `---\nname: ${name}\ndescription: ${description}\nmetadata:\n  type: ${type}\n---\n\n${body}\n`;
+
+  it('reads scope from the two memory dirs and nothing else', () => {
+    expect(memoryScopeOf(`${MEM}/x.md`)).toBe('user');
+    expect(memoryScopeOf('/Users/t/app/.claude/memory/x.md')).toBe('project');
+    expect(memoryScopeOf('/Users/t/.claude/skills/memory/SKILL.md')).toBeNull();
+  });
+
+  it('derives type and title from the filename when frontmatter is absent', () => {
+    expect(memoryTypeFromFilename('feedback_no_manual_app_launch.md')).toBe('feedback');
+    expect(memoryTypeFromFilename('reference_icloud.md')).toBe('reference');
+    expect(memoryTypeFromFilename('project_x.md')).toBe('project');
+    expect(memoryTypeFromFilename('plain_note.md')).toBe('user');
+    expect(memoryTitleFromFilename(`${MEM}/feedback_no_manual_app_launch.md`)).toBe(
+      'no-manual-app-launch'
+    );
+  });
+
+  // The wording of the Write result is the only place that says whether the file
+  // existed; when it doesn't say, neither do we.
+  it('distinguishes a created topic from an overwritten one via the tool result', () => {
+    expect(writeAction(`File created successfully at: ${MEM}/x.md`)).toBe('new');
+    expect(writeAction(`The file ${MEM}/x.md has been updated successfully.`)).toBe('revised');
+    expect(writeAction(null)).toBe('wrote');
+    expect(writeAction('something else entirely')).toBe('wrote');
+  });
+
+  it('groups the Write + MEMORY.md Edit pair into one topic plus an index op', () => {
+    const { touches, indexOps } = buildMemoryActivity([
+      op(
+        'Write',
+        {
+          file_path: `${MEM}/feedback_no_manual_app_launch.md`,
+          content: frontmatter(
+            'no-manual-app-launch',
+            'Non lanciare l app manualmente',
+            'feedback'
+          ),
+        },
+        `File created successfully at: ${MEM}/feedback_no_manual_app_launch.md`
+      ),
+      op('Edit', { file_path: `${MEM}/MEMORY.md`, old_string: 'a', new_string: 'b' }, 'updated'),
+    ] as never);
+
+    expect(touches).toHaveLength(1);
+    expect(touches[0]).toMatchObject({
+      title: 'no-manual-app-launch',
+      type: 'feedback',
+      scope: 'user',
+      description: 'Non lanciare l app manualmente',
+      action: 'new',
+      writes: 1,
+      reads: 0,
+    });
+    expect(indexOps).toHaveLength(1);
+  });
+
+  it('keeps a read-only topic, and lets the on-disk index name an Edit', () => {
+    const lookup = (path: string) =>
+      path.endsWith('reference_icloud.md')
+        ? {
+            name: 'icloud-dataless-files',
+            description: 'File dataless stallano',
+            type: 'reference' as const,
+          }
+        : undefined;
+    const { touches } = buildMemoryActivity(
+      [
+        op('Read', { file_path: `${MEM}/project_x.md` }, 'body'),
+        op(
+          'Edit',
+          { file_path: `${MEM}/reference_icloud.md`, old_string: 'a', new_string: 'b' },
+          'ok'
+        ),
+        op(
+          'Edit',
+          { file_path: `${MEM}/reference_icloud.md`, old_string: 'c', new_string: 'd' },
+          'ok'
+        ),
+      ] as never,
+      lookup
+    );
+
+    // Mutated topics float first, read-only ones follow.
+    expect(touches.map(t => t.title)).toEqual(['icloud-dataless-files', 'x']);
+    expect(touches[0]).toMatchObject({
+      action: 'revised',
+      writes: 2,
+      description: 'File dataless stallano',
+    });
+    expect(touches[1]).toMatchObject({ action: 'read', reads: 1, writes: 0 });
+  });
+
+  it('ranks a create above later revisions of the same topic, and flags failures', () => {
+    const { touches } = buildMemoryActivity([
+      op(
+        'Write',
+        { file_path: `${MEM}/user_me.md`, content: 'no frontmatter' },
+        `File created successfully at: ${MEM}/user_me.md`
+      ),
+      op('Edit', { file_path: `${MEM}/user_me.md` }, 'String not found', true),
+    ] as never);
+    expect(touches[0]).toMatchObject({ action: 'new', writes: 2, hasError: true });
+  });
+
+  it('ignores tools outside the memory dirs and tools with no path', () => {
+    const { touches, indexOps } = buildMemoryActivity([
+      op('Write', { file_path: '/Users/t/app/src/index.ts', content: 'x' }, 'created'),
+      op('Bash', { command: `rm ${MEM}/user_me.md` }, ''),
+    ] as never);
+    expect(touches).toEqual([]);
+    expect(indexOps).toEqual([]);
   });
 });


### PR DESCRIPTION
Memory operations landed in CHANGES like any other file edit. On disk, remembering one fact is always a `Write` of `<slug>.md` plus an `Edit` of `MEMORY.md`, so a file-oriented reading reported two rows of bookkeeping — `feedback_no_manual_app_launch.md +12 −0`, `MEMORY.md +1 −1` — and never said what was learned.

The new **MEMORY** block reads the same tool calls as *topics touched*, one line per topic, placed just before CHANGES: what the session learned reads before what it touched.

```
MEMORY  2 ──────────────────────────────────────
 FDBK   Check for existing PRs and branches…   NEW
 FDBK   Query invalidation strategy for file…  READ
        index MEMORY.md
```

## What it shows

- **Reads too, not just writes.** A `Read` of a topic is the only visible trace of which memories informed the session.
- **`NEW` vs `REVISED` from the tool result** (`File created successfully at:` vs `has been updated`) — the only place that says. When it doesn't say, the action stays `WROTE` rather than guessing.
- Topics mutated in the session float above read-only ones; repeated operations collapse into one expandable row (`×N`); a project-level topic is marked `repo` (it is committed to the repo).
- An `Edit` carries no frontmatter, so name/description/type fall back to the on-disk index (`useMemoryProject`) and then to the filename prefix — `memory-reader`'s own rule.

## Design notes

- **One line per topic, description in the tooltip.** A memory's `name` is often already a sentence, so name-over-description printed the same fact twice and made a two-topic block as tall as the AGENTS list. No diff bars either: `+12/−0` on a memory file measures nothing a reader cares about. The eyebrow tally appears only past 3 topics.
- Type tags reuse the `MEMORY_TYPE_STYLE` hues mapped onto brand tokens (`--cl-cyan`/`--cl-warn`/`--cl-ok`/`--cl-violet`) — a data encoding like `modelColor`, not a new accent.
- Memory files are excluded from CHANGES so the session's line totals don't count them twice.

## Known blind spots (by construction)

- A memory **recalled automatically** is invisible here: it arrives as a `<system-reminder>` and passes through no tool at all.
- A topic **deleted with `rm`** is invisible too: a `Bash` call carries no `file_path`.

## Testing

Model logic (`buildMemoryActivity`, `memoryScopeOf`, `memoryTypeFromFilename`, `memoryTitleFromFilename`, `writeAction`) is pure and lives in `chat/utils.ts`, with 7 new cases in `test/chat-utils.test.ts` — the Write+`MEMORY.md` pair, read-only topics, action ranking, index fallback, failed operations, exclusions. Full suite green (662 passed), typecheck + lint clean. UI verified against real `~/.claude/` data by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T1svfhctecUz2tgmqEt9WN