### PR TITLE
feat(updates): warn at launch when the installed Claude Code is behind

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -76,7 +76,11 @@ import {
 } from './modules/chat-runner';
 import type { PermissionDecision } from './shared/chat-types';
 import { readPrefs, setPref } from './modules/prefs-store';
-import { checkForUpdates, RELEASES_PAGE_URL } from './modules/update-checker';
+import {
+  checkForUpdates,
+  parseClaudeCliVersion,
+  RELEASES_PAGE_URL,
+} from './modules/update-checker';
 import {
   initTelemetry,
   track,
@@ -117,6 +121,7 @@ import {
   canonicalize,
   CLAUDE_DIR,
   isValidSessionId,
+  resolveClaudeExecutablePath,
 } from './utils';
 import { registerScreenshotHandlers } from './screenshotFixtures';
 
@@ -912,6 +917,28 @@ ipcMain.handle('updates:check', async () => {
     return ok(await checkForUpdates(app.getVersion()));
   } catch (e) {
     return err(e);
+  }
+});
+
+// Which Claude Code the user actually has installed, asked straight to the CLI
+// (`claude --version`) rather than to the Agent SDK handshake: this runs at
+// launch to decide whether to show the "your CLI is behind this build" notice,
+// and the handshake is both slow and cwd-scoped (an untrusted dir answers
+// nothing). The comparison against the required version lives renderer-side —
+// the requirement is `claudeCodeVersion` in package.json, which the renderer
+// already imports for Settings → General.
+ipcMain.handle('updates:claudeCodeVersion', async () => {
+  try {
+    if (process.env.SCREENSHOT_MODE) return ok({ version: null });
+    const { stdout } = await execClaude(['--version'], {
+      env: claudeEnv(),
+      executable: resolveClaudeExecutablePath(),
+      timeout: 8000,
+    });
+    return ok({ version: parseClaudeCliVersion(stdout) });
+  } catch (e: any) {
+    if (e?.code === 'ENOENT') return err(`'claude' CLI not found in PATH.`);
+    return err(e?.stderr || e?.message || String(e));
   }
 });
 

--- a/electron/modules/update-checker.ts
+++ b/electron/modules/update-checker.ts
@@ -79,6 +79,17 @@ export function checkForUpdates(currentVersion: string): Promise<UpdateInfo> {
   });
 }
 
