### PR TITLE
feat(home): bring the global home to design 1a

### DIFF
--- a/src/components/project/CLAUDE.md
+++ b/src/components/project/CLAUDE.md
@@ -299,6 +299,62 @@ c'è più di una pagina. Nota per gli screenshot: `screenshotFixtures.ts` semina
 già un pin (`cl-pinned-projects`), quindi SCREENSHOT_MODE continua a mostrare la
 sezione.
 
+**Fascia cifre sotto l'hero — design handoff _Global Home varianti_, opzione 1a.**
+Tra l'hero e la prima sezione c'è una striscia di 4 celle
+(`.cl-stats.cl-stats--home`): Projects · Tokens · Spend · **Live now**, con
+l'ultima cella come **slab scuro fisso in entrambi i temi** (il trattamento che
+`.cl-stat:last-child` già portava) e il dot sage `.cl-live-dot` a fianco della
+cifra. Riusa l'anatomia `.cl-stats`/`.cl-stat` che vive in `index.css` da
+Studio/Agents Live; il modificatore `--home` cambia una cosa sola: la **cifra
+viene prima e la label sotto**, perché qui i quattro numeri _sono_ l'affermazione
+e vanno letti prima per riga e poi per colonna, mentre le altre strisce
+etichettano una lista che le segue. I qualificatori (`$`, l'unità, i centesimi)
+sono lo stesso display face a metà altezza e **a filo** della cifra, così
+`$99.78` resta un numero e non tre token — la nota mono di `.cl-stat .num small`
+li avrebbe staccati.
+I totali sono su **tutto l'install** (somma di `cost:getSummary`), non sulla
+shortlist pinnata sotto: Tokens e Spend sono la sola risposta della home a
+"quanto è costato tutto questo", che prima non stava da nessuna parte. Projects
+e Live now ripetono di proposito due cifre della meta-riga dell'hero — è il
+ritmo editoriale del mock (frase d'inventario → strato numerico), non una svista.
+Con nessun processo vivo il dot **non pulsa**: un alone attorno a uno zero
+sarebbe l'elemento più urlato della striscia senza significare nulla.
+
+**Configuration a card + ritmo delle sezioni.** Sempre da 1a, la sezione
+Configuration non è più la lista a due colonne divisa da hairline: è una
+**griglia 3-up di card bordate** (`.cl-tile-grid--cards`, un modificatore di
+`.cl-tile-grid` — la lista resta il default per Skills, Plugins, memoria,
+CLAUDE.md e tutti gli altri usi). Sulla card il conteggio **scende sotto la
+descrizione** invece di stare nella terza colonna: appartiene alla frase che
+qualifica, e da colonna destra leggeva come una cella di tabella. Per la stessa
+ragione la descrizione perde il mono — quello era il device della lista per
+tenere allineate due colonne di testo, su una card è solo prosa breve. Glifo:
+tile arrotondata `--cl-r-tile`, piena accent sulla prima card.
+Il resto del corpo home è scopato sotto **`.cl-ghome`**: il filetto d'inchiostro
+**risale sotto la testata** (1.5px, 12px sotto il titolo) invece di stare in
+cima alla lista, dove i 24px di `.cl-sec-head` lo staccavano dal titolo che
+dovrebbe sottolineare. Con quel filetto a portare la separazione, la hairline di
+chiusura di `.cl-section` e quella della striscia cifre diventano una terza e
+una quarta riga fra due blocchi e vengono spente; le righe pinnate passano da
+`border-top` a `border-bottom` così l'ultima resta chiusa prima del pager.
+Nessuna di queste regole esce dalla home.
+**Attenzione ai token di raggio**: `--cl-r-card`/`--cl-r-tile` erano _usati_ da
+`.cl-plan-card` e `.cl-ask-card` ma **mai dichiarati** in `index.css` (vivono
+nel design system), e una var non definita invalida l'intera dichiarazione a
+computed-value time — quelle due card rendevano squadrate, e le card della
+Configuration hanno fatto lo stesso finché i token non sono stati dichiarati in
+`:root`. Le elevazioni (`--cl-elev-card`) restano non dichiarate di proposito:
+lì i call site passano un fallback esplicito.
+
+**Trigger di ricerca — pill nella top bar.** `.cl-lens-btn` non è più il tondo
+da 28px: è il pill di 1a (lente + `Search projects, sessions…` + chip `⌘F`).
+Il mock lo disegna dentro l'hero, ma il mock non ha la top bar dell'app e un
+secondo trigger per lo stesso popover è esattamente ciò che era stato tolto dal
+rail progetto — quindi resta uno solo, dov'era, e vale su ogni vista. Sotto i
+1080px label e chip spariscono e torna il tondo. Lo stato aperto **tinge invece
+di riempire**: un pieno terracotta largo 230px sarebbe l'elemento più urlato
+della chrome, e il popover sotto dice già che la ricerca è aperta.
+
 **Chrome del progetto — design handoff _Sessions Varianti_ (rail 5a + contenuto 5b).**
 La navigazione di progetto non è più una fascia orizzontale di subtab: è una
 **colonna di lavoro** a sinistra (`ProjectRail`, 220px, `--cl-paper-2`, hairline

--- a/src/components/project/overview/GlobalHomeView.tsx
+++ b/src/components/project/overview/GlobalHomeView.tsx
@@ -61,6 +61,26 @@ export function GlobalHomeView({
     return m;
   }, [costSummary]);
 
+  // The figures strip totals the whole install, not the pinned shortlist below
+  // it: it answers "how much has all of this cost", which is the one question
+  // the home could not answer before.
+  const totals = useMemo(() => {
+    let tokens = 0;
+    let cost = 0;
+    for (const c of (costSummary as ProjectCost[] | undefined) ?? []) {
+      tokens += c.totalTokens;
+      cost += c.cost;
+    }
+    // Split on the rounded string so the dollars and the cents can never
+    // disagree (0.999 must not print as "$0" + ".00").
+    const [whole, cents] = cost.toFixed(2).split('.');
+    return {
+      tokens: formatTokens(tokens),
+      spendWhole: Number(whole).toLocaleString('en-US'),
+      spendCents: `.${cents}`,
+    };
+  }, [costSummary]);
+
   // The home lists pinned projects only — the full list lives in the lens
   // (⌘F). With nothing pinned there is no section at all, so this doubles as
   // the section's mount guard.
@@ -97,7 +117,7 @@ export function GlobalHomeView({
   const claudeMdLines = (globalClaudeMd ?? '').split('\n').length;
 
   return (
-    <div style={{ position: 'relative' }}>
+    <div className="cl-ghome" style={{ position: 'relative' }}>
       {/* ─── HERO ─────────────────────────────────────── */}
       <section className="cl-hero">
         <Lens />
@@ -131,6 +151,38 @@ export function GlobalHomeView({
           </span>
         </div>
       </section>
+
+      {/* ─── FIGURES STRIP ────────────────────────────── */}
+      <div className="cl-stats cl-stats--home">
+        <div className="cl-stat">
+          <div className="num">{allProjects.length}</div>
+          <div className="lbl">Projects</div>
+        </div>
+        <div className="cl-stat">
+          <div className="num">
+            {totals.tokens.value}
+            {totals.tokens.unit && <small>{totals.tokens.unit}</small>}
+          </div>
+          <div className="lbl">Tokens</div>
+        </div>
+        <div className="cl-stat">
+          <div className="num">
+            <small>$</small>
+            {totals.spendWhole}
+            <small>{totals.spendCents}</small>
+          </div>
+          <div className="lbl">Spend</div>
+        </div>
+        <div className="cl-stat cl-stat--live">
+          <div className="num">
+            <span>{procs.length}</span>
+            {/* No pulse with nothing running — a halo around a zero would be
+                the loudest thing on the strip and it would mean nothing. */}
+            {procs.length > 0 && <span className="dot cl-live-dot" />}
+          </div>
+          <div className="lbl">Live now</div>
+        </div>
+      </div>
 
       {/* ─── DUPLICATE PROJECTS (segnale compatto) ────── */}
       <DuplicateProjectsBadge onNavigate={onNavigate} />
@@ -318,7 +370,10 @@ export function GlobalHomeView({
           <h2>Configuration</h2>
           <span className="ct">shared across all projects</span>
         </div>
-        <div className="cl-tile-grid">
+        {/* Cards, not the hairline list: on a card the count belongs under the
+            sentence it qualifies, so `.t-meta` moves inside the text column
+            instead of standing as a right-hand table cell. */}
+        <div className="cl-tile-grid cl-tile-grid--cards">
           <button
             type="button"
             className="cl-tile accent"
@@ -330,16 +385,16 @@ export function GlobalHomeView({
               <div className="t-desc">
                 Global instructions injected into every Claude Code session.
               </div>
+              <span className="t-meta">
+                {globalClaudeMd ? (
+                  <>
+                    <b>{claudeMdLines}</b> lines
+                  </>
+                ) : (
+                  'not set'
+                )}
+              </span>
             </div>
-            <span className="t-meta">
-              {globalClaudeMd ? (
-                <>
-                  <b>{claudeMdLines}</b> lines
-                </>
-              ) : (
-                'not set'
-              )}
-            </span>
           </button>
           <button
             type="button"
@@ -352,10 +407,10 @@ export function GlobalHomeView({
               <div className="t-desc">
                 Reusable, invocable behaviors available to every project.
               </div>
+              <span className="t-meta">
+                <b>{skills.length}</b> skills
+              </span>
             </div>
-            <span className="t-meta">
-              <b>{skills.length}</b> skills
-            </span>
           </button>
           <button
             type="button"
@@ -366,10 +421,10 @@ export function GlobalHomeView({
             <div>
               <div className="t-name">Agents</div>
               <div className="t-desc">Specialized sub-agents available to delegate to.</div>
+              <span className="t-meta">
+                <b>{agents.length}</b> agents
+              </span>
             </div>
-            <span className="t-meta">
-              <b>{agents.length}</b> agents
-            </span>
           </button>
           <button
             type="button"
@@ -382,20 +437,20 @@ export function GlobalHomeView({
               <div className="t-desc">
                 Model Context Protocol integrations, shared across projects.
               </div>
+              <span className="t-meta">
+                <b>{mcpServers.length}</b> servers
+              </span>
             </div>
-            <span className="t-meta">
-              <b>{mcpServers.length}</b> servers
-            </span>
           </button>
           <button type="button" className="cl-tile" onClick={() => onNavigate({ type: 'plugins' })}>
             <span className="glyph">P</span>
             <div>
               <div className="t-name">Plugins</div>
               <div className="t-desc">Skills, agents & commands installed from marketplaces.</div>
+              <span className="t-meta">
+                <b>{plugins.length}</b> plugins
+              </span>
             </div>
-            <span className="t-meta">
-              <b>{plugins.length}</b> plugins
-            </span>
           </button>
         </div>
       </section>

--- a/src/index.css
+++ b/src/index.css
@@ -52,6 +52,18 @@
   /* shared editorial gutter (hero / section horizontal padding) */
   --cl-gutter: clamp(32px, 5.5vw, 80px);
 
+  /* Radii, as the design system declares them. These were referenced before
+     they were ever defined (.cl-plan-card and .cl-ask-card ask for
+     --cl-r-card), and an undefined var makes the whole declaration invalid at
+     computed-value time — so those cards have been rendering square, not
+     rounded. Declaring them here fixes those two and gives the card surfaces
+     a token instead of a repeated literal. */
+  --cl-r-pill: 999px;
+  --cl-r-btn: 12px;
+  --cl-r-card: 16px;
+  --cl-r-popover: 12px;
+  --cl-r-tile: 8px;
+
   /* legacy tokens kept for the not-yet-migrated dark "deep" views (chat,
      detail, modals) and prose-lens — do not remove until those migrate. */
   --bg-deep: #0d0f14;
@@ -421,11 +433,17 @@ body {
   gap: 12px;
 }
 
-/* ── LENS · search trigger button (top right) ── */
+/* ── LENS · search trigger (top right) ──────────────────────────────────
+   A pill that names itself (design 1a): lens + placeholder + the ⌘F chip.
+   It stays the app's ONE search entry — 1a draws it inside the hero, but the
+   mock has no top bar, and a second trigger for the same popover is exactly
+   what was removed from the project rail. Below 1080px the label and the chip
+   drop and it collapses back to the 28px lens: the pill would otherwise eat
+   the nav's breathing room in a narrow window. */
 .cl-lens-btn {
-  width: 28px;
   height: 28px;
-  border-radius: 50%;
+  padding: 0 8px 0 11px;
+  border-radius: var(--cl-r-pill);
   border: 1px solid oklch(1 0 0 / 0.35);
   background: oklch(1 0 0 / 0.18);
   -webkit-backdrop-filter: blur(18px) saturate(1.8);
@@ -433,6 +451,7 @@ body {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  gap: 8px;
   color: var(--cl-ink-3);
   cursor: pointer;
   transition:
@@ -447,19 +466,59 @@ body {
 .cl-lens-btn svg {
   width: 14px;
   height: 14px;
+  flex: none;
+}
+.cl-lens-btn .ph {
+  font-family: var(--font-sans);
+  font-size: 12.5px;
+  line-height: 1;
+  color: var(--cl-ink-3);
+  white-space: nowrap;
+}
+.cl-lens-btn .kbd {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  line-height: 1;
+  letter-spacing: 0.06em;
+  color: var(--cl-ink-4);
+  padding: 3px 5px;
+  border: 1px solid var(--cl-line);
+  border-radius: 5px;
+  flex: none;
 }
 .cl-lens-btn:hover {
   color: var(--cl-accent-ink);
   background: oklch(0.95 0.04 40 / 0.55);
   border-color: oklch(0.55 0.18 40 / 0.4);
 }
+.cl-lens-btn:hover .ph {
+  color: var(--cl-accent-ink);
+}
+/* Open state tints rather than fills: a solid terracotta bar 230px wide would
+   be the loudest thing in the chrome, and the popover under it already says
+   the search is open. */
 .cl-lens-btn.on {
-  color: var(--cl-on-accent);
-  background: linear-gradient(180deg, oklch(0.62 0.22 40), oklch(0.48 0.22 40));
-  border-color: oklch(0.46 0.22 40);
-  box-shadow:
-    inset 0 1px 0 oklch(1 0 0 / 0.45),
-    0 4px 10px -3px oklch(0.45 0.2 40 / 0.45);
+  color: var(--cl-accent-ink);
+  background: var(--cl-accent-soft);
+  border-color: var(--cl-accent);
+}
+.cl-lens-btn.on .ph {
+  color: var(--cl-accent-ink);
+}
+.cl-lens-btn.on .kbd {
+  border-color: var(--cl-accent);
+  color: var(--cl-accent-ink);
+}
+@media (max-width: 1080px) {
+  .cl-lens-btn {
+    width: 28px;
+    padding: 0;
+    border-radius: 50%;
+  }
+  .cl-lens-btn .ph,
+  .cl-lens-btn .kbd {
+    display: none;
+  }
 }
 :root[data-theme='dark'] .cl-lens-btn {
   background: oklch(1 0 0 / 0.08);
@@ -7246,6 +7305,90 @@ body {
   letter-spacing: 0.02em;
 }
 
+/* ── Global home variant (design 1a) ──────────────────────────────────────
+   The figure leads and the label sits under it. Elsewhere the strip labels
+   a list that follows it, so the label goes first; here the four numbers ARE
+   the statement, and putting them on one line of digits lets the row be read
+   across before it is read down. The qualifiers ($, the unit, the cents) are
+   the same display face at half height instead of the mono footnote used by
+   the label-first strips — flush against the figure, so "$99.78" stays one
+   number rather than three tokens. */
+.cl-stats--home .cl-stat .num {
+  margin-top: 0;
+}
+.cl-stats--home .cl-stat .lbl {
+  display: flex;
+  margin-top: 10px;
+  font-size: 10.5px;
+  letter-spacing: 0.2em;
+  color: var(--cl-ink-4);
+}
+.cl-stats--home .cl-stat:last-child .lbl {
+  color: oklch(0.72 0.006 80);
+}
+.cl-stats--home .cl-stat .num small {
+  font-family: var(--font-sans);
+  font-size: 26px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: var(--cl-ink-3);
+  margin-left: 0;
+}
+.cl-stats--home .cl-stat--live .num {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+.cl-stats--home .cl-stat--live .dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--cl-ok);
+  flex: none;
+}
+
+@media (max-width: 980px) {
+  .cl-stats--home .cl-stat {
+    padding: 20px 18px 22px;
+  }
+  .cl-stats--home .cl-stat .num {
+    font-size: 36px;
+  }
+  .cl-stats--home .cl-stat .num small {
+    font-size: 18px;
+  }
+}
+
+/* ── Global home section rhythm (design 1a) ───────────────────────────────
+   The rule belongs to the heading, not to the list. Everywhere else in the
+   app the ink rule sits on top of the list (.cl-proc-list / .cl-tile-grid /
+   .cl-row), which the shared .cl-sec-head's 24px gap detaches from the title
+   it is supposed to underline; 1a hugs it at 12px so head + rule read as one
+   masthead per block. With that rule carrying the separation, .cl-section's
+   closing hairline becomes a third line between two blocks, and the strip's
+   own bottom rule a fourth — both come off. Rows close with a hairline
+   instead of opening with one, so the last row is still shut before the
+   pager. All of it is scoped to the home: the rest of the app keeps the
+   list-top rule it was drawn with. */
+.cl-ghome .cl-sec-head {
+  border-bottom: 1.5px solid var(--cl-ink);
+  padding-bottom: 12px;
+  margin-bottom: 20px;
+}
+.cl-ghome .cl-section {
+  border-bottom: none;
+}
+.cl-ghome .cl-stats {
+  border-bottom: none;
+}
+.cl-ghome .cl-proc-list {
+  border-top: none;
+}
+.cl-ghome .cl-row {
+  border-top: none;
+  border-bottom: 1px solid var(--cl-line-soft);
+}
+
 /* ════════════════════════════════════════════════════════════════════════
    SECTION (generic editorial)
    ════════════════════════════════════════════════════════════════════════ */
@@ -10630,6 +10773,93 @@ button.cl-sw-member:focus-visible,
 }
 .cl-tile-grid--list {
   grid-template-columns: 1fr;
+}
+/* ── Card variant (design 1a, the global home's Configuration) ────────────
+   Bordered rounded cards on a 3-up grid instead of the hairline-divided
+   two-column list. The meta leaves the third column and sits under the
+   description: on a card the figure belongs to the thing it describes, while
+   as a right-hand column it read as a table cell. The description drops the
+   mono face for the same reason — a card is a small piece of prose, and mono
+   was the list's device for keeping two columns of text aligned. */
+.cl-tile-grid--cards {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  border-top: none;
+  border-bottom: none;
+}
+.cl-tile-grid--cards .cl-tile,
+.cl-tile-grid--cards .cl-tile:nth-child(odd),
+.cl-tile-grid--cards .cl-tile:nth-child(even) {
+  grid-template-columns: 36px 1fr;
+  gap: 14px;
+  padding: 18px;
+  border: 1px solid var(--cl-line);
+  border-radius: var(--cl-r-card);
+  background: var(--cl-paper);
+}
+.cl-tile-grid--cards .cl-tile.accent,
+.cl-tile-grid--cards .cl-tile.accent:nth-child(odd) {
+  border-color: var(--cl-accent);
+  background: var(--cl-accent-soft);
+  box-shadow: inset 0 1px 0 var(--cl-glass-highlight);
+}
+/* Hover lifts the edge, it does not wash the surface: the shared .cl-tile
+   hover is an accent tint, and on this grid that made a hovered neutral card
+   read as the accent card. Here the accent fill means "this one is different",
+   so hover has to say something else. */
+.cl-tile-grid--cards .cl-tile:hover {
+  background: var(--cl-paper);
+  border-color: var(--cl-accent);
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
+  box-shadow: 0 6px 18px -10px oklch(0.2 0.015 60 / 0.35);
+}
+.cl-tile-grid--cards .cl-tile.accent:hover {
+  background: var(--cl-accent-soft);
+  border-color: var(--cl-accent-ink);
+  box-shadow:
+    inset 0 1px 0 var(--cl-glass-highlight),
+    0 6px 18px -10px oklch(0.2 0.015 60 / 0.35);
+}
+.cl-tile-grid--cards .cl-tile .glyph {
+  width: 36px;
+  height: 36px;
+  border-radius: var(--cl-r-tile);
+  border: 1px solid var(--cl-line);
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--cl-ink-2);
+}
+.cl-tile-grid--cards .cl-tile.accent .glyph {
+  border-color: var(--cl-accent);
+  color: var(--cl-on-accent);
+}
+.cl-tile-grid--cards .cl-tile .t-name {
+  font-size: 17px;
+}
+.cl-tile-grid--cards .cl-tile .t-desc {
+  font-family: var(--font-sans);
+  font-size: 13px;
+  line-height: 1.6;
+}
+.cl-tile-grid--cards .cl-tile .t-meta {
+  display: block;
+  margin-top: 10px;
+  white-space: normal;
+}
+.cl-tile-grid--cards .cl-tile.accent .t-meta,
+.cl-tile-grid--cards .cl-tile.accent .t-meta b {
+  color: var(--cl-accent-ink);
+}
+@media (max-width: 1180px) {
+  .cl-tile-grid--cards {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+@media (max-width: 760px) {
+  .cl-tile-grid--cards {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }
 .cl-tile-grid--list .cl-tile {
   padding: 22px 0;

--- a/src/tabs/ProjectOverview.tsx
+++ b/src/tabs/ProjectOverview.tsx
@@ -743,6 +743,8 @@ export default function ProjectOverview() {
             title="Search"
           >
             <LensTriggerIcon />
+            <span className="ph">Search projects, sessions…</span>
+            <span className="kbd">⌘F</span>
           </button>
           <button
             className="cl-theme-toggle"


### PR DESCRIPTION
Implements design **1a** (_Global Home — varianti_, `claude.ai/design`) for the global home.

## What changed

**Figures strip** — the element 1a is named after, and the one thing the home was missing: `Projects · Tokens · Spend · Live now`, the last cell a fixed-dark slab with the sage live dot. Tokens and Spend total the whole install (not the pinned shortlist below) and are the home's only answer to "what has all of this cost". Reuses the existing `.cl-stats` anatomy; `--home` flips one thing — the figure leads, the label sits under it, because here the four numbers *are* the statement.

**Configuration → cards** — no longer a hairline-divided two-column list but the 3-up bordered card grid the mock draws. The count moves out of the third column and under the description: on a card it belongs to the sentence it qualifies; as a right-hand column it read as a table cell. Hover lifts the edge instead of washing the surface — the shared `.cl-tile` accent tint made a hovered neutral card read as the accent one.

**Section rhythm** — the ink rule moves up under its heading instead of sitting on top of the list, where `.cl-sec-head`'s 24px gap detached it from the title it underlines. `.cl-section`'s closing hairline and the strip's bottom rule come off (they'd be a third and fourth line between blocks), and rows close with a hairline instead of opening with one so the last row is still shut before the pager. Scoped to `.cl-ghome`.

**Search trigger → pill** — lens + `Search projects, sessions…` + `⌘F` chip. 1a draws it inside the hero, but the mock has no top bar and a second trigger for the same popover is exactly what was removed from the project rail, so it stays the single entry point where it was and works on every view. Collapses to the 28px lens under 1080px; the open state tints rather than fills.

## Latent bug fixed along the way

`--cl-r-card` / `--cl-r-tile` were **referenced but never declared** in `index.css` — they live only in the design-system bundle, and an undefined `var()` invalidates the whole declaration at computed-value time. Every surface asking for them rendered square. That had been silently true of `.cl-plan-card` and `.cl-ask-card` all along; declaring the radii in `:root` rounds those two as they were written to be. Elevations (`--cl-elev-card`) stay undeclared on purpose — their call sites pass an explicit fallback.

## Deliberately not done

The mock's **MCP servers** block is a plain 4-up card grid. The app already has sort and pagination there, so matching the mock would be a functional regression dressed as fidelity.

## Verification

`typecheck` + `lint --max-warnings 0` + `format:check` + 880 tests pass. Visual/layout behaviour has no automated coverage — checked by hand in the running app.