### PR TITLE
fix(overview): make the project metrics band say what it measures

### DIFF
--- a/src/components/project/overview/ProjectOverviewContent.tsx
+++ b/src/components/project/overview/ProjectOverviewContent.tsx
@@ -1,4 +1,5 @@
-import { memo, useCallback, useEffect, useMemo, useState, type CSSProperties } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
+import { createPortal } from 'react-dom';
 import {
   useMemoryProject,
   useSessionList,
@@ -12,13 +13,16 @@ import {
   useActiveSessions,
 } from '../../../hooks/useIPC';
 import { View } from '../types';
-import { fmt, fmtModel, sessionTitle, formatTokens, buildModelMix } from '../utils';
+import { fmt, fmtCost, fmtModel, sessionTitle, formatTokens, buildModelMix } from '../utils';
 import type { SessionSummary, MemoryTopic } from '../../../types';
 import { Lens } from './Lens';
 import { McpServerGrid } from '../mcp/McpServerGrid';
 import { AgentsLiveView } from '../agents-live/AgentsLiveView';
 import { TasksSection } from '../tasks/TasksSection';
 import { projectDisplayName } from '../shared/projectName';
+import { ReadoutShell, ReadoutCell, ReadoutPart, ReadoutRule } from '../shared/ReadoutCard';
+import { READOUT_RAMP } from '../shared/readout';
+import { kTok } from '../terminal/mission-feed';
 import { PlansSection } from '../plans/PlansSection';
 import { WorkflowsSection } from '../workflows/WorkflowsSection';
 import { TeamsSection } from '../teams/TeamsSection';
@@ -118,8 +122,10 @@ function normalizeRetentionDays(days: number): number {
   return Number.isFinite(days) && days > 0 ? Math.max(1, Math.round(days)) : DEFAULT_RETENTION_DAYS;
 }
 
+// en-US, not it-IT: the UI is english-only, and an it-IT month abbreviation
+// ("ago", "set") is the only italian word in the band's tooltips.
 function fmtBucketDate(ms: number): string {
-  return new Date(ms).toLocaleDateString('it-IT', { day: '2-digit', month: 'short' });
+  return new Date(ms).toLocaleDateString('en-US', { day: '2-digit', month: 'short' });
 }
 
 function bucketLabel(startMs: number, endMs: number): string {
@@ -128,32 +134,57 @@ function bucketLabel(startMs: number, endMs: number): string {
   return start === end ? start : `${start} - ${end}`;
 }
 
-function buildTimelineBuckets(sessions: SessionSummary[], days: number): TimelineBucket[] {
-  const bucketCount = Math.min(MAX_STAT_BARS, Math.max(1, Math.ceil(days)));
-  const now = Date.now();
-  const windowMs = days * DAY_MS;
-  const startMs = now - windowMs;
-  const bucketMs = windowMs / bucketCount;
-  const buckets = Array.from({ length: bucketCount }, (_, i) => {
-    const from = startMs + i * bucketMs;
-    const to = i === bucketCount - 1 ? now : startMs + (i + 1) * bucketMs;
-    return {
-      key: `${Math.round(from)}-${Math.round(to)}`,
-      label: bucketLabel(from, to),
-      sessions: 0,
-      tokens: 0,
-    };
-  });
+/** Local midnight, `offsetDays` away from the day `ms` falls in. Going through
+ *  `setDate` rather than adding `DAY_MS` keeps every boundary on a true
+ *  midnight across a DST change, where a day is 23 or 25 hours long. */
+function dayStart(ms: number, offsetDays = 0): number {
+  const d = new Date(ms);
+  d.setHours(0, 0, 0, 0);
+  d.setDate(d.getDate() + offsetDays);
+  return d.getTime();
+}
+
+// Buckets span whole days, aligned to local midnight. Slicing the window into
+// exactly MAX_STAT_BARS parts made 30 days into 2.5-day buckets cut at noon, so
+// two adjacent bars both printed the day they shared ("14 Aug - 16 Aug" next to
+// "16 Aug - 19 Aug") — the one thing a reader uses the label to rule out.
+function buildTimelineBuckets(
+  sessions: SessionSummary[],
+  days: number,
+  nowMs: number
+): TimelineBucket[] {
+  const daysPerBucket = Math.max(1, Math.ceil(days / MAX_STAT_BARS));
+  const bucketCount = Math.max(1, Math.ceil(days / daysPerBucket));
+  // Boundaries are computed, not derived by division: with DST in the window
+  // they are not equally spaced in milliseconds.
+  const edges = Array.from({ length: bucketCount + 1 }, (_, k) =>
+    dayStart(nowMs, 1 - (bucketCount - k) * daysPerBucket)
+  );
+  const buckets = Array.from({ length: bucketCount }, (_, i) => ({
+    key: `${edges[i]}-${edges[i + 1]}`,
+    label: bucketLabel(edges[i], edges[i + 1]),
+    sessions: 0,
+    tokens: 0,
+  }));
 
   for (const s of sessions) {
     const t = new Date(s.date).getTime();
-    if (isNaN(t) || t < startMs || t > now) continue;
-    const idx = Math.min(bucketCount - 1, Math.max(0, Math.floor((t - startMs) / bucketMs)));
+    if (isNaN(t) || t < edges[0] || t >= edges[bucketCount]) continue;
+    let idx = bucketCount - 1;
+    while (idx > 0 && t < edges[idx]) idx -= 1;
     buckets[idx].sessions += 1;
     buckets[idx].tokens += s.totalTokens;
   }
 
   return buckets;
+}
+
+/** Width of the token breakdown card — needed both to draw it and to clamp it
+ *  inside the window before it is drawn. */
+const PEEK_W = 300;
+
+function pctOf(part: number, whole: number): number {
+  return whole > 0 ? (part / whole) * 100 : 0;
 }
 
 function bucketValue(bucket: TimelineBucket, metric: StatMetric): number {
@@ -314,17 +345,41 @@ export function ProjectView({
   const liveProc = procs.find(p => p.cwd === project.realPath);
 
   // Wall-clock for the retention window, kept in state so render never calls
-  // Date.now() directly. Seeded right after mount and refreshed each minute;
-  // 0 until the first tick (statsSessions falls back to all sessions then).
-  const [nowMs, setNowMs] = useState(0);
+  // Date.now() directly. The lazy initialiser runs once at mount, so the window
+  // is correct on the FIRST render: seeding it from an effect left one frame
+  // where `statsSessions` fell back to the whole history under a "/ 30d" label,
+  // i.e. the band briefly printed project-wide totals as if they were the month's.
+  // Hover/focus state of the token figure's breakdown card. The card is
+  // portalled (the hero clips its children), so what is stored is where to pin
+  // it in viewport coordinates, measured from the figure it explains.
+  const tokenNumRef = useRef<HTMLDivElement>(null);
+  const [tokenPeek, setTokenPeek] = useState<{ top: number; left: number } | null>(null);
+  const openTokenPeek = useCallback(() => {
+    const r = tokenNumRef.current?.getBoundingClientRect();
+    if (!r) return;
+    setTokenPeek({
+      top: r.bottom + 8,
+      // Clamped so the card never hangs off the right edge on a narrow window.
+      left: Math.max(12, Math.min(r.left, window.innerWidth - PEEK_W - 12)),
+    });
+  }, []);
+  const closeTokenPeek = useCallback(() => setTokenPeek(null), []);
+  // A fixed card measured once would drift away from its figure on scroll, and
+  // the pointer may never leave the cell while the page moves under it.
   useEffect(() => {
-    const tick = () => setNowMs(Date.now());
-    const seed = setTimeout(tick, 0);
-    const t = setInterval(tick, 60_000);
+    if (!tokenPeek) return;
+    const drop = () => setTokenPeek(null);
+    window.addEventListener('scroll', drop, true);
+    window.addEventListener('resize', drop);
     return () => {
-      clearTimeout(seed);
-      clearInterval(t);
+      window.removeEventListener('scroll', drop, true);
+      window.removeEventListener('resize', drop);
     };
+  }, [tokenPeek]);
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  useEffect(() => {
+    const t = setInterval(() => setNowMs(Date.now()), 60_000);
+    return () => clearInterval(t);
   }, []);
 
   // ── Derived ──
@@ -335,7 +390,6 @@ export function ProjectView({
   const isTeamsSection = section === 'teams';
   const retentionDays = normalizeRetentionDays(cleanupDays);
   const statsSessions = useMemo(() => {
-    if (nowMs === 0) return sessions;
     const cutoff = nowMs - retentionDays * DAY_MS;
     return sessions.filter(s => {
       const t = new Date(s.date).getTime();
@@ -347,22 +401,36 @@ export function ProjectView({
   const totalCost = statsSessions.reduce((s, x) => s + x.estimatedCost, 0);
   const totalMessages = statsSessions.reduce((s, x) => s + x.messageCount, 0);
   const tokensFmt = formatTokens(totalTokens);
-  const avgTokens =
-    sessionCount > 0
-      ? formatTokens(Math.round(totalTokens / sessionCount))
-      : { value: '0', unit: '' };
   const avgMessages = sessionCount > 0 ? Math.round(totalMessages / sessionCount) : 0;
+  // What the token figure is made of. `totalTokens` sums cache reads at full
+  // weight even though they bill at a tenth of input, so on a long project the
+  // headline number mostly measures re-read context — the composition is what
+  // makes it honest, and it rides in the hover card rather than in the band.
+  const tokenParts = useMemo(() => {
+    const sum = (pick: (s: SessionSummary) => number) =>
+      statsSessions.reduce((n, s) => n + pick(s), 0);
+    const fresh = sum(s => s.inputTokens) + sum(s => s.outputTokens);
+    const cacheRead = sum(s => s.cacheReadTokens);
+    const cacheWrite = sum(s => s.cacheWriteTokens);
+    const total = fresh + cacheRead + cacheWrite;
+    return {
+      fresh,
+      cacheRead,
+      cacheWrite,
+      cacheSavings: sum(s => s.cacheSavings),
+      cacheShare: total > 0 ? (cacheRead / total) * 100 : 0,
+    };
+  }, [statsSessions]);
   const allSessionCount = sessions.length;
   const olderSessionCount = Math.max(0, allSessionCount - sessionCount);
   const lastActive = sessions[0]?.date;
   const statBuckets = useMemo(
-    () => buildTimelineBuckets(statsSessions, retentionDays),
-    [statsSessions, retentionDays]
+    () => buildTimelineBuckets(statsSessions, retentionDays, nowMs),
+    [statsSessions, retentionDays, nowMs]
   );
   // Sessions in the window immediately before the retention one, so the hero
   // band's session figure can carry an honest delta instead of a bare count.
   const prevWindowSessions = useMemo(() => {
-    if (nowMs === 0) return 0;
     const end = nowMs - retentionDays * DAY_MS;
     const start = end - retentionDays * DAY_MS;
     return sessions.filter(s => {
@@ -752,42 +820,117 @@ export function ProjectView({
               </div>
               <div className="num">
                 {fmt(sessionCount)}
-                {nowMs > 0 && sessionDelta !== 0 && (
-                  <span className={`delta${sessionDelta < 0 ? ' down' : ''}`}>
+                {sessionDelta !== 0 && (
+                  /* The delta is against the window immediately before this one.
+                     It carried no reference at all, and a green "+3" also read as
+                     a verdict the data does not hold — more sessions is not
+                     better — so it states its baseline and stays neutral. */
+                  <span
+                    className="delta"
+                    title={`${fmt(prevWindowSessions)} in the previous ${retentionDays} days`}
+                  >
                     {sessionDelta > 0 ? '+' : '−'}
                     {Math.abs(sessionDelta)}
                   </span>
                 )}
               </div>
+              {/* The only sparkline left: sessions and tokens trace nearly the
+                  same curve, so a second one spent a quarter of the band
+                  re-drawing this one. */}
               <Bars buckets={statBuckets} metric="sessions" />
               <div className="sub">
                 {olderSessionCount > 0
                   ? `${fmt(olderSessionCount)} older · ${fmt(allSessionCount)} total`
-                  : 'full retention'}
+                  : `all ${fmt(allSessionCount)} in window`}
               </div>
             </div>
 
-            <div className="cl-hcell">
-              <div className="lbl">Tokens</div>
-              <div className="num">
+            <div
+              className="cl-hcell cl-hcell--hover"
+              onMouseEnter={openTokenPeek}
+              onMouseLeave={closeTokenPeek}
+            >
+              <div className="lbl">Tokens / {retentionDays}d</div>
+              <div
+                className="num"
+                ref={tokenNumRef}
+                tabIndex={0}
+                onFocus={openTokenPeek}
+                onBlur={closeTokenPeek}
+              >
                 {tokensFmt.value}
                 <small>{tokensFmt.unit}</small>
               </div>
-              <Bars buckets={statBuckets} metric="tokens" />
               <div className="sub">
-                {avgTokens.value}
-                {avgTokens.unit || ' tok'} avg · est. ${totalCost.toFixed(2)}
+                {Math.round(tokenParts.cacheShare)}% cache read
+                <span className="cl-hpeek-hint"> · hover</span>
+              </div>
+              {/* Portalled to <body> on purpose: `.cl-hero` clips its children
+                  (`overflow: hidden` keeps the Lens, which overhangs by 120px,
+                  inside), so a card anchored inside the cell was cut off at the
+                  hero's bottom edge. Same move MemoryPeekCard makes. */}
+              {tokenPeek &&
+                totalTokens > 0 &&
+                createPortal(
+                  <ReadoutShell
+                    title="TOKENS"
+                    meta={`${retentionDays}d`}
+                    style={{
+                      position: 'fixed',
+                      top: tokenPeek.top,
+                      left: tokenPeek.left,
+                      width: PEEK_W,
+                    }}
+                  >
+                    <div className="flex" style={{ gap: 12, marginTop: 11 }}>
+                      <ReadoutCell label="TOTAL" value={kTok(totalTokens)} />
+                      <ReadoutCell
+                        label="CACHE READ"
+                        value={`${Math.round(tokenParts.cacheShare)}%`}
+                      />
+                      <ReadoutCell
+                        label="SAVED"
+                        value={fmtCost(tokenParts.cacheSavings)}
+                        color="var(--cl-ok)"
+                      />
+                    </div>
+                    <ReadoutRule />
+                    <ReadoutPart
+                      label="fresh in/out"
+                      value={kTok(tokenParts.fresh)}
+                      share={pctOf(tokenParts.fresh, totalTokens)}
+                      color={READOUT_RAMP.soft}
+                    />
+                    <ReadoutPart
+                      label="cache read"
+                      value={kTok(tokenParts.cacheRead)}
+                      share={pctOf(tokenParts.cacheRead, totalTokens)}
+                      color={READOUT_RAMP.full}
+                    />
+                    <ReadoutPart
+                      label="cache write"
+                      value={kTok(tokenParts.cacheWrite)}
+                      share={pctOf(tokenParts.cacheWrite, totalTokens)}
+                      color={READOUT_RAMP.mid}
+                    />
+                  </ReadoutShell>,
+                  document.body
+                )}
+            </div>
+
+            {/* Spend takes the cell Messages held: it is the question an
+                overview gets asked, and it used to be the smallest line of the
+                band. Messages survives as the qualifier it always was. */}
+            <div className="cl-hcell">
+              <div className="lbl">Spend / {retentionDays}d</div>
+              <div className="num">{fmtCost(totalCost)}</div>
+              <div className="sub">
+                {fmt(avgMessages)} msg avg · {fmt(totalMessages)} total
               </div>
             </div>
 
-            <div className="cl-hcell">
-              <div className="lbl">Messages</div>
-              <div className="num">{fmt(totalMessages)}</div>
-              <div className="sub">{fmt(avgMessages)} avg / session</div>
-            </div>
-
             <div className="cl-hcell cl-hcell--mix">
-              <div className="lbl">Model distribution</div>
+              <div className="lbl">Model mix / {retentionDays}d</div>
               {modelMix.length === 0 ? (
                 <div className="sub">No usage in this window</div>
               ) : (
@@ -804,11 +947,13 @@ export function ProjectView({
                       />
                     ))}
                   </div>
+                  {/* One line, dot-separated: bar plus a stacked legend was the
+                      same share encoded twice, over two rows. */}
                   <div className="cl-mixlegend">
                     {modelMix.map(slice => (
                       <span key={slice.key}>
                         <i className={`dot ${slice.key}`} />
-                        {slice.label} {Math.round(slice.pct)}%
+                        {slice.label} {slice.pctLabel}%
                       </span>
                     ))}
                   </div>

--- a/src/components/project/shared/ReadoutCard.tsx
+++ b/src/components/project/shared/ReadoutCard.tsx
@@ -1,0 +1,151 @@
+import type { CSSProperties, ReactNode } from 'react';
+import { READOUT_SURFACE } from './readout';
+
+/**
+ * The hover-readout anatomy: a mono eyebrow, a row of headline figures, and
+ * the composition behind them as label · value · fill rows.
+ *
+ * Extracted from Mission Control's `VitalsPopover`, which invented it to
+ * recover the figures the feed redesign had folded away. The project hero band
+ * needs exactly the same move for its token figure — `totalTokens` sums cache
+ * reads at full weight, so the composition is what makes the headline honest —
+ * and a second copy of the idiom would be two cards that drift apart.
+ *
+ * Pointer-transparent by design: these hold no controls, so trapping the cursor
+ * would only keep the card up after the pointer has left the number it belongs
+ * to.
+ */
+
+export function ReadoutShell({
+  title,
+  meta,
+  style,
+  children,
+}: {
+  title: string;
+  meta?: string;
+  /** Positioning — the surface itself is fixed, where it hangs is the host's. */
+  style?: CSSProperties;
+  children: ReactNode;
+}) {
+  return (
+    <div role="tooltip" className="cl-vitals-pop" style={{ ...READOUT_SURFACE, ...style }}>
+      <div className="font-mono flex items-baseline" style={{ gap: 8 }}>
+        <span style={{ fontSize: 9, letterSpacing: '0.2em', color: 'var(--cl-ink-4)' }}>
+          {title}
+        </span>
+        <span style={{ flex: 1 }} />
+        {meta && (
+          <span style={{ fontSize: 9, letterSpacing: '0.06em', color: 'var(--cl-ink-4)' }}>
+            {meta}
+          </span>
+        )}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+/** A flat fill rule — the same gauge idiom as the rail's 2px context line. */
+export function ReadoutFill({
+  pct,
+  color,
+  height = 4,
+}: {
+  pct: number;
+  color: string;
+  height?: number;
+}) {
+  return (
+    <span
+      style={{
+        flex: 1,
+        height,
+        borderRadius: 999,
+        background: 'var(--cl-line-soft)',
+        overflow: 'hidden',
+      }}
+    >
+      <span
+        style={{
+          display: 'block',
+          // A part that exists but rounds to nothing still gets a sliver: the
+          // reader should see there IS a fresh-input segment, not infer it.
+          width: pct > 0 ? `max(2px, ${Math.min(100, pct)}%)` : 0,
+          height: '100%',
+          background: color,
+          transition: 'width 0.3s ease',
+        }}
+      />
+    </span>
+  );
+}
+
+/** One of the headline figures (USED / LEFT / TOTAL, BILLED / SAVED / …). */
+export function ReadoutCell({
+  label,
+  value,
+  color,
+}: {
+  label: string;
+  value: string;
+  color?: string;
+}) {
+  return (
+    <div style={{ flex: 1, minWidth: 0 }}>
+      <div
+        className="font-mono truncate"
+        style={{ fontSize: 8.5, letterSpacing: '0.16em', color: 'var(--cl-ink-4)' }}
+      >
+        {label}
+      </div>
+      <div
+        className="font-mono"
+        style={{
+          marginTop: 3,
+          fontSize: 13,
+          fontWeight: 600,
+          fontVariantNumeric: 'tabular-nums',
+          color: color ?? 'var(--cl-ink)',
+        }}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
+/** A composition row: what the headline number is made of. */
+export function ReadoutPart({
+  label,
+  value,
+  share,
+  color,
+}: {
+  label: string;
+  value: string;
+  share: number;
+  color: string;
+}) {
+  return (
+    <div className="font-mono flex items-center" style={{ gap: 9, marginTop: 6 }}>
+      <span style={{ width: 74, fontSize: 9.5, color: 'var(--cl-ink-3)' }}>{label}</span>
+      <span
+        style={{
+          width: 42,
+          textAlign: 'right',
+          fontSize: 10,
+          fontVariantNumeric: 'tabular-nums',
+          color: 'var(--cl-ink-2)',
+        }}
+      >
+        {value}
+      </span>
+      <ReadoutFill pct={share} color={color} />
+    </div>
+  );
+}
+
+export function ReadoutRule() {
+  return <div style={{ height: 1, background: 'var(--cl-line)', margin: '13px 0 3px' }} />;
+}

--- a/src/components/project/shared/readout.ts
+++ b/src/components/project/shared/readout.ts
@@ -1,0 +1,27 @@
+/**
+ * Non-component half of the readout card (see `ReadoutCard.tsx`) — kept in its
+ * own file for the `react-refresh/only-export-components` rule, which CI runs
+ * as an error.
+ */
+import type { CSSProperties } from 'react';
+
+/** Accent ramp for a part-of-whole. Same hue, three weights — mixing against
+ *  `--cl-paper` (not white) so the ramp flips correctly in the dark theme. */
+export const READOUT_RAMP = {
+  soft: 'color-mix(in oklch, var(--cl-accent) 32%, var(--cl-paper))',
+  mid: 'color-mix(in oklch, var(--cl-accent) 62%, var(--cl-paper))',
+  full: 'var(--cl-accent)',
+};
+
+/** The card's own surface. Callers add the positioning, which differs per host:
+ *  Mission Control pins it across the rail, the project band anchors it under
+ *  the figure it explains. */
+export const READOUT_SURFACE: CSSProperties = {
+  zIndex: 30,
+  pointerEvents: 'none',
+  padding: '13px 15px 15px',
+  borderRadius: 10,
+  background: 'var(--cl-paper)',
+  border: '1px solid var(--cl-line)',
+  boxShadow: '0 10px 30px rgba(0, 0, 0, 0.14)',
+};

--- a/src/components/project/terminal/VitalsPopover.tsx
+++ b/src/components/project/terminal/VitalsPopover.tsx
@@ -3,6 +3,14 @@ import type { SessionSummary } from '../../../types';
 import { fmtCost, fmtModel } from '../utils';
 import type { ContextState } from './context-window';
 import { kTok } from './mission-feed';
+import {
+  ReadoutShell,
+  ReadoutFill,
+  ReadoutCell,
+  ReadoutPart,
+  ReadoutRule,
+} from '../shared/ReadoutCard';
+import { READOUT_RAMP } from '../shared/readout';
 
 /**
  * The hover cards behind Mission Control's vitals line.
@@ -22,132 +30,22 @@ import { kTok } from './mission-feed';
 
 /** Accent ramp for a part-of-whole. Same hue, three weights — mixing against
  *  `--cl-paper` (not white) so the ramp flips correctly in the dark theme. */
-const RAMP = {
-  soft: 'color-mix(in oklch, var(--cl-accent) 32%, var(--cl-paper))',
-  mid: 'color-mix(in oklch, var(--cl-accent) 62%, var(--cl-paper))',
-  full: 'var(--cl-accent)',
-};
+const RAMP = READOUT_RAMP;
 
-const card: CSSProperties = {
-  position: 'absolute',
-  top: 'calc(100% + 8px)',
-  left: 20,
-  right: 20,
-  zIndex: 30,
-  pointerEvents: 'none',
-  padding: '13px 15px 15px',
-  borderRadius: 10,
-  background: 'var(--cl-paper)',
-  border: '1px solid var(--cl-line)',
-  boxShadow: '0 10px 30px rgba(0, 0, 0, 0.14)',
-};
+/** Mission Control pins the card across the rail; the surface itself is shared. */
+const card: CSSProperties = { position: 'absolute', top: 'calc(100% + 8px)', left: 20, right: 20 };
 
 function Shell({ title, meta, children }: { title: string; meta?: string; children: ReactNode }) {
   return (
-    <div role="tooltip" className="cl-vitals-pop" style={card}>
-      <div className="font-mono flex items-baseline" style={{ gap: 8 }}>
-        <span style={{ fontSize: 9, letterSpacing: '0.2em', color: 'var(--cl-ink-4)' }}>
-          {title}
-        </span>
-        <span style={{ flex: 1 }} />
-        {meta && (
-          <span style={{ fontSize: 9, letterSpacing: '0.06em', color: 'var(--cl-ink-4)' }}>
-            {meta}
-          </span>
-        )}
-      </div>
+    <ReadoutShell title={title} meta={meta} style={card}>
       {children}
-    </div>
+    </ReadoutShell>
   );
 }
-
-/** A flat fill rule — the same gauge idiom as the rail's 2px context line. */
-function Fill({ pct, color, height = 4 }: { pct: number; color: string; height?: number }) {
-  return (
-    <span
-      style={{
-        flex: 1,
-        height,
-        borderRadius: 999,
-        background: 'var(--cl-line-soft)',
-        overflow: 'hidden',
-      }}
-    >
-      <span
-        style={{
-          display: 'block',
-          // A part that exists but rounds to nothing still gets a sliver: the
-          // reader should see there IS a fresh-input segment, not infer it.
-          width: pct > 0 ? `max(2px, ${Math.min(100, pct)}%)` : 0,
-          height: '100%',
-          background: color,
-          transition: 'width 0.3s ease',
-        }}
-      />
-    </span>
-  );
-}
-
-/** One of the three headline figures (USED / LEFT / TOTAL, BILLED / SAVED / …). */
-function Cell({ label, value, color }: { label: string; value: string; color?: string }) {
-  return (
-    <div style={{ flex: 1, minWidth: 0 }}>
-      <div
-        className="font-mono truncate"
-        style={{ fontSize: 8.5, letterSpacing: '0.16em', color: 'var(--cl-ink-4)' }}
-      >
-        {label}
-      </div>
-      <div
-        className="font-mono"
-        style={{
-          marginTop: 3,
-          fontSize: 13,
-          fontWeight: 600,
-          fontVariantNumeric: 'tabular-nums',
-          color: color ?? 'var(--cl-ink)',
-        }}
-      >
-        {value}
-      </div>
-    </div>
-  );
-}
-
-/** A composition row: what the headline number is made of. */
-function Part({
-  label,
-  value,
-  share,
-  color,
-}: {
-  label: string;
-  value: string;
-  share: number;
-  color: string;
-}) {
-  return (
-    <div className="font-mono flex items-center" style={{ gap: 9, marginTop: 6 }}>
-      <span style={{ width: 74, fontSize: 9.5, color: 'var(--cl-ink-3)' }}>{label}</span>
-      <span
-        style={{
-          width: 42,
-          textAlign: 'right',
-          fontSize: 10,
-          fontVariantNumeric: 'tabular-nums',
-          color: 'var(--cl-ink-2)',
-        }}
-      >
-        {value}
-      </span>
-      <Fill pct={share} color={color} />
-    </div>
-  );
-}
-
-function Rule() {
-  return <div style={{ height: 1, background: 'var(--cl-line)', margin: '13px 0 3px' }} />;
-}
+const Fill = ReadoutFill;
+const Cell = ReadoutCell;
+const Part = ReadoutPart;
+const Rule = ReadoutRule;
 
 function Waiting({ text }: { text: string }) {
   return (

--- a/src/components/project/utils.ts
+++ b/src/components/project/utils.ts
@@ -80,7 +80,11 @@ export type ModelMixSlice = {
   label: string;
   tokens: number;
   sessions: number;
+  /** Exact share, for the bar's segment width. */
   pct: number;
+  /** Rounded share for the legend — whole numbers that sum to exactly 100,
+   *  with a share too small to round up printed as "<1" rather than "0". */
+  pctLabel: string;
 };
 
 export type ModelMixKey = 'opus' | 'sonnet' | 'haiku' | 'other';
@@ -100,23 +104,63 @@ export function modelMixKey(model?: string): ModelMixKey {
   return 'other';
 }
 
+// Whole-number shares that still add up to 100 (largest remainder): rounding
+// each slice on its own makes the legend read 99% or 101%, which is exactly the
+// kind of arithmetic a reader checks. A slice that exists but rounds to nothing
+// prints "<1" — "0%" next to a visible segment reads as a bug.
+function pctLabels(pcts: number[]): string[] {
+  const floors = pcts.map(p => Math.floor(p));
+  let left = 100 - floors.reduce((n, v) => n + v, 0);
+  const order = pcts
+    .map((p, i) => ({ i, rem: p - Math.floor(p) }))
+    .sort((a, b) => b.rem - a.rem || a.i - b.i);
+  for (const { i } of order) {
+    if (left <= 0) break;
+    floors[i] += 1;
+    left -= 1;
+  }
+  return floors.map((v, i) => (v === 0 && pcts[i] > 0 ? '<1' : String(v)));
+}
+
 export function buildModelMix(
-  sessions: { model?: string; totalTokens: number }[]
+  sessions: { model?: string; models?: Record<string, number>; totalTokens: number }[]
 ): ModelMixSlice[] {
   const acc = new Map<ModelMixKey, { tokens: number; sessions: number }>();
-  for (const s of sessions) {
-    const key = modelMixKey(s.model);
+  const add = (key: ModelMixKey, tokens: number) => {
     const cur = acc.get(key) ?? { tokens: 0, sessions: 0 };
-    cur.tokens += s.totalTokens;
+    cur.tokens += tokens;
     cur.sessions += 1;
     acc.set(key, cur);
+  };
+  for (const s of sessions) {
+    // `models` counts messages per model id, so a session that switched model
+    // mid-way (a `/model` call) splits its tokens across the families in
+    // proportion to the messages each produced. It is an approximation — the
+    // transcript does not bill tokens per family — but attributing every token
+    // to the dominant model, as this used to, is a worse one: it hides the
+    // switch entirely. `model` stays the fallback for sessions read before
+    // `models` existed.
+    const perModel = Object.entries(s.models ?? {}).filter(([, n]) => n > 0);
+    const totalMsgs = perModel.reduce((n, [, v]) => n + v, 0);
+    if (totalMsgs <= 0) {
+      add(modelMixKey(s.model), s.totalTokens);
+      continue;
+    }
+    const byFamily = new Map<ModelMixKey, number>();
+    for (const [id, count] of perModel) {
+      const key = modelMixKey(id);
+      byFamily.set(key, (byFamily.get(key) ?? 0) + count);
+    }
+    for (const [key, count] of byFamily) add(key, (s.totalTokens * count) / totalMsgs);
   }
   const total = [...acc.values()].reduce((n, v) => n + v.tokens, 0);
   if (total <= 0) return [];
-  return MODEL_MIX_ORDER.map(({ key, label }) => {
+  const slices = MODEL_MIX_ORDER.map(({ key, label }) => {
     const v = acc.get(key) ?? { tokens: 0, sessions: 0 };
     return { key, label, tokens: v.tokens, sessions: v.sessions, pct: (v.tokens / total) * 100 };
   }).filter(slice => slice.tokens > 0);
+  const labels = pctLabels(slices.map(s => s.pct));
+  return slices.map((s, i) => ({ ...s, tokens: Math.round(s.tokens), pctLabel: labels[i] }));
 }
 
 // Colore accent per famiglia modello.

--- a/src/index.css
+++ b/src/index.css
@@ -15149,9 +15149,11 @@ select.cl-opt-input {
 }
 .cl-hcell .lbl {
   font-family: var(--font-mono);
-  font-size: 9px;
+  /* 9px at .2em tracking was at the practical floor for a label that has to be
+     read, not just recognised; 10px at .14em costs the same width. */
+  font-size: 10px;
   line-height: 1;
-  letter-spacing: 0.2em;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--cl-ink-4);
   display: flex;
@@ -15179,16 +15181,15 @@ select.cl-opt-input {
   letter-spacing: 0;
   color: var(--cl-ink-4);
 }
+/* Neutral in both directions: green on "+3 sessions" encoded a verdict the
+   figure does not carry. The sign already says which way it went. */
 .cl-hcell .num .delta {
   font-family: var(--font-mono);
   font-size: 11px;
   font-weight: 400;
   letter-spacing: 0;
-  color: var(--cl-ok);
-  margin-left: 8px;
-}
-.cl-hcell .num .delta.down {
   color: var(--cl-ink-4);
+  margin-left: 8px;
 }
 .cl-hcell .sub {
   font-family: var(--font-mono);
@@ -15229,19 +15230,24 @@ select.cl-opt-input {
 .cl-mixbar .seg.other {
   background: var(--cl-ink-4);
 }
+/* One row, not a stack: the bar above already encodes the shares, so a legend
+   that wrapped to two lines was the same fact drawn twice at double height. */
 .cl-mixlegend {
   display: flex;
-  flex-wrap: wrap;
-  gap: 6px 16px;
+  flex-wrap: nowrap;
+  overflow: hidden;
+  gap: 14px;
   margin-top: 9px;
   font-family: var(--font-mono);
   font-size: 10px;
+  font-variant-numeric: tabular-nums;
   color: var(--cl-ink-4);
 }
 .cl-mixlegend span {
   display: inline-flex;
   align-items: center;
   gap: 6px;
+  white-space: nowrap;
 }
 .cl-mixlegend .dot {
   width: 6px;
@@ -15264,12 +15270,63 @@ select.cl-opt-input {
   border-right: none;
 }
 
+/* The cell whose figure opens a breakdown card: it anchors the card and says so
+   with a hint that only shows on approach. */
+.cl-hcell--hover {
+  position: relative;
+}
+.cl-hcell--hover .num {
+  outline: none;
+  cursor: default;
+  width: max-content;
+  border-bottom: 1px dotted var(--cl-line);
+}
+.cl-hcell--hover:hover .num,
+.cl-hcell--hover .num:focus-visible {
+  border-bottom-color: var(--cl-accent);
+}
+.cl-hpeek-hint {
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+.cl-hcell--hover:hover .cl-hpeek-hint,
+.cl-hcell--hover:focus-within .cl-hpeek-hint {
+  opacity: 1;
+}
+
 @media (max-width: 980px) {
   .cl-hcell {
     padding: 14px 18px 0;
   }
   .cl-hcell .cl-bars {
     display: none;
+  }
+}
+
+/* Below this the four cells cannot sit on one line. Free wrapping left the
+   cell that happened to end the first row carrying a vertical hairline against
+   the container edge, and the two rows touching with nothing between them — so
+   the band becomes an explicit 2×2 where every rule is placed on purpose. */
+@media (max-width: 760px) {
+  .cl-hband {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
+  .cl-hcell,
+  .cl-hcell--mix {
+    padding: 14px 18px;
+    border-right: 1px solid var(--cl-line);
+  }
+  .cl-hcell:nth-child(2n),
+  .cl-hband > .cl-hcell:last-child {
+    border-right: none;
+    padding-right: 0;
+  }
+  .cl-hcell:nth-child(2n + 1) {
+    padding-left: 0;
+  }
+  .cl-hcell:nth-child(n + 3) {
+    border-top: 1px solid var(--cl-line);
   }
 }
 

--- a/test/project-formatters.test.ts
+++ b/test/project-formatters.test.ts
@@ -138,7 +138,46 @@ describe('buildModelMix — project hero band', () => {
 
   it('files an unrecognised model id under "other" rather than guessing a family', () => {
     const mix = buildModelMix([s('some-future-model', 10)]);
-    expect(mix).toEqual([{ key: 'other', label: 'Other', tokens: 10, sessions: 1, pct: 100 }]);
+    expect(mix).toEqual([
+      { key: 'other', label: 'Other', tokens: 10, sessions: 1, pct: 100, pctLabel: '100' },
+    ]);
+  });
+
+  // A session that switched model mid-way used to be filed entirely under its
+  // dominant one, which hid the switch. `models` (messages per model id) splits
+  // its tokens across the families instead.
+  it('splits a session across the families it actually used', () => {
+    const mix = buildModelMix([
+      {
+        model: 'claude-opus-5',
+        models: { 'claude-opus-5': 3, 'claude-sonnet-4-6': 1 },
+        totalTokens: 400,
+      },
+    ]);
+    expect(mix.map(m => m.key)).toEqual(['opus', 'sonnet']);
+    expect(mix.find(m => m.key === 'opus')).toMatchObject({ tokens: 300, pct: 75 });
+    expect(mix.find(m => m.key === 'sonnet')).toMatchObject({ tokens: 100, pct: 25 });
+  });
+
+  it('falls back to the dominant model when no per-model counts were recorded', () => {
+    const mix = buildModelMix([{ model: 'claude-opus-5', models: {}, totalTokens: 100 }]);
+    expect(mix).toMatchObject([{ key: 'opus', tokens: 100 }]);
+  });
+
+  // The legend prints whole numbers, and a reader checks whether they add up.
+  it('rounds the legend so the shares sum to exactly 100', () => {
+    const mix = buildModelMix([
+      s('claude-opus-5', 1),
+      s('claude-sonnet-4-6', 1),
+      s('claude-haiku-4-5', 1),
+    ]);
+    expect(mix.reduce((n, m) => n + Number(m.pctLabel), 0)).toBe(100);
+  });
+
+  it('prints "<1" for a family too small to round up, never "0"', () => {
+    const mix = buildModelMix([s('claude-opus-5', 10_000), s('claude-haiku-4-5', 20)]);
+    expect(mix.find(m => m.key === 'haiku')?.pctLabel).toBe('<1');
+    expect(mix.find(m => m.key === 'opus')?.pctLabel).toBe('100');
   });
 });
 


### PR DESCRIPTION
The four figures under the project name are all scoped to the retention window, but only the first cell said so — and several of them were wrong on real data.

## Correctness

| | |
|---|---|
| Spend | `toFixed(2)` printed `est. $0.00` under a cent (the reading `fmtCost` exists to prevent) and no thousands separator above $1,000 |
| Sparkline tooltips | formatted with `it-IT` — italian month names in an english-only UI |
| First render | `nowMs` seeded from an effect, so one frame showed project-wide totals under a "/ 30d" label; lazy initialiser now |
| Buckets | the window divided by 12 made 30 days into 2.5-day buckets cut at noon, so adjacent bars printed the day they shared. Whole days aligned to local midnight now, via `setDate` so DST cannot move a boundary |
| Model mix | filed every token of a session under its dominant model, hiding mid-session `/model` switches; splits across families using `models` now |
| Legend | independent rounding summed to 99/101 and printed "0%" next to a visible segment; largest remainder + `<1` |

## Design — same four cells, less noise

- **Spend takes the cell Messages held.** It is the question an overview gets asked and it was the smallest line of the band; Messages survives as the qualifier it always was.
- **One sparkline instead of two** — sessions and tokens trace nearly the same curve.
- **The token figure opens a breakdown on hover/focus**: fresh in/out · cache read · cache write · cache savings. `totalTokens` sums cache reads at full weight although they bill at a tenth of input, so the headline mostly measures re-read context — the composition is what makes it honest, at no cost to the band. Portalled to `<body>` because `.cl-hero` clips its children, and it closes on scroll/resize so it cannot drift from its figure.
- **One definition of that anatomy**: `VitalsPopover`'s atoms move to `shared/ReadoutCard.tsx`, and Mission Control renders from them too.
- Window on every label · single-row legend with tabular figures · delta that names its baseline and stops being green · labels at 10px/.14em · explicit 2×2 grid below 760px (free wrapping left a hairline against the container edge with nothing between the rows).

## Verification

`typecheck` (all three projects) · `lint --max-warnings 0` · `format:check` · 926 tests, with 5 new cases over `buildModelMix` (per-model split, fallback, sum-to-100, `<1`). Visual check of the band and the hover card is manual, as always.
