### PR TITLE
fix(watcher): stop every transcript append from invalidating the whole cache

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -100,6 +100,7 @@ import { executeMerge } from './modules/duplicate-merge-executor';
 import {
   resolveRealPath,
   invalidateCwdCache,
+  hasResolvedCwd,
   canonicalize,
   CLAUDE_DIR,
   isValidSessionId,
@@ -2022,9 +2023,16 @@ async function startWatcher() {
   // A transcript is often added before its first complete JSONL record. Treat
   // add/change/unlink as one debounced registry update so the authoritative cwd
   // replaces any temporary, lossy hash-derived workflow path.
+  //
+  // `isResolved` bounds that to the window where it is true. The sync ends in an
+  // unscoped `notify()` — every query cache — and a project's transcript path is
+  // shaped exactly like a new project's, so without it every append of every live
+  // session paid for the whole invalidation. `discoverKnownProjectPaths()` above
+  // has already resolved every project on disk, so in steady state this is silent.
   const studioWatchSync = createProjectWorkflowWatchSync({
     projectsDir: PROJECTS_DIR,
     invalidate: invalidateCwdCache,
+    isResolved: hasResolvedCwd,
     sync: () => {
       syncProjectWorkflowDirs();
       // The immediate event may have refetched through a temporary hash-derived

--- a/electron/modules/studio-watch-sync.ts
+++ b/electron/modules/studio-watch-sync.ts
@@ -1,6 +1,16 @@
 // Keeps Agent Studio's project-local workflow watchers aligned with Claude's
 // project registry. Registry transcripts are created before their first complete
 // JSONL record, so add and change events must be treated as one debounced update.
+//
+// That "and change" is why this coordinator needs `isResolved`. A project's
+// transcript path is indistinguishable from a *newly created* project's, and a
+// live session appends to it continuously — so without the predicate every
+// append re-ran the sync, and the sync ends in an unscoped `data:changed` that
+// invalidates every React Query cache. The scoped-invalidation work (#148) was
+// therefore inert during exactly the workload it was written for: a live chat.
+//
+// The predicate states the coordinator's actual job — react while a project's
+// authoritative cwd is still unknown, go quiet once it has been read.
 
 import { isAbsolute, relative, sep } from 'path';
 
@@ -18,11 +28,19 @@ export function createProjectWorkflowWatchSync({
   projectsDir,
   invalidate,
   sync,
+  isResolved,
   delayMs = 100,
 }: {
   projectsDir: string;
   invalidate: (hash: string) => void;
   sync: () => void;
+  /**
+   * True when `hash` already has an authoritative cwd. Events for such a
+   * project are dropped: there is nothing left to learn from them, and the
+   * sync they would trigger is a full-cache invalidation. Omitted = every
+   * event is processed, the behaviour before the predicate existed.
+   */
+  isResolved?: (hash: string) => boolean;
   delayMs?: number;
 }): { onEvent: (eventPath: string) => void } {
   const pendingHashes = new Set<string>();
@@ -39,6 +57,9 @@ export function createProjectWorkflowWatchSync({
     onEvent(eventPath: string) {
       const hash = projectHashForRegistryEvent(projectsDir, eventPath);
       if (!hash) return;
+      // Checked on arrival, not at flush time: the point is to never arm the
+      // timer for a settled project, so a busy session stays entirely silent.
+      if (isResolved?.(hash)) return;
 
       pendingHashes.add(hash);
       if (timer) clearTimeout(timer);

--- a/electron/utils.ts
+++ b/electron/utils.ts
@@ -112,6 +112,19 @@ export function invalidateCwdCache(hash?: string): void {
   else cwdCache.clear();
 }
 
+/**
+ * True quando il cwd autoritativo di `hash` è già stato letto da un transcript.
+ *
+ * La cache è popolata SOLO da una lettura riuscita: il fallback lossy di
+ * `hashToPath` non viene mai memorizzato, quindi "in cache" significa
+ * esattamente "risolto dal disco, non stimato dal nome cartella". È il segnale
+ * che serve a chi osserva il registry per capire se su un progetto c'è ancora
+ * qualcosa da imparare.
+ */
+export function hasResolvedCwd(hash: string): boolean {
+  return cwdCache.has(hash);
+}
+
 export function resolveRealPath(projectsDir: string, hash: string): string {
   const cached = cwdCache.get(hash);
   if (cached) return cached;

--- a/test/studio-watch-sync.test.ts
+++ b/test/studio-watch-sync.test.ts
@@ -37,6 +37,61 @@ describe('project workflow watcher sync', () => {
     expect(notifyAfterSync).toHaveBeenCalledTimes(1);
   });
 
+  it('stays silent while a live session appends to a resolved project', () => {
+    // The regression: a transcript append is shaped exactly like a new
+    // project's first write, so every one of them used to arm the timer and
+    // fire the sync — whose `notify()` carries no scopes and therefore drops
+    // every React Query cache (#148 inert during a live chat).
+    vi.useFakeTimers();
+    const invalidate = vi.fn();
+    const sync = vi.fn();
+    const coordinator = createProjectWorkflowWatchSync({
+      projectsDir: '/claude/projects',
+      invalidate,
+      sync,
+      isResolved: hash => hash === '-Users-me-repo',
+      delayMs: 100,
+    });
+
+    for (let i = 0; i < 40; i++) {
+      coordinator.onEvent('/claude/projects/-Users-me-repo/session.jsonl');
+      vi.advanceTimersByTime(30); // appends land faster than the debounce
+    }
+    vi.advanceTimersByTime(500);
+
+    expect(invalidate).not.toHaveBeenCalled();
+    expect(sync).not.toHaveBeenCalled();
+  });
+
+  it('still reacts for a project whose cwd is not resolved yet', () => {
+    vi.useFakeTimers();
+    const invalidate = vi.fn();
+    const sync = vi.fn();
+    // A project appears; its cwd becomes readable only after the first record.
+    const resolved = new Set<string>();
+    const coordinator = createProjectWorkflowWatchSync({
+      projectsDir: '/claude/projects',
+      invalidate,
+      sync: () => {
+        resolved.add('-Users-me-new');
+        sync();
+      },
+      isResolved: hash => resolved.has(hash),
+      delayMs: 100,
+    });
+
+    coordinator.onEvent('/claude/projects/-Users-me-new'); // addDir
+    coordinator.onEvent('/claude/projects/-Users-me-new/session.jsonl'); // add, still empty
+    vi.advanceTimersByTime(100);
+    expect(invalidate).toHaveBeenCalledWith('-Users-me-new');
+    expect(sync).toHaveBeenCalledTimes(1);
+
+    // Once resolved, the session's own appends no longer cost anything.
+    coordinator.onEvent('/claude/projects/-Users-me-new/session.jsonl');
+    vi.advanceTimersByTime(500);
+    expect(sync).toHaveBeenCalledTimes(1);
+  });
+
   it('ignores paths outside the project registry and nested transcript artifacts', () => {
     expect(projectHashForRegistryEvent('/claude/projects', '/elsewhere/session.jsonl')).toBeNull();
     expect(

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -9,6 +9,7 @@ import {
   isValidSessionId,
   resolveRealPath,
   invalidateCwdCache,
+  hasResolvedCwd,
 } from '../electron/utils';
 
 describe('isAbsolutePath', () => {
@@ -172,5 +173,29 @@ describe('resolveRealPath (cwd extraction)', () => {
   it('falls back to the lossy hash inversion when no transcript carries a cwd', () => {
     const hash = project([`${PREAMBLE}\n`]);
     expect(resolveRealPath(root, hash)).toBe(`/${hash.replace(/^-/, '').replace(/-/g, '/')}`);
+  });
+
+  describe('hasResolvedCwd', () => {
+    it('turns true only once a cwd has been read off disk', () => {
+      const hash = project([`${JSON.stringify({ type: 'user', cwd: '/Users/foo/known' })}\n`]);
+      expect(hasResolvedCwd(hash)).toBe(false);
+      resolveRealPath(root, hash);
+      expect(hasResolvedCwd(hash)).toBe(true);
+    });
+
+    it('stays false when the resolve fell back to the lossy hash inversion', () => {
+      // Load-bearing for the registry watch-sync: an estimated path is not an
+      // answer, so the coordinator must keep listening for the real record.
+      const hash = project([`${PREAMBLE}\n`]);
+      resolveRealPath(root, hash);
+      expect(hasResolvedCwd(hash)).toBe(false);
+    });
+
+    it('goes back to false when the entry is invalidated (e.g. after a merge)', () => {
+      const hash = project([`${JSON.stringify({ type: 'user', cwd: '/Users/foo/merged' })}\n`]);
+      resolveRealPath(root, hash);
+      invalidateCwdCache(hash);
+      expect(hasResolvedCwd(hash)).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
## The bug

The scoped `data:changed` protocol (#148) was inert during exactly the workload it was written for: a live chat or terminal session.

Every watcher event runs two notifications (`electron/main.ts`):

```ts
const notifyAndRefreshStudioWatches = (path: string) => {
  studioWatchSync.onEvent(path);            // debounced, ends in notify()
  notify(scopesForPath(path, CLAUDE_DIR));  // correctly narrowed
};
```

The second correctly tags an append to `projects/<hash>/<id>.jsonl` as `sessions|cost|plans|memory`. The first, 100 ms later, flushes into a `sync()` that ends with a bare `notify()` — no scopes — which `scopesFromPayload` reads as `ALL_SCOPES`. Both land inside the renderer's 200 ms debounce window, so the union wins and the narrowing never takes effect.

The cause is in `projectHashForRegistryEvent`: it cannot tell a **new** project from an append to an existing one, because both are `projects/<hash>/<something>.jsonl`. The flat layout is the live one on disk (`<hash>/<uuid>.jsonl`), so every write of every running session matched.

## What it cost

Every ~100 ms during an active session:

- `invalidateCwdCache(hash)` drops a cwd that never changed, forcing the next `resolveRealPath` to redo `readdirSync` + a `statSync` per transcript + a 64 KB read — **synchronously on the main process**
- `syncProjectWorkflowDirs()` re-sweeps the whole project registry
- all fourteen namespaces refetch: `skills`, `agents`, `plugins`, `mcp:global` (a `claude mcp list` subprocess), `teams:project` (a serial walk of every session dir), `studio:all`, `claudeMd`, `rules`, `cost:summary`, …

None of which a transcript append can affect.

## The fix

The coordinator takes an `isResolved` predicate and drops events for projects whose authoritative cwd is already known — a statement of its actual job: react while the cwd is still unknown, go quiet once it has been read.

The window it was written for survives intact: a project dir appears, its transcript is added before carrying a complete record, and events keep flowing until the `cwd` line is readable.

`hasResolvedCwd` is backed by the existing `cwdCache`, which only ever stores a value read off disk — the lossy `hashToPath` fallback is deliberately not cached, so *resolved* means *authoritative*, never *estimated*. In steady state the predicate is true for everything, because `discoverKnownProjectPaths()` already resolves every project when the watcher is set up.

## Tests

Both new watch-sync tests fail against the previous behaviour:

- 40 appends to a resolved project never arm the timer
- an unresolved project still triggers exactly one sync, and goes quiet once resolved

Plus three on `hasResolvedCwd`, including the load-bearing one: a resolve that fell back to the lossy inversion leaves it `false`.

## Verification

`format:check`, `typecheck`, `lint --max-warnings 0`, 667 tests and `build` all green.

The reduction in refetch traffic is not observable from a test — it wants a human pass with a live session running.