### PR TITLE
build(macos): sign and notarize releases when the Apple secrets exist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,60 @@ jobs:
       - name: Build renderer + electron
         run: npm run build
 
+      # macOS is packaged on its own path because it is the only platform with a
+      # signing story. It is deliberately conditional: with the Apple secrets
+      # configured the DMG is signed with the Developer ID certificate and
+      # notarized, and without them the job produces exactly the unsigned build
+      # it produced before — so forks, and this repo before the certificate
+      # exists, keep releasing. Setup: docs/macos-signing.md.
+      - name: Package mac (x64 + arm64)
+        id: package-mac
+        if: matrix.platform == 'mac'
+        env:
+          CSC_LINK: ${{ secrets.MACOS_CERTIFICATE }}
+          CSC_KEY_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          if [ -n "$CSC_LINK" ] && [ -n "$APPLE_ID" ] && [ -n "$APPLE_TEAM_ID" ]; then
+            echo "signed=true" >> "$GITHUB_OUTPUT"
+            npx electron-builder --mac --publish never -c.mac.notarize=true
+          else
+            echo "signed=false" >> "$GITHUB_OUTPUT"
+            echo "::warning title=Unsigned macOS build::No Apple signing secrets configured; users will need the quarantine workaround. See docs/macos-signing.md."
+            # Without this electron-builder would pick up any stray identity in
+            # the runner keychain and sign with something we did not choose.
+            CSC_IDENTITY_AUTO_DISCOVERY=false npx electron-builder --mac --publish never
+          fi
+
+      # A DMG that builds is not the same as a DMG Gatekeeper accepts, and the
+      # difference only surfaces on a user's Mac after the release is out. Assert
+      # it here: valid signature, accepted by policy, and a stapled notarization
+      # ticket (the last one is what makes a first launch work offline).
+      - name: Verify signature and notarization
+        if: steps.package-mac.outputs.signed == 'true'
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          apps=(release/mac*/ClaudeLens.app)
+          # Without nullglob + this check a renamed output dir would surface as a
+          # confusing "codesign: no such file", indistinguishable from a real
+          # signing failure.
+          if [ ${#apps[@]} -eq 0 ]; then
+            echo "No packaged .app found under release/ — did electron-builder's output layout change?" >&2
+            exit 1
+          fi
+          for app in "${apps[@]}"; do
+            echo "── $app"
+            codesign --verify --deep --strict --verbose=2 "$app"
+            spctl --assess --type execute --verbose=4 "$app"
+            xcrun stapler validate "$app"
+          done
+
       - name: Package ${{ matrix.platform }} (x64 + arm64)
+        if: matrix.platform != 'mac'
         run: npx electron-builder --${{ matrix.platform }} --publish never
 
       - name: Upload binaries
@@ -75,8 +128,9 @@ jobs:
           path: artifacts
           merge-multiple: true
 
-      # The builds are unsigned, so a checksum is the only way for someone to
-      # tell the download matches what CI produced. Shipped as a release asset.
+      # Checksums cover every platform, including the ones with no signing story
+      # at all (Linux, Windows), and stay useful for macOS as a cheap integrity
+      # check that needs no Apple tooling to verify. Shipped as a release asset.
       - name: Generate SHA-256 checksums
         working-directory: artifacts
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,18 @@ Release without overwriting its notes. Don't run `npm run electron:build` or
 attach assets by hand; just wait for the workflow and verify the assets landed
 (`gh release view vX.Y.Z --json assets`).
 
+**macOS signing is wired but conditional** (`docs/macos-signing.md`). The mac job
+signs with a Developer ID certificate and notarizes when the repo has the five
+Apple secrets, and falls back to the historical unsigned DMG when it doesn't —
+so forks and this repo pre-certificate keep releasing. The build config
+(`hardenedRuntime` + `build/entitlements.mac.*.plist`) is inert until an identity
+exists; the entitlements are the short list a hardened Electron app needs, and
+the app must stay **unsandboxed** (it reads `~/.claude`, drives arbitrary project
+dirs and spawns the `claude` CLI through a pty). When a signed build ships,
+three pieces of user-facing text about the quarantine workaround go stale —
+README, Settings → General (`QUARANTINE_CMD`) and `UpdateBanner.tsx` — and
+`electron-updater` becomes possible for the first time.
+
 ## Architecture
 
 ClaudeLens is an Electron app that reads Claude Code's local data from `~/.claude/`.

--- a/build/entitlements.mac.inherit.plist
+++ b/build/entitlements.mac.inherit.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Entitlements for the Electron helper processes (Renderer, GPU, Plugin), signed
+  separately from the main bundle.
+
+  They match the main app's list rather than inheriting it: `com.apple.security.inherit`
+  is a sandbox mechanism, and ClaudeLens is not sandboxed (see entitlements.mac.plist),
+  so each helper has to carry the exceptions it needs itself. The renderer helper is
+  the one actually running V8, so dropping the JIT entitlements here would break the
+  app even though the main bundle has them.
+-->
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+  </dict>
+</plist>

--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Entitlements for the signed macOS build (see docs/macos-signing.md).
+
+  Notarization requires the hardened runtime, which switches on protections that
+  a stock Electron app trips over — hence the four exceptions below. Each one is
+  a hole in that armour, so the list stays as short as the app can run with.
+
+  Deliberately NOT here: com.apple.security.app-sandbox. ClaudeLens reads
+  Claude Code's data straight out of ~/.claude, drives project directories
+  anywhere on disk, and spawns the `claude` CLI through a pty. The sandbox would
+  confine it to a container and break all three, so this is a hardened but
+  unsandboxed app — which is what Developer ID distribution outside the App Store
+  expects.
+-->
+<plist version="1.0">
+  <dict>
+    <!-- V8 compiles JavaScript at runtime; without JIT the renderer will not start. -->
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+
+    <!-- V8 also writes to pages it later executes, which the hardened runtime
+         blocks separately from the JIT entitlement above. -->
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+
+    <!-- Electron's helper processes are configured through DYLD_* variables,
+         which the hardened runtime strips by default. -->
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+
+    <!-- Native modules loaded from outside the asar (node-pty, the Agent SDK —
+         see `asarUnpack` in package.json) are not covered by the main bundle's
+         signature, so library validation has to allow them. -->
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+  </dict>
+</plist>

--- a/docs/macos-signing.md
+++ b/docs/macos-signing.md
@@ -1,0 +1,199 @@
+# macOS code signing and notarization
+
+ClaudeLens currently ships **unsigned**. macOS quarantines the download, the
+first launch fails with _"ClaudeLens is damaged and can't be opened"_ or
+_"cannot be opened because the developer cannot be verified"_, and every new
+user has to be talked through a Terminal command before the app will start —
+[README](../README.md#macos), Settings → General, and the update banner all
+carry that workaround today.
+
+The release workflow can sign and notarize instead. It is **opt-in**: with the
+Apple secrets configured, the mac job signs with a Developer ID certificate and
+notarizes; without them it produces the same unsigned DMG as before, so forks
+and secret-less runs keep working. This document is the setup.
+
+Everything on the repository side is already in place — entitlements
+(`build/entitlements.mac.*.plist`), the `build.mac` block in `package.json`, and
+the conditional path in `.github/workflows/release.yml`. What is missing is an
+Apple Developer account and five GitHub secrets.
+
+---
+
+## What it costs
+
+- **Apple Developer Program membership — $99/year.** There is no free tier for
+  Developer ID signing. A free Apple ID can only sign apps for the machine that
+  built them, which does nothing for distribution.
+- **~5–15 extra minutes per release**, waiting on Apple's notary service.
+
+Nothing else changes: the app stays outside the Mac App Store, unsandboxed, and
+free to read `~/.claude`.
+
+---
+
+## Setup
+
+You only do this once. Steps 1–2 need a Mac; the rest is browser and GitHub.
+
+### 1. Create a Developer ID Application certificate
+
+Only the **Developer ID Application** type works for distribution outside the
+App Store. Do not use "Apple Development" or "Mac App Distribution".
+
+1. On your Mac, open **Keychain Access** → menu **Keychain Access** →
+   **Certificate Assistant** → **Request a Certificate From a Certificate
+   Authority…**
+2. Enter your email and name, select **Saved to disk**, and save the
+   `CertificateSigningRequest.certSigningRequest` file.
+3. Go to [developer.apple.com/account/resources/certificates](https://developer.apple.com/account/resources/certificates),
+   click **+**, choose **Developer ID Application**, and upload the CSR.
+4. Download the resulting `.cer` and double-click it to install it into your
+   login keychain.
+
+### 2. Export it as a `.p12`
+
+1. In **Keychain Access** → **My Certificates**, find
+   `Developer ID Application: <your name> (<TEAMID>)`.
+2. Right-click → **Export…** → format **Personal Information Exchange (.p12)**.
+   Expand the certificate first and confirm it has a private key underneath — a
+   `.p12` exported without one cannot sign.
+3. Set a strong export password and keep it; it becomes
+   `MACOS_CERTIFICATE_PASSWORD`.
+4. Base64-encode it for GitHub:
+
+   ```bash
+   base64 -i ClaudeLens.p12 | tr -d '\n' | pbcopy
+   ```
+
+   The `tr` matters — a secret with embedded newlines fails to decode in CI.
+
+### 3. Create an app-specific password
+
+Notarization authenticates as your Apple ID, and will not accept your real
+password.
+
+1. Go to [appleid.apple.com](https://appleid.apple.com) → **Sign-In and
+   Security** → **App-Specific Passwords**.
+2. Generate one (name it e.g. `ClaudeLens notarization`) and copy the
+   `xxxx-xxxx-xxxx-xxxx` value.
+
+### 4. Find your Team ID
+
+[developer.apple.com/account](https://developer.apple.com/account) →
+**Membership details** → **Team ID**. Ten characters, e.g. `A1B2C3D4E5`. It is
+also the part in parentheses in your certificate's name.
+
+### 5. Add the GitHub secrets
+
+**Settings → Secrets and variables → Actions → New repository secret**, five
+times:
+
+| Secret                        | Value                                       |
+| ----------------------------- | ------------------------------------------- |
+| `MACOS_CERTIFICATE`           | base64 of the `.p12` from step 2            |
+| `MACOS_CERTIFICATE_PASSWORD`  | the `.p12` export password                  |
+| `APPLE_ID`                    | the Apple ID email of the developer account |
+| `APPLE_APP_SPECIFIC_PASSWORD` | the app-specific password from step 3       |
+| `APPLE_TEAM_ID`               | the Team ID from step 4                     |
+
+The workflow takes the signed path only when `MACOS_CERTIFICATE`, `APPLE_ID` and
+`APPLE_TEAM_ID` are all set. A partial set silently falls back to unsigned, so
+add all five.
+
+### 6. Release and check
+
+Cut a release as usual (see [CLAUDE.md](../CLAUDE.md#release)). In the mac job:
+
+- **Package mac** should not print the "Unsigned macOS build" warning.
+- **Verify signature and notarization** runs `codesign --verify`,
+  `spctl --assess` and `xcrun stapler validate` against both architectures. The
+  job fails if any of them rejects the app, so a broken signature cannot reach a
+  release unnoticed.
+
+Then confirm on a real machine — ideally one that has never run a ClaudeLens
+build, since Gatekeeper caches verdicts per app:
+
+```bash
+# Download the DMG through a browser so it actually carries the quarantine flag,
+# then, after dragging to /Applications:
+spctl --assess --type execute --verbose=4 /Applications/ClaudeLens.app
+# → /Applications/ClaudeLens.app: accepted
+#   source=Notarized Developer ID
+```
+
+Double-clicking should open the app with no Terminal step and no scary dialog.
+
+---
+
+## After it works: clean up the workarounds
+
+Signing makes three pieces of user-facing text wrong. They are intentionally
+left in place until a signed build has actually shipped — remove them in a
+follow-up, not in advance:
+
+- `README.md` — the `xattr -d com.apple.quarantine` step in **Installation →
+  macOS**, and the sentence in **Updates** that explains why there is no
+  auto-install.
+- `src/components/project/settings/SettingsView.tsx` — the `QUARANTINE_CMD`
+  block in `UpdatesBlock` (Settings → General).
+- `src/components/UpdateBanner.tsx` — the "Unsigned build" footnote.
+
+Signing also unblocks **automatic updates**, which are off today for exactly
+this reason: Squirrel.Mac refuses unsigned bundles, and a silently swapped app
+would land quarantined anyway. Once releases are signed and notarized,
+`electron-updater` becomes a real option. That is a separate piece of work with
+its own failure modes — treat it as a follow-up, not part of this change.
+
+---
+
+## Troubleshooting
+
+**`No identity found` / the build is unsigned despite the secrets.** The `.p12`
+was exported without its private key, or the base64 has newlines in it. Re-do
+step 2, expanding the certificate to confirm the key is included, and re-copy
+with the `tr -d '\n'` above.
+
+**Notarization fails with `Team is not yet configured for notarization`.** A new
+Developer Program membership can take up to ~24h to be enabled for the notary
+service. Retry the next day.
+
+**Notarization fails with `Invalid` and mentions the hardened runtime.** The app
+was signed without `hardenedRuntime` or without the entitlements — notarization
+requires both. `package.json` sets them; check nothing overrode `build.mac`.
+
+**Notarization is rejected for an unsigned nested binary.** Something under
+`asarUnpack` (node-pty, the Agent SDK) shipped a helper electron-builder did not
+sign. Get the log for the exact path:
+
+```bash
+xcrun notarytool log <submission-id> \
+  --apple-id "$APPLE_ID" --team-id "$APPLE_TEAM_ID" --password "$APPLE_APP_SPECIFIC_PASSWORD"
+```
+
+**The app is notarized but still warns on first launch.** The ticket is probably
+not stapled — without it Gatekeeper has to reach Apple, which fails offline. The
+release job's `xcrun stapler validate` catches this; if it passed and users still
+see a warning, check that they are not running a cached older copy.
+
+---
+
+## Signing locally (optional)
+
+Not needed for releases — CI does it — but useful when debugging entitlements.
+With the certificate in your login keychain:
+
+```bash
+npm run build
+
+export APPLE_ID="you@example.com"
+export APPLE_APP_SPECIFIC_PASSWORD="xxxx-xxxx-xxxx-xxxx"
+export APPLE_TEAM_ID="A1B2C3D4E5"
+
+npx electron-builder --mac -c.mac.notarize=true
+```
+
+To package unsigned the way CI does without secrets:
+
+```bash
+CSC_IDENTITY_AUTO_DISCOVERY=false npx electron-builder --mac
+```

--- a/package.json
+++ b/package.json
@@ -127,7 +127,13 @@
           ]
         }
       ],
-      "icon": "./assets/icon4.icns"
+      "icon": "./assets/icon4.icns",
+      "category": "public.app-category.developer-tools",
+      "hardenedRuntime": true,
+      "entitlements": "build/entitlements.mac.plist",
+      "entitlementsInherit": "build/entitlements.mac.inherit.plist",
+      "gatekeeperAssess": false,
+      "notarize": false
     },
     "linux": {
       "target": [


### PR DESCRIPTION
## What this changes

ClaudeLens ships unsigned, so macOS quarantines every download: the first launch fails with _"ClaudeLens is damaged and can't be opened"_, and each new user has to be walked through an `xattr` command in Terminal before the app will start. It's the largest piece of friction between a release and someone actually using it — and it's also why there's no auto-update, since Squirrel.Mac refuses unsigned bundles.

This wires up the entire signing path and leaves it **dormant until a certificate exists**. Nothing about the current unsigned release changes until the secrets are added.

- **`build/entitlements.mac.plist`** (+ a helper variant). Notarization requires the hardened runtime, which a stock Electron app trips over, so four exceptions are granted: JIT and writable-executable memory for V8, DYLD variables for Electron's helpers, and library validation off for the native modules living outside the asar (node-pty, the Agent SDK). The helpers repeat the list rather than inheriting it — `com.apple.security.inherit` is a sandbox mechanism, and this app is deliberately **not** sandboxed: it reads `~/.claude`, drives arbitrary project directories, and spawns the `claude` CLI through a pty. The sandbox would break all three.
- **`build.mac`** gains `hardenedRuntime` + the entitlements, with `notarize` off by default.
- **`.github/workflows/release.yml`** packages macOS on its own path. With `MACOS_CERTIFICATE`, `APPLE_ID` and `APPLE_TEAM_ID` present it signs and notarizes; without them it forces `CSC_IDENTITY_AUTO_DISCOVERY=false` and emits exactly the unsigned DMG it emitted before — so forks, and this repo pre-certificate, keep releasing. A signed build is then checked with `codesign --verify`, `spctl --assess` and `xcrun stapler validate` **before** upload: a DMG that packages is not the same as a DMG Gatekeeper accepts, and that difference otherwise only surfaces on a user's Mac after the release is public.
- **`docs/macos-signing.md`** covers the part that can't be automated.

## What you need to do

This PR can't finish the job on its own — it needs an **Apple Developer Program membership ($99/year)**. There's no free tier for Developer ID signing. Once you have it, `docs/macos-signing.md` walks through creating the certificate, exporting the `.p12`, and adding five repository secrets:

| Secret | Value |
| --- | --- |
| `MACOS_CERTIFICATE` | base64 of the `.p12` |
| `MACOS_CERTIFICATE_PASSWORD` | the `.p12` export password |
| `APPLE_ID` | the developer account email |
| `APPLE_APP_SPECIFIC_PASSWORD` | from appleid.apple.com |
| `APPLE_TEAM_ID` | 10 chars, from Membership details |

Cost on the release side is ~5–15 min extra per release, waiting on Apple's notary service.

Until then, merging this is a no-op for users: the mac job logs an `::warning::` and produces the same artifact as today.

## How to verify

The signing path itself can't be exercised without a certificate, so what's verifiable here is that the config is valid and the unsigned path is unchanged:

```bash
# electron-builder validates the full config schema before any platform work.
npm run build
npx electron-builder --linux --dir --publish never
```

To confirm that validation actually covers the new `build.mac` block rather than skipping it, add a bogus property (e.g. `hardenedRuntimeXX`) and re-run — electron-builder refuses with `Invalid configuration object … configuration.mac should be one of these`, at `validateConfiguration`, before it reaches the native rebuild. The real config gets past that point. (In a sandbox without network the run then fails at node-gyp fetching Electron headers; on a normal machine it completes.)

Also checked: `-c.mac.notarize=true` parses as a CLI override, both entitlements plists parse as plists and contain no `app-sandbox` key, `release.yml` is valid YAML, and both branches of the verification step's glob logic behave (empty → explicit failure, populated → both architectures).

Standard gate: `npm run typecheck`, `npm run lint`, `npm test` (667 passing), `npm run build` all pass.

Post-merge, the real verification is the first signed release — the workflow's own verify step gates it, and the doc has a `spctl --assess` check to run on a clean Mac.

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] `npm run build` passes
- [ ] UI changes validated manually with `npm run dev` — n/a, no runtime code changed
- [ ] Tests added or updated — n/a, build configuration
- [x] `CLAUDE.md` updated (Release section)

## Screenshots

n/a — no UI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FT35N59CUTMaAfoa679jzD

---
_Generated by [Claude Code](https://claude.ai/code/session_01FT35N59CUTMaAfoa679jzD)_