### PR TITLE
feat(overview): one session block, and memory as index cards

### DIFF
--- a/src/components/project/CLAUDE.md
+++ b/src/components/project/CLAUDE.md
@@ -324,17 +324,47 @@ titolo. Il titolo tronca prima, il cluster non si sposta mai.
 La riga pinnata prende il wash accent + il filetto accent, e la lista si apre
 con il filetto d'inchiostro 1.5px. Il piede riporta il range (`1–N of M`) e il
 "Show more": il caricamento resta progressivo, prende solo l'idioma del pager
-del mock. Nella landing di progetto (`section === 'overview'`) le sessioni si dividono in
-due blocchi, entrambi che scompaiono da soli quando non hanno niente da dire:
-**Pinned sessions** (`PinnedSessionsSection`, righe `.cl-srow` piene — ritorna
-`null` a zero pin) e **Recent** (`RecentSessionsStrip`, `.cl-mrow`). Il secondo
-è volutamente **più leggero** delle righe della subtab: quelle portano pin,
-indice, tag, il cluster di cifre e le azioni in hover, e ripeterle qui rendeva
-la landing una copia più corta della subtab Sessions — che il rail ha a un click
-di distanza. Resta ciò che si cerca su una landing: **quale conversazione, se sta
-girando, quando** (titolo · LIVE · filetto puntinato · tempo relativo); tutto il
-resto sta un livello più in basso. Il caption conta sul totale della storia
-(`sessions.length`), non sulla lista senza pin da cui pesca.
+del mock.
+
+**Landing di progetto — design handoff _Overview Redesign_, opzione 1c**
+(`section === 'overview'`). Le sessioni sono **un blocco solo**, non due: la
+sezione **Pinned sessions** e la striscia **Recent** (`RecentSessionsStrip`,
+`.cl-mrow`, entrambe rimosse col loro CSS) erano la stessa lista letta due
+volte, e la seconda doveva rinunciare a pin, tag e cluster di cifre per
+giustificare di stare sotto una sezione che li portava. Ora: testata
+`Sessions · N pinned · M total · View all` e **tre righe `.cl-srow` piene**
+(`LANDING_SESSIONS`), **pinnate per prime** — non avendo più una sezione
+propria, è la testa della terna che tiene raggiungibile dalla landing una
+conversazione pinnata e quindi magari vecchia. Il `rankOf` resta l'indice vero
+nella storia completa, così i numeri di riga non mentono. Il caption conta sul
+totale della storia (`sessions.length`).
+
+La **memoria** è la sezione che 1c cambia di più, ed era la più penalizzata:
+una definition-list a 3 colonne (`.cl-mem`/`.cl-mem-row`, rimosse) dove un
+topic si leggeva come una riga di tabella — niente tipo, niente tag, niente
+gerarchia. Diventa una **griglia di index card** (`.cl-mem-cards`/`.cl-mcard`,
+`renderMemCard`): header con glifo iniziale + tipo + età relativa, nome come
+titolo, **tre righe di prosa** in `--font-reading` (`memPreview` accetta ora un
+`max`, qui `MEM_CARD_PREVIEW_MAX`) e i tag a piede card. La prima card prende
+il wash accent, come la prima tile di Skills/Agents. I tag sono **read-only**
+qui: aggiungerli/rimuoverli resta nella subtab Memory, che possiede la lista
+intera (e il `TagPicker`). Cap a `LANDING_MEM_CARDS` (due file da tre), con
+`View all` verso la subtab.
+Il caption è `N topics · <due tipi più frequenti>`: un breakdown completo
+sfora la testata su qualsiasi memoria vera, e i due tipi dominanti sono ciò che
+dice che cosa questo progetto ricorda. Il controllo **Newest / By type** è un
+`.cl-seg` nella variante **`--paper`** (il `.cl-seg` originale è vetro perché
+nasce nella pill della chat, che galleggia su un transcript; su una sezione
+editoriale deve essere la stessa carta di tutto il resto — la mossa che
+`.cl-pill` ha già fatto). Il suo stato (`memCardView`) è **tenuto separato** da
+`memSort`/`memGroupBy` della subtab: leggono gli stessi topic ma sono superfici
+diverse, e un toggle sulla landing che rimodella in silenzio la lista completa
+è il tipo di cross-talk che noti solo dopo che ti ha confuso.
+**Non implementata** di 1c: la card tratteggiata "New topic" — l'app non ha
+(ancora) nessun ingresso di creazione memoria, solo l'IPC `memory:createTopic`
+e l'hook `useCreateTopic` inutilizzato; sarebbe una feature, non un cambio di
+layout. Fuori scope anche la «context chain» che collassa CLAUDE.md sotto
+l'hero: la sezione CLAUDE.md resta la tile-grid attuale.
 La sezione **Teams** conserva l'hero compatto (`cl-hero--compact`) e la
 vecchia meta-riga: è una vista operativa, non una landing di progetto.
 Il **filtro per tag** (`sessions/TagBar`) non è più una banda sotto il titolo:

