### PR TITLE
fix(release): make the unsigned macOS fallback actually reachable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,13 @@ jobs:
           else
             echo "signed=false" >> "$GITHUB_OUTPUT"
             echo "::warning title=Unsigned macOS build::No Apple signing secrets configured; users will need the quarantine workaround. See docs/macos-signing.md."
+            # A missing secret still defines its env var, as the empty string.
+            # electron-builder reads CSC_LINK with `chooseNotNull`, which only
+            # rejects null — so "" counts as "a certificate was provided", and it
+            # resolves the empty path against the project dir and dies with
+            # "<workspace> not a file" before packaging anything. Unset them so
+            # the unsigned path is the one it actually takes.
+            unset CSC_LINK CSC_KEY_PASSWORD APPLE_ID APPLE_APP_SPECIFIC_PASSWORD APPLE_TEAM_ID
             # Without this electron-builder would pick up any stray identity in
             # the runner keychain and sign with something we did not choose.
             CSC_IDENTITY_AUTO_DISCOVERY=false npx electron-builder --mac --publish never


### PR DESCRIPTION
## What broke

The mac job of the v2.2.4 release died in `Package mac (x64 + arm64)`:

```
::warning::No Apple signing secrets configured; users will need the quarantine workaround.
  • empty password will be used for code signing  reason=CSC_KEY_PASSWORD is not defined
  ⨯ /Users/runner/work/ClaudeLens/ClaudeLens not a file
```

Linux and Windows built fine; `release` never ran (`needs: build`), so the tag shipped with no assets.

## Why

A secret that does not exist still defines its env var — as the empty string. electron-builder reads `CSC_LINK` through `chooseNotNull`, which rejects only `null`:

```js
function chooseNotNull(v1, v2) { return v1 == null ? v2 : v1 }
```

so `""` counts as "a certificate was provided". `MacPackager` then resolves it against the project dir (`path.resolve(projectDir, "")` — the project dir itself) and dies before packaging anything.

The shell branch in #183 was correct — it printed its warning and picked the unsigned command — but the environment it ran in was not.

## Fix

`unset` the five Apple vars in the unsigned branch, so electron-builder actually takes the path that branch was written for. `CSC_IDENTITY_AUTO_DISCOVERY=false` stays — it guards a different failure (a stray keychain identity on the runner).

This shipped green in #183 because CI never pushes a tag: the release workflow ran for the first time on v2.2.4, after the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDnxnV9fitJ2yeenZi7jiT