+/**
+ * Pull the version out of `claude --version`, whose output is a single line
+ * like `2.1.232 (Claude Code)`. Parsed defensively (the format is the CLI's,
+ * not a contract): anything that doesn't start with a `x.y` number returns
+ * null, so the caller says "unknown" instead of comparing against garbage.
+ */
+export function parseClaudeCliVersion(stdout: string): string | null {
+  const m = /(\d+\.\d+(?:\.\d+)?(?:-[0-9A-Za-z.-]+)?)/.exec((stdout || '').trim());
+  return m ? m[1] : null;
+}
+
 function fetchLatestRelease(): Promise<unknown> {
   return new Promise((resolve, reject) => {
     const req = https.request(

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -202,6 +202,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
   updates: {
     check: () => ipcRenderer.invoke('updates:check'),
+    claudeCodeVersion: () => ipcRenderer.invoke('updates:claudeCodeVersion'),
   },
   config: {
     getEffective: (cwd?: string) => ipcRenderer.invoke('config:getEffective', cwd),

--- a/src/components/CLAUDE.md
+++ b/src/components/CLAUDE.md
@@ -56,6 +56,28 @@ No auto-install by design — the app ships unsigned. It is now the **only** use
 of the `.cl-toast` stripe-card anatomy: session notifications moved to the
 feed-row form (below), so the two bottom corners no longer share one shape.
 
+The file hosts a **second, quieter notice** in the same bottom-left anchor
+(`.cl-update-anchor`, now a column stack so both can be on screen without
+either knowing about the other): **the installed Claude Code CLI is older than
+the `claudeCodeVersion` this build was prepared against**. The installed
+version comes from `useClaudeCodeVersion()` (IPC `updates:claudeCodeVersion` →
+`claude --version` via `execClaude`, parsed by `parseClaudeCliVersion` in
+`update-checker.ts`), compared renderer-side with the shared `compareVersions`
+— the same verdict Settings → General already prints as the `outdated` chip,
+now surfaced at launch, where a stale CLI actually costs something (ClaudeLens
+reads what that CLI writes to `~/.claude`).
+
+Deliberately minimal: **no stripe and no title** — nothing is broken, so it
+gets one sentence, the `claude update` command with a Copy button, and a
+"Don't remind me". The CLI check is asked to the CLI itself rather than to the
+Agent SDK handshake, which is slow and cwd-scoped (an untrusted dir answers
+nothing). A failed read (`claude` not in PATH, timeout) throws and the notice
+simply never appears — an unknown version is never treated as outdated.
+Dismissal pins the **required** version in prefs
+(`cl-cli-update-dismissed-version`), so raising the requirement in a later
+ClaudeLens brings the notice back; ✕ hides it for this run only. Silent in
+`SCREENSHOT_MODE` (the handler returns a null version).
+
 ### NotificationToaster.tsx
 
 Transient toasts for session-lifecycle events pushed over `notifications:event`

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -1,20 +1,57 @@
 import { useState } from 'react';
 import { AnimatePresence, motion } from 'motion/react';
-import { useUpdateCheck, useSkippedUpdateVersion, useSkipUpdateVersion } from '../hooks/useIPC';
+import {
+  useUpdateCheck,
+  useSkippedUpdateVersion,
+  useSkipUpdateVersion,
+  useClaudeCodeVersion,
+  useDismissedCliUpdate,
+  useDismissCliUpdate,
+} from '../hooks/useIPC';
+import { compareVersions } from '../../electron/shared/version-compare';
+import { claudeCodeVersion as requiredCliVersion } from '../../package.json';
 
-// Passive update notice, shown once per launch when GitHub has a newer release
-// than the running build (see electron/modules/update-checker.ts for why there
-// is no auto-install: ClaudeLens ships unsigned). Anchored bottom-left so it
-// never fights the session-notification toaster in the bottom-right corner.
+// Passive update notices, shown once per launch, anchored bottom-left so they
+// never fight the session-notification toaster in the bottom-right corner.
+// Two independent things can be behind:
 //
-// Dismissal semantics: ✕ hides it for this run only; "Skip this version"
-// persists to ~/.claudelens/preferences.json so that release stays quiet until
-// the next one. "View release" opens the GitHub release page in the browser
-// (the main process routes external links through shell.openExternal).
+//   1. ClaudeLens itself — GitHub has a newer release than the running build
+//      (see electron/modules/update-checker.ts for why there is no
+//      auto-install: ClaudeLens ships unsigned).
+//   2. The Claude Code CLI — the installed version (`claude --version`, via
+//      `updates:claudeCodeVersion`) is older than the `claudeCodeVersion` this
+//      build was prepared against, which is what Settings → General calls
+//      "Claude Code required". The app reads data written by that CLI, so an
+//      older one can mean formats this build doesn't know about.
+//
+// Both are advisory: they suggest, never block, and both remember a dismissal
+// per version in ~/.claudelens/preferences.json.
+//
+// The anchor is a column stack so the two can be on screen together without
+// either one having to know about the other.
 
 const IS_MAC = typeof navigator !== 'undefined' && /mac/i.test(navigator.platform);
 
+const ENTER = { opacity: 0, y: 16, scale: 0.98 };
+const SHOWN = { opacity: 1, y: 0, scale: 1 };
+const MOTION = { duration: 0.22, ease: 'easeOut' } as const;
+
 export function UpdateBanner() {
+  return (
+    <div className="cl-update-anchor">
+      <ClaudeCodeNotice />
+      <AppUpdateNotice />
+    </div>
+  );
+}
+
+/**
+ * "A newer ClaudeLens is published". Dismissal semantics: ✕ hides it for this
+ * run only; "Skip this version" persists so that release stays quiet until the
+ * next one. "View release" opens the GitHub release page in the browser (the
+ * main process routes external links through shell.openExternal).
+ */
+function AppUpdateNotice() {
   const { data: update } = useUpdateCheck();
   const { data: skippedVersion, isLoading: skippedLoading } = useSkippedUpdateVersion();
   const skip = useSkipUpdateVersion();
@@ -30,13 +67,12 @@ export function UpdateBanner() {
     <AnimatePresence>
       {visible && update && (
         <motion.div
-          className="cl-update-anchor"
           role="status"
           aria-label="Update available"
-          initial={{ opacity: 0, y: 16, scale: 0.98 }}
-          animate={{ opacity: 1, y: 0, scale: 1 }}
-          exit={{ opacity: 0, y: 16, scale: 0.98 }}
-          transition={{ duration: 0.22, ease: 'easeOut' }}
+          initial={ENTER}
+          animate={SHOWN}
+          exit={ENTER}
+          transition={MOTION}
         >
           <div className="cl-toast cl-toast--update">
             <span className="cl-toast-stripe" aria-hidden="true" />
@@ -70,27 +106,100 @@ export function UpdateBanner() {
                 </div>
               )}
             </div>
-            <button
-              type="button"
-              className="cl-toast-close"
-              aria-label="Dismiss"
-              onClick={() => setHidden(true)}
-            >
-              <svg
-                width="13"
-                height="13"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2.4"
-                strokeLinecap="round"
-              >
-                <path d="M18 6 6 18M6 6l12 12" />
-              </svg>
-            </button>
+            <CloseButton onClick={() => setHidden(true)} />
           </div>
         </motion.div>
       )}
     </AnimatePresence>
+  );
+}
+
+// What updates the CLI in place, whichever installer put it there.
+const CLI_UPDATE_CMD = 'claude update';
+
+/**
+ * "Your Claude Code is older than this build expects". Deliberately quieter
+ * than the notice above — no stripe, no title, one sentence and the command —
+ * because nothing is broken: the app keeps working, it just may not understand
+ * everything a newer CLI writes. Dismissal pins the *required* version, so
+ * raising the requirement in a later ClaudeLens brings the notice back.
+ */
+function ClaudeCodeNotice() {
+  const { data } = useClaudeCodeVersion();
+  const { data: dismissed, isLoading: dismissedLoading } = useDismissedCliUpdate();
+  const dismiss = useDismissCliUpdate();
+  const [hidden, setHidden] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const installed = data?.version ?? null;
+  const outdated = !!installed && compareVersions(installed, requiredCliVersion) < 0;
+  const visible = !hidden && !dismissedLoading && outdated && dismissed !== requiredCliVersion;
+
+  const copy = () => {
+    navigator.clipboard
+      .writeText(CLI_UPDATE_CMD)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1600);
+      })
+      .catch(() => {});
+  };
+
+  return (
+    <AnimatePresence>
+      {visible && (
+        <motion.div
+          role="status"
+          aria-label="Claude Code update suggested"
+          initial={ENTER}
+          animate={SHOWN}
+          exit={ENTER}
+          transition={MOTION}
+        >
+          <div className="cl-toast cl-toast--cli">
+            <div className="cl-toast-body">
+              <div className="cl-toast-sub">
+                Claude Code {installed} is older than the {requiredCliVersion} this ClaudeLens
+                expects.
+              </div>
+              <div className="cl-cli-cmd">
+                <code>{CLI_UPDATE_CMD}</code>
+                <button type="button" onClick={copy} className="cl-cli-copy">
+                  {copied ? 'Copied' : 'Copy'}
+                </button>
+              </div>
+              <div className="cl-toast-actions">
+                <button
+                  type="button"
+                  className="cl-toast-action cl-toast-action--quiet"
+                  onClick={() => dismiss.mutate(requiredCliVersion)}
+                >
+                  Don’t remind me
+                </button>
+              </div>
+            </div>
+            <CloseButton onClick={() => setHidden(true)} />
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}
+
+function CloseButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button type="button" className="cl-toast-close" aria-label="Dismiss" onClick={onClick}>
+      <svg
+        width="13"
+        height="13"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.4"
+        strokeLinecap="round"
+      >
+        <path d="M18 6 6 18M6 6l12 12" />
+      </svg>
+    </button>
   );
 }

--- a/src/hooks/useIPC.ts
+++ b/src/hooks/useIPC.ts
@@ -393,6 +393,7 @@ declare global {
       };
       updates: {
         check: () => Promise<IpcResult<UpdateInfo>>;
+        claudeCodeVersion: () => Promise<IpcResult<{ version: string | null }>>;
       };
       config: {
         getEffective: (cwd?: string) => Promise<IpcResult<EffectiveConfig>>;
@@ -793,6 +794,48 @@ export function useSkipUpdateVersion() {
       unwrap(window.electronAPI.prefs.set(UPDATE_SKIPPED_KEY, version)),
     onSuccess: (_data, version) => {
       qc.setQueryData(['prefs:update-skipped'], version);
+    },
+  });
+}
+
+// Installed Claude Code CLI version (`claude --version`), read once per run.
+// Feeds the launch notice that suggests updating when the CLI is older than
+// the `claudeCodeVersion` this build expects. A failed read throws — the
+// notice stays silent rather than guessing.
+export function useClaudeCodeVersion() {
+  return useQuery({
+    queryKey: ['updates:claude-code-version'],
+    queryFn: () => unwrap(window.electronAPI.updates.claudeCodeVersion()),
+    staleTime: Infinity,
+    retry: false,
+    refetchOnWindowFocus: false,
+  });
+}
+
+// Per-version dismissal of that notice, same shape as the app-update skip:
+// dismissing pins the *required* version, so the notice comes back the next
+// time ClaudeLens raises the bar.
+const CLI_UPDATE_DISMISSED_KEY = 'cl-cli-update-dismissed-version';
+
+export function useDismissedCliUpdate() {
+  return useQuery({
+    queryKey: ['prefs:cli-update-dismissed'],
+    queryFn: async (): Promise<string | null> => {
+      const all = await unwrap(window.electronAPI.prefs.getAll());
+      const v = all[CLI_UPDATE_DISMISSED_KEY];
+      return typeof v === 'string' ? v : null;
+    },
+    staleTime: Infinity,
+  });
+}
+
+export function useDismissCliUpdate() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (version: string) =>
+      unwrap(window.electronAPI.prefs.set(CLI_UPDATE_DISMISSED_KEY, version)),
+    onSuccess: (_data, version) => {
+      qc.setQueryData(['prefs:cli-update-dismissed'], version);
     },
   });
 }

