### PR TITLE
refactor(mission-control): drop the density toggle that only moved half a pixel

### DIFF
--- a/src/components/project/terminal/MissionRail.tsx
+++ b/src/components/project/terminal/MissionRail.tsx
@@ -250,13 +250,11 @@ function FeedGlyph({ e }: { e: FeedEvent }) {
 function FeedRow({
   e,
   now,
-  compact,
   open,
   onActivate,
 }: {
   e: FeedEvent;
   now: number;
-  compact: boolean;
   open: boolean;
   onActivate: () => void;
 }) {
@@ -273,7 +271,7 @@ function FeedRow({
         gap: 9,
         width: '100%',
         textAlign: 'left',
-        padding: `${compact ? 6 : 8}px 6px`,
+        padding: '6px',
         margin: '0 -6px',
         borderRadius: 6,
         border: 0,
@@ -297,7 +295,7 @@ function FeedRow({
           className="truncate"
           style={{
             display: 'block',
-            font: `500 ${compact ? 12 : 12.5}px/1.3 var(--font-sans)`,
+            font: '500 12px/1.3 var(--font-sans)',
             color: e.danger ? 'var(--cl-danger)' : 'var(--cl-ink)',
           }}
         >
@@ -373,13 +371,7 @@ function FeedOperations({
 }
 
 /** Disclosure under a task row — the detail the dedicated Tasks page shows. */
-function TaskDetail({
-  event,
-  fontSize,
-}: {
-  event: Extract<FeedEvent['source'], { kind: 'task' }>;
-  fontSize: number;
-}) {
+function TaskDetail({ event }: { event: Extract<FeedEvent['source'], { kind: 'task' }> }) {
   const t = event.task;
   const liveForm = t.status === 'in_progress' ? t.activeForm?.trim() : '';
   return (
@@ -392,12 +384,14 @@ function TaskDetail({
       }}
     >
       {liveForm && (
-        <span style={{ fontSize, lineHeight: 1.45, color: 'var(--cl-ok)', fontWeight: 600 }}>
+        <span style={{ fontSize: 11, lineHeight: 1.45, color: 'var(--cl-ok)', fontWeight: 600 }}>
           ⟳ {liveForm}…
         </span>
       )}
       {t.description?.trim() && (
-        <span style={{ fontSize, lineHeight: 1.5, color: 'var(--cl-ink-2)' }}>{t.description}</span>
+        <span style={{ fontSize: 11, lineHeight: 1.5, color: 'var(--cl-ink-2)' }}>
+          {t.description}
+        </span>
       )}
       {(t.blockedBy.length > 0 || t.blocks.length > 0) && (
         <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
@@ -525,16 +519,6 @@ export function MissionRail({
       return next;
     });
   }, []);
-  const [compact, setCompact] = useState<boolean>(
-    () => localStorage.getItem('tmc-density') !== 'comfortable'
-  );
-  const toggleCompact = useCallback(() => {
-    setCompact(v => {
-      localStorage.setItem('tmc-density', v ? 'comfortable' : 'compact');
-      return !v;
-    });
-  }, []);
-
   const onResizeStart = useCallback(
     (e: React.PointerEvent<HTMLDivElement>) => {
       e.preventDefault();
@@ -884,21 +868,6 @@ export function MissionRail({
             </button>
           );
         })}
-        <button
-          type="button"
-          className="font-mono transition-colors"
-          onClick={toggleCompact}
-          aria-pressed={compact}
-          title="Toggle density"
-          style={{
-            marginLeft: 'auto',
-            fontSize: 9,
-            letterSpacing: '0.12em',
-            color: compact ? 'var(--cl-accent-ink)' : 'var(--cl-ink-4)',
-          }}
-        >
-          {compact ? 'COMPACT' : 'COMFY'}
-        </button>
       </div>
 
       {/* the stream */}
@@ -932,19 +901,11 @@ export function MissionRail({
           const open = expanded.has(e.id);
           return (
             <div key={e.id}>
-              <FeedRow
-                e={e}
-                now={now}
-                compact={compact}
-                open={open}
-                onActivate={() => activate(e)}
-              />
+              <FeedRow e={e} now={now} open={open} onActivate={() => activate(e)} />
               {open && e.items.length > 0 && (
                 <FeedOperations items={e.items} onOpenTool={onOpenTool} />
               )}
-              {open && e.source.kind === 'task' && (
-                <TaskDetail event={e.source} fontSize={compact ? 11 : 11.5} />
-              )}
+              {open && e.source.kind === 'task' && <TaskDetail event={e.source} />}
             </div>
           );
         })}


### PR DESCRIPTION
The COMPACT/COMFY button in the Mission Control rail promised two ways to read the feed and delivered three differences nobody can see:

| | COMPACT | COMFY |
|---|---|---|
| row padding | `6px` | `8px` |
| row title | `12px` | `12.5px` |
| task detail | `11px` | `11.5px` |

Half a pixel of font size is not a density, so the control was announcing a mode that did not exist.

Everything it existed to carry goes with it:

- the `compact` state and its `localStorage[tmc-density]` key — registered in neither `prefsBackend` nor read anywhere else, so nothing is left orphaned
- `FeedRow`'s `compact` prop, with the values frozen at the compact variant (what the rail rendered by default)
- `TaskDetail`'s `fontSize` prop, which was only ever a conduit for that half pixel

Net −39 lines in one file, no behavior change beyond the button being gone.

## Verification

`typecheck` + `lint` + `format:check` + `test` (880 passed, 3 skipped) all green. The rail's look is unverified by automation as usual — worth a glance at the filter bar, which is now the filters alone (the button held the `marginLeft: auto`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwmWrW78LS6wG1TwkFeNEC