### PR TITLE
fix(mission-control): cap dollar figures at two decimals

### DIFF
--- a/src/components/project/CLAUDE.md
+++ b/src/components/project/CLAUDE.md
@@ -17,7 +17,7 @@ Tutti i componenti UI del progetto ClaudeLens, organizzati per dominio funzional
 Formatter puri (nessuna dipendenza React):
 
 - `fmt(n)` — numero con separatori migliaia
-- `fmtCost(n)` — costo in dollari (`$0.0042`)
+- `fmtCost(n)` — costo in dollari, max 2 decimali + separatore migliaia (`$1,234.56`); sotto il centesimo → `<$0.01` (mai `$0.00`)
 - `fmtDate(d)` — data localizzata `it-IT`
 - `fmtModel(m)` — ID modello → nome leggibile (`claude-sonnet-4-6` → `Sonnet 4.6`)
 - `modelColor(m)` — colore hex accent per famiglia modello

--- a/src/components/project/utils.ts
+++ b/src/components/project/utils.ts
@@ -1,8 +1,19 @@
 export function fmt(n: number) {
   return n.toLocaleString('en-US');
 }
+// Dollar amount with at most 2 decimals and thousands separators ($1,234.56).
+// Sub-cent amounts collapse to "<$0.01": rounding them to "$0.00" would read as
+// "free", and a third decimal is exactly what made these figures look like
+// thousands instead of a fraction of a dollar.
 export function fmtCost(n: number) {
-  return '$' + n.toFixed(4);
+  if (!Number.isFinite(n)) return '$0.00';
+  const sign = n < 0 ? '-' : '';
+  const abs = Math.abs(n);
+  if (abs > 0 && abs < 0.005) return `${sign}<$0.01`;
+  return `${sign}$${abs.toLocaleString('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
 }
 export function fmtDate(d: string) {
   const date = new Date(d);


### PR DESCRIPTION
## Problem

`fmtCost` printed `'$' + n.toFixed(4)` with no thousands separator, so Mission Control's SPEND gauge and the terminal top bar rendered `$12.3456`. Four decimals with no grouping make a fraction of a dollar read as a four-digit amount.

## Fix

`fmtCost` now formats through `toLocaleString('en-US')` with min/max 2 fraction digits, which also restores the thousands separator (`$1,234.56`) — the signal that actually tells a large number from a decimal one.

- amounts under a cent collapse to `<$0.01` rather than rounding to `$0.00`: at two decimals a half-cent turn would read as free, and the marker stays within the two-digit rule
- negative and non-finite inputs handled explicitly (the rail passes savings positive and prints its own minus sign)

The formatter is shared, so this also covers the live chat meta row and the session markdown export. The project overview computes its own total with `toFixed(2)` and was already correct.

## Verification

`format:check`, `typecheck`, `lint --max-warnings 0`, 667 tests. UI pass left to a manual run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDnxnV9fitJ2yeenZi7jiT