--- a/src/index.css
+++ b/src/index.css
@@ -13918,19 +13918,63 @@ select.cl-opt-input {
   }
 }
 
-/* ─── Update notice (UpdateBanner.tsx) ────────────────────────────────────
-   Single passive toast anchored bottom-LEFT (the session toaster owns the
-   bottom-right corner), reusing the .cl-toast anatomy with an accent stripe
-   and a two-action row (View release / Skip this version). */
+/* ─── Update notices (UpdateBanner.tsx) ───────────────────────────────────
+   Passive toasts anchored bottom-LEFT (the session toaster owns the
+   bottom-right corner), reusing the .cl-toast anatomy: the ClaudeLens release
+   notice with an accent stripe and a two-action row (View release / Skip this
+   version), and — quieter, no stripe — the "your Claude Code CLI is behind"
+   notice. The anchor is a column stack so both can sit there at once. */
 .cl-update-anchor {
   position: fixed;
   left: 18px;
   bottom: 18px;
   z-index: 1190;
   width: min(360px, calc(100vw - 36px));
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 }
 .cl-toast--update .cl-toast-stripe {
   background: var(--cl-accent);
+}
+/* The CLI notice reports a mismatch, not a fault — it stays on plain paper
+   with no stripe, and the command is the only thing that carries weight. */
+.cl-toast--cli .cl-toast-sub {
+  margin-top: 0;
+}
+.cl-cli-cmd {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 9px;
+}
+.cl-cli-cmd code {
+  flex: 1;
+  min-width: 0;
+  overflow-x: auto;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--cl-ink-2);
+  background: var(--cl-line-soft);
+  border: 1px solid var(--cl-line);
+  border-radius: 6px;
+  padding: 3px 7px;
+}
+.cl-cli-copy {
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--cl-ink-3);
+  border: 1px solid var(--cl-line);
+  border-radius: 6px;
+  padding: 2px 8px;
+  transition: color 0.15s ease;
+}
+.cl-cli-copy:hover {
+  color: var(--cl-accent);
 }
 .cl-toast-actions {
   display: flex;

--- a/test/update-checker.test.ts
+++ b/test/update-checker.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   compareVersions,
+  parseClaudeCliVersion,
   parseLatestRelease,
   RELEASES_PAGE_URL,
 } from '../electron/modules/update-checker';