--- a/src/components/project/overview/ProjectOverviewContent.tsx
+++ b/src/components/project/overview/ProjectOverviewContent.tsx
@@ -215,6 +215,13 @@ function Bars({ buckets, metric }: { buckets: TimelineBucket[]; metric: StatMetr
 }
 
 const MEM_PREVIEW_MAX = 70;
+// The landing's index cards give the preview three lines of prose instead of a
+// single mono line, so they get a longer slice of the same cleaned text.
+const MEM_CARD_PREVIEW_MAX = 190;
+/** How many sessions and memory topics the project landing shows before
+ *  handing over to the subtab (design 1c: three rows, two rows of cards). */
+const LANDING_SESSIONS = 3;
+const LANDING_MEM_CARDS = 6;
 
 const CLAUDE_MD_SCOPE_LABEL: Record<'global' | 'project' | 'local' | 'subdir', string> = {
   project: 'Project',
@@ -223,8 +230,8 @@ const CLAUDE_MD_SCOPE_LABEL: Record<'global' | 'project' | 'local' | 'subdir', s
   global: 'Global',
 };
 
-// Ripulisce la sintassi markdown e tronca per un'anteprima pulita su una riga.
-function memPreview(raw: string): string {
+// Ripulisce la sintassi markdown e tronca per un'anteprima pulita.
+function memPreview(raw: string, max: number = MEM_PREVIEW_MAX): string {
   const clean = raw
     .replace(/```[\s\S]*?```/g, ' ') // blocchi di codice
     .replace(/`([^`]+)`/g, '$1') // codice inline
@@ -235,7 +242,7 @@ function memPreview(raw: string): string {
     .replace(/[*_~>#]/g, '') // enfasi e marcatori
     .replace(/\s+/g, ' ') // collassa whitespace
     .trim();
-  return clean.length > MEM_PREVIEW_MAX ? clean.slice(0, MEM_PREVIEW_MAX).trimEnd() + '…' : clean;
+  return clean.length > max ? clean.slice(0, max).trimEnd() + '…' : clean;
 }
 
 export function ProjectView({
@@ -279,6 +286,11 @@ export function ProjectView({
   const [memPickerFor, setMemPickerFor] = useState<{ filename: string; rect: DOMRect } | null>(
     null
   );
+  // The landing's card grid has its own two-state view control, kept apart from
+  // the subtab's sort + group-by: they read the same topics but are different
+  // surfaces, and a toggle on the landing silently reshaping the full list is
+  // the kind of cross-talk you only notice after it has confused you.
+  const [memCardView, setMemCardView] = useState<'newest' | 'type'>('newest');
   const { data: memory } = useMemoryProject(project.hash);
   const { data: sessions = [] } = useSessionList(project.hash);
   const { data: claudeMd } = useClaudeMdHierarchy(project.realPath);
@@ -529,6 +541,88 @@ export function ProjectView({
     );
   };
 
+  // ── Project landing (design 1c) ──
+  // One session list, pins first: they no longer have a section of their own,
+  // so putting them at the head of the three is what keeps a pinned — and
+  // therefore possibly old — conversation reachable from the landing.
+  const landingSessions = useMemo(
+    () => [...pinnedSessions, ...unpinnedSessions].slice(0, LANDING_SESSIONS),
+    [pinnedSessions, unpinnedSessions]
+  );
+  const landingMemTopics = useMemo(
+    () =>
+      [...memTopics]
+        .sort((a, b) => (Date.parse(b.createdAt) || 0) - (Date.parse(a.createdAt) || 0))
+        .slice(0, LANDING_MEM_CARDS),
+    [memTopics]
+  );
+  const landingMemGroups = useMemo(() => {
+    if (memCardView !== 'type') return [];
+    return (['project', 'reference', 'feedback', 'user'] as const)
+      .map(ty => ({ key: ty, label: ty, topics: landingMemTopics.filter(t => t.type === ty) }))
+      .filter(g => g.topics.length > 0);
+  }, [memCardView, landingMemTopics]);
+  // "12 topics · 5 reference · 4 feedback" — the total, then the two commonest
+  // kinds. A full breakdown runs past the section head on any real memory, and
+  // the two that dominate are what says what this project remembers.
+  const memTypeBreakdown = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const t of memTopics) counts.set(t.type, (counts.get(t.type) ?? 0) + 1);
+    return [...counts.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 2)
+      .map(([type, n]) => `${n} ${type}`);
+  }, [memTopics]);
+  const renderMemCard = (t: MemoryTopic, accent: boolean) => {
+    const tTags = tagsForMemory(t.filename);
+    const open = () =>
+      onNavigate({
+        type: 'memory-topic',
+        topic: t,
+        content: topicContent(t.filename),
+        hash: project.hash,
+      });
+    return (
+      <div
+        key={t.filename}
+        role="button"
+        tabIndex={0}
+        className={`cl-mcard${accent ? ' accent' : ''}`}
+        title={t.description || t.name}
+        onClick={open}
+        onKeyDown={e => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            open();
+          }
+        }}
+      >
+        <div className="head">
+          <span className="glyph">{(t.name[0] ?? '?').toUpperCase()}</span>
+          <span className="kind">{t.type}</span>
+          {t.createdAt && <span className="when">{relIso(t.createdAt)}</span>}
+        </div>
+        <div className="name">{t.name}</div>
+        <p className="preview">
+          {t.description ? memPreview(t.description, MEM_CARD_PREVIEW_MAX) : '—'}
+        </p>
+        {tTags.length > 0 && (
+          <div className="tags">
+            {tTags.map(name => (
+              <TagChip
+                key={name}
+                name={name}
+                tone="soft"
+                variant="plain"
+                style={{ fontSize: 10, height: 18 }}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  };
+
   const enabledMcp = useMemo(() => {
     const all = [...(mcpData?.cloudServers ?? []), ...(mcpData?.localServers ?? [])];
     return all.filter(s => !s.disabledProjectPaths.includes(project.realPath));
@@ -715,29 +809,64 @@ export function ProjectView({
       {/* ─── SECTION CONTENT ──────────────────────────── */}
       {section === 'overview' && (
         <>
-          {/* Nothing pinned = no section (PinnedSessionsSection returns null). */}
-          <PinnedSessionsSection
-            sessions={pinnedSessions}
-            projectHash={project.hash}
-            cleanupDays={cleanupDays}
-            onOpen={openTerminal}
-            onOpenChat={openChat}
-            rankOf={s => sessionRank.get(s.filename) ?? 0}
-          />
-
-          <RecentSessionsStrip
-            sessions={unpinnedSessions}
-            total={sessions.length}
-            onOpen={openTerminal}
-            onViewAll={() => onNavigate({ type: 'sessions', project })}
-          />
+          {/* One session block, not two (design 1c): the pinned section and the
+              thinner "Recent" strip were the same list read twice, and the strip
+              had to drop pins, tags and the figure cluster to justify sitting
+              under a section that carried them. Three full rows instead, pins
+              first, with the caption saying how many pins the history holds. */}
+          <section className="cl-section">
+            <div className="cl-sec-head">
+              <h2>Sessions</h2>
+              <span className="ct">
+                {hasPinnedSession ? `${pinnedSessions.length} pinned · ` : ''}
+                {fmt(sessions.length)} total
+              </span>
+              <button
+                className="all"
+                type="button"
+                onClick={() => onNavigate({ type: 'sessions', project })}
+              >
+                View all
+              </button>
+            </div>
+            {/* SessionRows prints its own "No sessions yet." empty state. */}
+            <SessionRows
+              sessions={landingSessions}
+              projectHash={project.hash}
+              cleanupDays={cleanupDays}
+              onOpen={openTerminal}
+              onOpenChat={openChat}
+              rankOf={s => sessionRank.get(s.filename) ?? 0}
+            />
+          </section>
 
           <section className="cl-section">
             <div className="cl-sec-head">
               <h2>Memory</h2>
               <span className="ct">
-                {Math.min(4, memTopics.length)} of {memoryCount}
+                {memoryCount} {memoryCount === 1 ? 'topic' : 'topics'}
+                {memTypeBreakdown.length > 0 && ` · ${memTypeBreakdown.join(' · ')}`}
               </span>
+              {memTopics.length > 1 && (
+                <div className="cl-seg cl-seg--paper" role="group" aria-label="Memory view">
+                  <button
+                    type="button"
+                    className={memCardView === 'newest' ? 'on' : ''}
+                    aria-pressed={memCardView === 'newest'}
+                    onClick={() => setMemCardView('newest')}
+                  >
+                    Newest
+                  </button>
+                  <button
+                    type="button"
+                    className={memCardView === 'type' ? 'on' : ''}
+                    aria-pressed={memCardView === 'type'}
+                    onClick={() => setMemCardView('type')}
+                  >
+                    By type
+                  </button>
+                </div>
+              )}
               <button
                 className="all"
                 type="button"
@@ -746,17 +875,23 @@ export function ProjectView({
                 View all
               </button>
             </div>
-            <MemoryRows
-              topics={memTopics.slice(0, 4)}
-              onOpen={t =>
-                onNavigate({
-                  type: 'memory-topic',
-                  topic: t,
-                  content: topicContent(t.filename),
-                  hash: project.hash,
-                })
-              }
-            />
+            {landingMemTopics.length === 0 ? (
+              <div className="cl-empty">No memory topics yet.</div>
+            ) : memCardView === 'newest' ? (
+              <div className="cl-mem-cards">
+                {landingMemTopics.map((t, i) => renderMemCard(t, i === 0))}
+              </div>
+            ) : (
+              landingMemGroups.map(g => (
+                <div key={g.key} className="cl-mem-group">
+                  <div className="cl-mem-group-head">
+                    <span className="lbl">{g.label}</span>
+                    <span className="ct">{g.topics.length}</span>
+                  </div>
+                  <div className="cl-mem-cards">{g.topics.map(t => renderMemCard(t, false))}</div>
+                </div>
+              ))
+            )}
           </section>
 
           <section className="cl-section">
@@ -1442,68 +1577,6 @@ function PinnedSessionsSection({
   );
 }
 
-/** The landing page's jumping-off point into the session history — deliberately
- *  thinner than `SessionRows`. That row carries pin, index, tags, the figure
- *  cluster and hover actions; repeating it here made the landing a shorter copy
- *  of the Sessions subtab, which the rail is one click away from. What is left
- *  is what you scan for on a landing page: which conversation, is it running,
- *  when. Everything else stays one click deeper. */
-function RecentSessionsStrip({
-  sessions,
-  total,
-  count = 4,
-  onOpen,
-  onViewAll,
-}: {
-  sessions: SessionSummary[];
-  /** The whole history, for the "N of M" caption — `sessions` excludes pins. */
-  total: number;
-  count?: number;
-  onOpen: (s: SessionSummary) => void;
-  onViewAll: () => void;
-}) {
-  const { data: activeSessions = [] } = useActiveSessions();
-  const liveIds = useMemo(
-    () => new Set(activeSessions.map(a => a.sessionId).filter(Boolean)),
-    [activeSessions]
-  );
-  if (sessions.length === 0) return null;
-  const shown = sessions.slice(0, count);
-
-  return (
-    <section className="cl-section">
-      <div className="cl-sec-head">
-        <h2>Recent</h2>
-        <span className="ct">
-          {shown.length} of {total}
-        </span>
-        <button className="all" type="button" onClick={onViewAll}>
-          View all
-        </button>
-      </div>
-      <div className="cl-mrows">
-        {shown.map(s => {
-          const live = liveIds.has(s.filename.replace(/\.jsonl$/, ''));
-          return (
-            <button
-              key={s.filename}
-              type="button"
-              className="cl-mrow"
-              onClick={() => onOpen(s)}
-              title={sessionTitle(s)}
-            >
-              <span className="title">{sessionTitle(s)}</span>
-              {live && <LiveTag />}
-              <span className="lead" aria-hidden />
-              <span className="when">{relIso(s.date)} ago</span>
-            </button>
-          );
-        })}
-      </div>
-    </section>
-  );
-}
-
 type SessionRowProps = {
   session: SessionSummary;
   rank: number;
@@ -1777,33 +1850,6 @@ function SessionRows({
           onDeleted={() => setDeleteFor(null)}
         />
       )}
-    </div>
-  );
-}
-
-function MemoryRows({
-  topics,
-  onOpen,
-}: {
-  topics: {
-    name: string;
-    description: string;
-    type: string;
-    filename: string;
-    updatedAt: string;
-  }[];
-  onOpen: (t: any) => void;
-}) {
-  if (topics.length === 0) return <div className="cl-empty">No memory topics yet.</div>;
-  return (
-    <div className="cl-mem">
-      {topics.map(t => (
-        <div key={t.filename} className="cl-mem-row" onClick={() => onOpen(t)}>
-          <div className="key">{t.name}</div>
-          <div className="val">{t.description ? memPreview(t.description) : '—'}</div>
-          <div className="when">{relIso(t.updatedAt)}</div>
-        </div>
-      ))}
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -2442,6 +2442,21 @@ body {
     inset 0 1px 0 oklch(1 0 0 / 0.1),
     0 1px 4px -1px color-mix(in oklch, var(--cl-accent) 45%, transparent);
 }
+/* Paper variant. The glass original belongs to the chat pill, which floats
+   over a transcript; on an editorial section it has to be the same paper as
+   everything else around it — the same move `.cl-pill` already made. */
+.cl-seg--paper {
+  background: var(--cl-paper-2);
+  border-color: var(--cl-line);
+  box-shadow: none;
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
+}
+:root[data-theme='dark'] .cl-seg--paper {
+  background: var(--cl-paper-2);
+  border-color: var(--cl-line);
+  box-shadow: none;
+}
 
 .cl-export-label {
   font-family: var(--font-mono);
@@ -7259,6 +7274,16 @@ body {
   color: var(--cl-ink-3);
   letter-spacing: 0.06em;
 }
+/* A view control in the head takes the free space, and "View all" then rides
+   right after it — two auto margins would split the gap and leave the control
+   stranded mid-row. */
+.cl-sec-head .cl-seg {
+  margin-left: auto;
+  align-self: center;
+}
+.cl-sec-head .cl-seg + .all {
+  margin-left: 0;
+}
 .cl-sec-head .all {
   margin-left: auto;
   font-family: var(--font-mono);
@@ -10141,65 +10166,117 @@ button.cl-sw-member:focus-visible,
   gap: 10px;
 }
 
-/* Memory definition list */
-.cl-mem {
+/* ── Memory index cards (project landing, design 1c) ──
+   The landing's memory used to be a 3-column definition list, where a topic
+   read as a table row: no type, no tags, no hierarchy — the most penalised
+   section of the page. It is now a grid of index cards carrying the four
+   things that identify a memory: what kind it is and how old (header), what
+   it is called (headline), what it says (three lines of prose) and how it is
+   filed (tags). The tags are read-only here; editing them lives in the
+   Memory subtab, which owns the full list. */
+.cl-mem-cards {
   display: grid;
-  grid-template-columns: 220px 1fr 100px;
-  column-gap: 36px;
+  grid-template-columns: repeat(auto-fill, minmax(248px, 1fr));
+  gap: 16px;
 }
-.cl-mem-row {
-  display: contents;
+.cl-mcard {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  min-height: 176px;
+  padding: 18px;
+  border: 1px solid var(--cl-line);
+  border-radius: 14px;
+  background: var(--cl-paper);
+  text-align: left;
   cursor: pointer;
-}
-.cl-mem-row > * {
-  padding: 18px 0;
-  border-top: 1px solid var(--cl-line-soft);
   transition:
-    background 120ms ease,
-    box-shadow 120ms ease;
+    border-color 120ms,
+    box-shadow 120ms;
 }
-.cl-mem-row:first-child > * {
-  border-top: 1px solid var(--cl-ink);
+.cl-mcard:hover {
+  border-color: color-mix(in oklch, var(--cl-accent) 30%, var(--cl-line));
+  box-shadow: 0 2px 12px -6px oklch(0 0 0 / 0.18);
 }
-.cl-mem-row:last-child > * {
-  border-bottom: 1px solid var(--cl-line-soft);
+:root[data-theme='dark'] .cl-mcard:hover {
+  box-shadow: 0 2px 12px -6px oklch(0 0 0 / 0.5);
 }
-/* hover: tint neutro continuo (box-shadow colma i 36px di column-gap) */
-.cl-mem-row:hover > * {
-  background: var(--cl-glass-hover-bg);
-  -webkit-backdrop-filter: blur(8px) saturate(var(--cl-glass-sat));
-  backdrop-filter: blur(8px) saturate(var(--cl-glass-sat));
-  box-shadow:
-    -18px 0 0 var(--cl-glass-hover-bg),
-    18px 0 0 var(--cl-glass-hover-bg),
-    inset 0 1px 0 var(--cl-glass-hover-edge);
+.cl-mcard:focus-visible {
+  outline: 2px solid var(--cl-accent);
+  outline-offset: -2px;
 }
-.cl-mem .key {
-  font-family: var(--font-sans);
-  font-size: 13px;
-  letter-spacing: -0.005em;
+.cl-mcard.accent {
+  border-color: color-mix(in oklch, var(--cl-accent) 34%, var(--cl-line));
+  background: linear-gradient(180deg, var(--cl-accent-soft), var(--cl-paper) 62%);
+  box-shadow: inset 0 1px 0 oklch(1 0 0 / 0.6);
+}
+:root[data-theme='dark'] .cl-mcard.accent {
+  box-shadow: inset 0 1px 0 oklch(1 0 0 / 0.06);
+}
+.cl-mcard .head {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+.cl-mcard .glyph {
+  flex: none;
+  width: 28px;
+  height: 28px;
+  border: 1.5px solid var(--cl-ink);
+  border-radius: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-mono);
+  font-weight: 600;
+  font-size: 12px;
   color: var(--cl-ink);
-  font-weight: 500;
-  padding-top: 20px;
 }
-.cl-mem .val {
-  font-size: 15px;
-  line-height: 1.48;
+.cl-mcard.accent .glyph {
+  background: var(--cl-accent);
+  border-color: var(--cl-accent);
+  color: var(--cl-on-accent);
+}
+.cl-mcard .kind {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--cl-ink-4);
+}
+.cl-mcard.accent .kind {
+  color: var(--cl-accent-ink);
+}
+.cl-mcard .when {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  color: var(--cl-ink-4);
+}
+.cl-mcard .name {
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 1.25;
+  letter-spacing: -0.015em;
+  color: var(--cl-ink);
+}
+.cl-mcard .preview {
+  margin: 0;
+  font-family: var(--font-reading);
+  font-size: 13px;
+  line-height: 1.55;
   color: var(--cl-ink-2);
-  font-weight: 400;
-  padding-top: 20px;
   display: -webkit-box;
-  -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
   overflow: hidden;
 }
-.cl-mem .when {
-  font-family: var(--font-mono);
-  font-size: 11px;
-  color: var(--cl-ink-4);
-  text-align: right;
-  padding-top: 22px;
-  letter-spacing: 0.02em;
+.cl-mcard .tags {
+  margin-top: auto;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 5px;
 }
 
 /* Config strip */
@@ -15038,65 +15115,6 @@ select.cl-opt-input {
   color: var(--cl-accent-ink);
   border-color: color-mix(in oklch, var(--cl-accent) 45%, transparent);
   background: var(--cl-accent-soft);
-}
-
-/* ── Recent strip (project landing) ──
-   The leader-dot language of .cl-srow at half the weight: title · live · leader
-   · when, and nothing else. It is a way into the history, not a second copy of
-   it — pins, tags, the figure cluster and the row actions all stay in the
-   Sessions subtab. */
-.cl-mrows {
-  border-top: 1px solid var(--cl-line);
-}
-.cl-mrow {
-  display: flex;
-  align-items: baseline;
-  gap: 10px;
-  width: 100%;
-  text-align: left;
-  padding: 8px 0;
-  border: 0;
-  border-bottom: 1px solid var(--cl-line-soft);
-  background: transparent;
-  cursor: pointer;
-  transition: background 100ms;
-}
-.cl-mrow:hover {
-  background: var(--cl-glass-hover-bg);
-  box-shadow: inset 0 1px 0 var(--cl-glass-hover-edge);
-}
-.cl-mrow:focus-visible {
-  outline: 2px solid var(--cl-accent);
-  outline-offset: -2px;
-}
-.cl-mrow .title {
-  font-size: 13px;
-  line-height: 1.35;
-  font-weight: 500;
-  color: var(--cl-ink);
-  flex: 0 1 auto;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.cl-mrow:hover .title {
-  color: var(--cl-accent-ink);
-}
-.cl-mrow .lead {
-  flex: 1 0 auto;
-  min-width: 40px;
-  align-self: center;
-  height: 1em;
-  border-bottom: 1px dotted var(--cl-line);
-  transform: translateY(-3px);
-}
-.cl-mrow .when {
-  flex: none;
-  font-family: var(--font-mono);
-  font-size: 10.5px;
-  color: var(--cl-ink-4);
-  font-variant-numeric: tabular-nums;
 }
 
 @media (max-width: 980px) {


### PR DESCRIPTION
Design handoff [Overview Redesign](https://claude.ai/design/p/4f483dad-3184-494b-b76b-c983677f18c1?file=Overview+Redesign.dc.html), **option 1c**, applied to the two sections it reshapes: sessions and memory. The CLAUDE.md "context chain" and the config strip stay as they are.

## Sessions — one block, not two

The landing carried the same session list twice. `PinnedSessionsSection` and the `Recent` strip were both reading `sessions`, and the second one had to give up pins, tags and the figure cluster to justify sitting under a section that carried them — a lighter copy of a list already on the page.

It is one block now: `Sessions · N pinned · M total · View all` over three full `.cl-srow` rows, **pinned first**. That order is the point: with no section of its own, the head of the three is what keeps a pinned — and therefore possibly old — conversation reachable from the landing. `rankOf` still resolves each row to its true position in the whole history, so the row numbers do not lie about where you are in the list.

## Memory — index cards

The section 1c changes most, and the one the old layout penalised hardest: a three-column definition list where a topic read as a table row — no type, no tags, no hierarchy, just a name and a truncated line.

Now a grid of index cards carrying the four things that identify a memory: what kind it is and how old (header), what it is called (headline), what it says (three lines of prose in the reading face) and how it is filed (tags). `memPreview` takes a `max`, because three lines of prose need a longer slice of the same cleaned text than one mono line did. The tags are **read-only** here — adding and removing them stays in the Memory subtab, which owns the full list and the picker; the landing is a way in, not a second editor.

The head says `N topics · <two commonest types>`: a full breakdown runs past the head on any real memory, and the two kinds that dominate are what tells you what this project remembers.

The **Newest / By type** control is a `.cl-seg` in a new `--paper` variant — the original is glass because it was born in the chat pill, which floats over a transcript, and on an editorial section it has to be the same paper as everything around it (the move `.cl-pill` has already made). Its state is kept apart from the subtab's sort and group-by: they read the same topics but are different surfaces, and a toggle on the landing silently reshaping the full list is the kind of cross-talk you only notice after it has confused you.

## Deliberately left out

The dashed **"New topic"** card. The app has no memory-creation entrance at all — only the `memory:createTopic` IPC and an unused `useCreateTopic` hook — so that card would be a feature, not a layout change, and a card that does nothing is worse than no card.

## Removed

`.cl-mem`/`.cl-mem-row` and `.cl-mrows`/`.cl-mrow`, with `MemoryRows` and `RecentSessionsStrip`, their only callers.

## Verification

`npm run typecheck`, `npm run lint` (`--max-warnings 0`), `npm run format:check`, `npm test` (773 passed). Visual and layout behaviour has no automated coverage — the app was not launched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016BWxPQrdoQaAUkDmRtfs2A