### PR TITLE
fix(search): let the project switcher close on a second click

### DIFF
--- a/src/components/project/overview/ProjectOverviewContent.tsx
+++ b/src/components/project/overview/ProjectOverviewContent.tsx
@@ -28,6 +28,7 @@ import { usePinnedSessions } from '../../../hooks/usePinnedSessions';
 import { useSessionTags } from '../../../hooks/useSessionTags';
 import { useMemoryTags } from '../../../hooks/useMemoryTags';
 import { PinIcon } from '../shared/SearchPopover';
+import { searchTriggerProps } from '../shared/searchTrigger';
 import { TagChip } from '../sessions/TagChip';
 import { TagBar } from '../sessions/TagBar';
 import { TagPicker } from '../sessions/TagPicker';
@@ -241,12 +242,12 @@ export function ProjectView({
   project,
   section,
   onNavigate,
-  onOpenProjectSearch,
+  onToggleProjectSearch,
 }: {
   project: Project;
   section: ProjectSection;
   onNavigate: (v: View) => void;
-  onOpenProjectSearch: (rect: DOMRect) => void;
+  onToggleProjectSearch: (anchor: HTMLElement) => void;
 }) {
   const { isPinned, togglePin } = usePinnedProjects();
   const pinnedNow = isPinned(project.hash);
@@ -607,7 +608,8 @@ export function ProjectView({
         <button
           className="cl-h-name"
           type="button"
-          onClick={e => onOpenProjectSearch(e.currentTarget.getBoundingClientRect())}
+          {...searchTriggerProps}
+          onClick={e => onToggleProjectSearch(e.currentTarget)}
           aria-haspopup="dialog"
         >
           <span className="label-name">{projectName}</span>

--- a/src/components/project/overview/ProjectRail.tsx
+++ b/src/components/project/overview/ProjectRail.tsx
@@ -17,6 +17,7 @@ import {
 import { useRailCollapsed } from '../../../hooks/useRailCollapsed';
 import { View } from '../types';
 import { projectDisplayName } from '../shared/projectName';
+import { searchTriggerProps } from '../shared/searchTrigger';
 import type { ProjectSection } from './ProjectOverviewContent';
 
 type Project = { hash: string; realPath: string };
@@ -57,12 +58,12 @@ export function ProjectRail({
   project,
   active,
   onNavigate,
-  onOpenProjectSearch,
+  onToggleProjectSearch,
 }: {
   project: Project;
   active: ProjectSection;
   onNavigate: (v: View) => void;
-  onOpenProjectSearch: (rect: DOMRect) => void;
+  onToggleProjectSearch: (anchor: HTMLElement) => void;
 }) {
   const { data: sessions = [] } = useSessionList(project.hash);
   const { data: memory } = useMemoryProject(project.hash);
@@ -243,10 +244,11 @@ export function ProjectRail({
       <aside className="cl-rail is-collapsed" aria-label="Project sections">
         <button
           type="button"
+          {...searchTriggerProps}
           className="cl-rail-mark"
           title={`${projectName} · switch project`}
           aria-label="Switch project"
-          onClick={e => onOpenProjectSearch(e.currentTarget.getBoundingClientRect())}
+          onClick={e => onToggleProjectSearch(e.currentTarget)}
         >
           <i />
         </button>
@@ -298,10 +300,11 @@ export function ProjectRail({
     <aside className="cl-rail" aria-label="Project sections">
       <button
         type="button"
+        {...searchTriggerProps}
         className="cl-rail-project"
         title={project.realPath}
         aria-haspopup="dialog"
-        onClick={e => onOpenProjectSearch(e.currentTarget.getBoundingClientRect())}
+        onClick={e => onToggleProjectSearch(e.currentTarget)}
       >
         <span className="cl-rail-mark" aria-hidden>
           <i />

--- a/src/components/project/shared/SearchPopover.tsx
+++ b/src/components/project/shared/SearchPopover.tsx
@@ -2,6 +2,7 @@ import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
 import type { Agent, McpServer, ProjectCost, SessionSummary, Skill } from '../../../types';
 import { fmtModel, sessionTitle } from '../utils';
 import { projectDisplayName } from './projectName';
+import { isSearchTrigger } from './searchTrigger';
 
 type Project = { hash: string; realPath: string };
 export type SearchMode = 'global' | 'projects';
@@ -224,6 +225,9 @@ export function SearchPopover({
     if (!open) return;
     function onDown(e: MouseEvent) {
       if (popRef.current?.contains(e.target as Node)) return;
+      // A trigger owns its own toggle: closing here would let the click that
+      // follows this mousedown reopen the popover, so it never shut.
+      if (isSearchTrigger(e.target)) return;
       onClose();
     }
     function onKey(e: KeyboardEvent) {

--- a/src/components/project/shared/searchTrigger.ts
+++ b/src/components/project/shared/searchTrigger.ts
@@ -1,0 +1,18 @@
+/**
+ * Marker for the buttons that open the unified search popover (the top-bar lens
+ * and every "switch project" affordance).
+ *
+ * The popover closes on a `mousedown` outside itself, which fires *before* the
+ * trigger's own `click`: without this marker the second click on a trigger read
+ * as close-then-reopen, so the popover looked like it never toggled shut. The
+ * popover skips marked triggers and leaves the toggle to their `onClick`.
+ */
+export const SEARCH_TRIGGER_ATTR = 'data-cl-search-trigger';
+
+/** Spread onto a trigger button: `<button {...searchTriggerProps} …>`. */
+export const searchTriggerProps = { [SEARCH_TRIGGER_ATTR]: '' } as const;
+
+/** True when `target` sits inside a marked trigger. */
+export function isSearchTrigger(target: EventTarget | null): boolean {
+  return target instanceof Element && !!target.closest(`[${SEARCH_TRIGGER_ATTR}]`);
+}

--- a/src/tabs/ProjectOverview.tsx
+++ b/src/tabs/ProjectOverview.tsx
@@ -24,6 +24,7 @@ import {
   type SearchMode,
   type SearchSession,
 } from '../components/project/shared/SearchPopover';
+import { searchTriggerProps } from '../components/project/shared/searchTrigger';
 import type { ProjectCost } from '../types';
 
 // ─── Shared
@@ -211,32 +212,43 @@ export default function ProjectOverview() {
   const [searchMode, setSearchMode] = useState<SearchMode>('global');
   const [searchAnchorAlign, setSearchAnchorAlign] = useState<SearchAnchorAlign>('right');
   const [anchorRect, setAnchorRect] = useState<DOMRect | null>(null);
+  // Which button the popover is currently anchored to, so a second click on
+  // that same trigger closes it while a click on another one re-anchors it
+  // (the rail header and the hero project name are both on screen at once).
+  const searchTriggerRef = useRef<HTMLElement | null>(null);
   const [searchSessions, setSearchSessions] = useState<SearchSession[]>([]);
   const [searchSessionsLoading, setSearchSessionsLoading] = useState(false);
   // Stable identities: the ⌘F/⌘P key handler below lists openGlobalSearch as a
   // dependency, so a fresh closure each render would re-bind the listener on
   // every render.
   const openSearch = useCallback(
-    (mode: SearchMode, rect: DOMRect | null, align: SearchAnchorAlign) => {
+    (mode: SearchMode, anchor: HTMLElement | null, align: SearchAnchorAlign) => {
+      searchTriggerRef.current = anchor;
       setSearchMode(mode);
       setSearchAnchorAlign(align);
-      setAnchorRect(rect);
+      setAnchorRect(anchor?.getBoundingClientRect() ?? null);
       setSearchOpen(true);
     },
     []
   );
   const openGlobalSearch = useCallback(() => {
-    openSearch('global', lensBtnRef.current?.getBoundingClientRect() ?? null, 'right');
+    openSearch('global', lensBtnRef.current, 'right');
   }, [openSearch]);
-  const openProjectSearch = useCallback(
-    (rect: DOMRect) => {
-      openSearch('projects', rect, 'left');
-    },
-    [openSearch]
-  );
   const closeSearch = useCallback(() => {
+    searchTriggerRef.current = null;
     setSearchOpen(false);
   }, []);
+  // Same trigger + same mode → close; anything else opens (or re-anchors).
+  const toggleProjectSearch = useCallback(
+    (anchor: HTMLElement) => {
+      if (searchOpen && searchMode === 'projects' && searchTriggerRef.current === anchor) {
+        closeSearch();
+        return;
+      }
+      openSearch('projects', anchor, 'left');
+    },
+    [closeSearch, openSearch, searchMode, searchOpen]
+  );
 
   const costByHash = useMemo(() => {
     const m = new Map<string, ProjectCost>();
@@ -719,6 +731,7 @@ export default function ProjectOverview() {
           <button
             ref={lensBtnRef}
             type="button"
+            {...searchTriggerProps}
             className={`cl-lens-btn${searchOpen && searchMode === 'global' ? ' on' : ''}`}
             onClick={() =>
               searchOpen && searchMode === 'global' ? closeSearch() : openGlobalSearch()
@@ -750,7 +763,7 @@ export default function ProjectOverview() {
             project={selected}
             active={sectionFromView(view)}
             onNavigate={setView}
-            onOpenProjectSearch={openProjectSearch}
+            onToggleProjectSearch={toggleProjectSearch}
           />
         )}
 
@@ -806,7 +819,7 @@ export default function ProjectOverview() {
                     project={selected}
                     section={sectionFromView(view)}
                     onNavigate={setView}
-                    onOpenProjectSearch={openProjectSearch}
+                    onToggleProjectSearch={toggleProjectSearch}
                   />
                 ) : null}
               </ErrorBoundary>

--- a/test/search-popover-trigger.test.tsx
+++ b/test/search-popover-trigger.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+//
+// The unified search popover closes on a `mousedown` anywhere outside itself.
+// That listener and the trigger button's own `onClick` fire on the *same*
+// physical click, in that order — so before the trigger was marked, a second
+// click on "switch project" closed the popover on mousedown and reopened it on
+// click: it looked like the popover simply refused to toggle shut, and the only
+// way out was clicking somewhere else entirely.
+//
+// These tests pin the seam: a marked trigger is left alone by the outside-click
+// handler (its onClick owns the toggle), everything else still closes.
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+import { SearchPopover } from '../src/components/project/shared/SearchPopover';
+import {
+  SEARCH_TRIGGER_ATTR,
+  isSearchTrigger,
+} from '../src/components/project/shared/searchTrigger';
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = '';
+});
+
+function renderPopover(onClose: () => void) {
+  return render(
+    <SearchPopover
+      open
+      mode="projects"
+      anchorRect={null}
+      projects={[{ hash: '-Users-foo-bar', realPath: '/Users/foo/bar' }]}
+      costByHash={new Map()}
+      pinned={new Set<string>()}
+      onTogglePin={() => {}}
+      onSelectProject={() => {}}
+      onClose={onClose}
+    />
+  );
+}
+
+/** Appends a button to the document body, optionally marked as a trigger. */
+function addButton(marked: boolean): HTMLButtonElement {
+  const btn = document.createElement('button');
+  if (marked) btn.setAttribute(SEARCH_TRIGGER_ATTR, '');
+  document.body.appendChild(btn);
+  return btn;
+}
+
+describe('search popover outside-click', () => {
+  it('leaves a marked trigger to its own toggle', () => {
+    const onClose = vi.fn();
+    renderPopover(onClose);
+    const trigger = addButton(true);
+
+    trigger.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('still closes on a mousedown that is not a trigger', () => {
+    const onClose = vi.fn();
+    renderPopover(onClose);
+    const elsewhere = addButton(false);
+
+    elsewhere.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('recognizes a descendant of a trigger (the icon inside the button)', () => {
+    const trigger = addButton(true);
+    const icon = document.createElement('span');
+    trigger.appendChild(icon);
+
+    expect(isSearchTrigger(icon)).toBe(true);
+    expect(isSearchTrigger(addButton(false))).toBe(false);
+    expect(isSearchTrigger(null)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

Clicking the project name in the rail opens the project picker; clicking it again does nothing — the popover stays open and can only be dismissed by clicking somewhere unrelated.

## Cause

`SearchPopover` closes on a `mousedown` outside itself. That listener fires **before** the trigger's `click`, on the same physical click: the popover closed on mousedown and the trigger's `onClick` reopened it. The top-bar lens button already had a toggle in its `onClick` and was hitting the same close-then-reopen path.

## Fix

- New `shared/searchTrigger.ts`: a `data-cl-search-trigger` marker (+ `isSearchTrigger` helper) for the buttons that open the popover.
- The popover's outside-click handler skips marked triggers, leaving the toggle to their `onClick`.
- `ProjectOverview` tracks which element the popover is anchored to: same trigger + same mode → close; another trigger → re-anchor (the rail header and the hero project name are both on screen at once, so a plain mode-based toggle would have closed instead of moving the popover).
- Trigger callback renamed `onOpenProjectSearch` → `onToggleProjectSearch` and now takes the anchor element instead of a `DOMRect`.

## Tests

`test/search-popover-trigger.test.tsx` (jsdom): a mousedown on a marked trigger does not call `onClose`, a mousedown elsewhere still does, and the marker is recognized on descendants (the icon inside the button). Verified the first case fails without the fix.

`npm run typecheck` + `npm run lint` + `npm test` (719 passed) green locally.