@@ -78,5 +79,26 @@ describe('parseLatestRelease', () => {
   it('normalizes a blank release name to null', () => {
     const info = parseLatestRelease({ tag_name: 'v2.2.0', name: '  ' }, '2.1.5');
     expect(info!.releaseName).toBeNull();
+  });
+});
+
+describe('parseClaudeCliVersion', () => {
+  it('reads the version out of `claude --version`', () => {
+    expect(parseClaudeCliVersion('2.1.232 (Claude Code)\n')).toBe('2.1.232');
+    expect(parseClaudeCliVersion('  2.1.232 (Claude Code)  ')).toBe('2.1.232');
+    expect(parseClaudeCliVersion('2.2.0-beta.1 (Claude Code)')).toBe('2.2.0-beta.1');
+  });
+
+  it('returns null when the output carries no version', () => {
+    expect(parseClaudeCliVersion('')).toBeNull();
+    expect(parseClaudeCliVersion('command not found: claude')).toBeNull();
+  });
+
+  it('feeds a comparison that flags an outdated CLI', () => {
+    const installed = parseClaudeCliVersion('2.1.190 (Claude Code)')!;
+    expect(compareVersions(installed, '2.1.232')).toBeLessThan(0);
+    expect(
+      compareVersions(parseClaudeCliVersion('2.2.0 (Claude Code)')!, '2.1.232')
+    ).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## What

ClaudeLens reads what the Claude Code CLI writes to `~/.claude`. When the installed CLI is older than the `claudeCodeVersion` a build was prepared against, it can be writing (or missing) formats this build doesn't understand — but the only place saying so was Settings → General, as an `outdated` chip nobody goes looking for.

This surfaces the same verdict **at launch**, as a passive notice.

## How

- **Main**: `updates:claudeCodeVersion` runs `claude --version` through `execClaude` (PATH-augmented env + packaged-app executable resolution) with an 8s cap; `parseClaudeCliVersion` in `update-checker.ts` reads the version out of the output, defensively — no `x.y` number means `null`, never a guess. The CLI is asked directly rather than the Agent SDK handshake, which is slow and cwd-scoped (an untrusted dir answers nothing).
- **Renderer**: `useClaudeCodeVersion()` (once per run) + the shared `compareVersions` against `package.json`'s `claudeCodeVersion` — the same comparison Settings already does.
- **UI**: a second notice in `UpdateBanner.tsx`, in the same bottom-left anchor, now a column stack so it and the release notice can coexist without either knowing about the other.

## Minimal by design

Nothing is broken when the CLI is behind, so the notice gets **no stripe and no title**: one sentence, the `claude update` command with a Copy button (that command works whichever installer put the CLI there), and "Don't remind me". ✕ hides it for the run; "Don't remind me" pins the **required** version in prefs (`cl-cli-update-dismissed-version`), so a later ClaudeLens raising the bar brings it back. A failed read never shows anything — an unknown version is not an outdated one. Silent in `SCREENSHOT_MODE`.

## Tests

`parseClaudeCliVersion` unit-tested in `test/update-checker.test.ts` (real `--version` output, pre-release suffix, garbage → null, and the comparison that drives the notice). Full suite + typecheck + lint + build green.

## Note

Root `CLAUDE.md` is intentionally untouched: it had uncommitted edits from another agent's work in the same tree. The component doc (`src/components/CLAUDE.md`) carries the rationale.