### PR TITLE
refactor(monitor): a band for what blocks you, a hairline grid for the rest

### DIFF
--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -37,7 +37,7 @@ This directory contains the Electron renderer process: a single-page React app t
 - `project/skills/` — `GlobalSkillsView`, `SkillDetailView`, `CreateSkillPage`
 - `project/agents/` — `GlobalAgentsView`, `AgentDetailView`, `RunAgentDialog`, `CreateAgentPage`
 - `project/agents-live/` — `AgentsLiveView` (background/live agent sessions)
-- `project/monitor/` — `MonitorView` (global "what is running right now": one board, one lane per live process, one shared time axis)
+- `project/monitor/` — `MonitorView` (global "what is running right now": a full-bleed band per blocked process, a hairline grid for everything else)
 - `project/mcp/` — `GlobalMcpView`, `McpServerCard`, `McpServerDetailView`
 - `project/analytics/` — `AnalyticsView`
 - `project/ai-assistant/` — `AiAssistantView`

--- a/src/components/project/CLAUDE.md
+++ b/src/components/project/CLAUDE.md
@@ -324,73 +324,87 @@ tutto ciò che hai dispatchato — per la maggior parte finito o addormentato �
 controlli per agirci; il Monitor legge il **registro dei processi**
 (`~/.claude/sessions/<pid>.json`) più il **tail dei transcript**. Un background
 agent **vivo** compare anche qui (è un processo claude che consuma token), ma come
-card che **instrada** ad Agent View: dispatch/stop/respawn restano in un posto
+cella che **instrada** ad Agent View: dispatch/stop/respawn restano in un posto
 solo — il Monitor osserva.
 
-| File              | Esporta                                  | Descrizione                                                                                                                                                                                                                                                                                                                                                                                                          |
-| ----------------- | ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `MonitorView.tsx` | `MonitorView`                            | Una index card per processo. Join di due hook per `sessionId`: `useActiveSessions` (il registro: busy/waiting + `waitingFor`) e `useSessionActivity` (il digest del tail: azione corrente, nastro, contesto, spesa, conteggi)                                                                                                                                                                                        |
-| `trace.ts`        | `buildTape`, `TAPE_SPAN_MS`, `TAPE_ROWS` | Modulo puro del nastro: dai `TraceMark` ricava le ultime azioni dalla più recente, collassa i ripetuti esatti in `×N`, scarta la prosa e sa saltare la chiamata in volo. **Non tronca**: restituisce tutta la finestra, perché è lo slot della card (`TAPE_ROWS = 3`) a decidere quante righe stampa e gli serve il conto intero per dire quante ne lascia fuori (`+3`). Unit-tested in `test/monitor-view.test.tsx` |
+| File              | Esporta                                                          | Descrizione                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| ----------------- | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MonitorView.tsx` | `MonitorView`                                                    | Due livelli: una **band a tutta larghezza** per ogni processo bloccato, una **griglia a hairline** (`.cl-mxcell`) per tutti gli altri. Join di due hook per `sessionId`: `useActiveSessions` (il registro: busy/waiting + `waitingFor`) e `useSessionActivity` (il digest del tail: azione corrente, nastro, contesto, spesa, conteggi)                                                                                                                                          |
+| `trace.ts`        | `buildRibbon`, `RIBBON_SPAN_MS`, `RIBBON_CELLS`, `RIBBON_WINDOW` | Modulo puro del **ribbon**: dai `TraceMark` ricava le corse di blocchi tinti per tool su un asse di 2,5 minuti. La finestra è tagliata in `RIBBON_CELLS` celle, ogni mark cade nella cella del suo `at` e le celle contigue dello stesso tool collassano in **un** blocco (un retry loop = un blocco lungo). Scarta la prosa (niente tool → niente tinta), scarta i mark fuori finestra invece di clamparli (incluso lo skew di clock) e non disegna mai un blocco sotto lo 0,9% |
 
-**Tre forme, e le prime due sono l'argomento per la terza.** Sono state bocciate
-una griglia di card **scure** e poi una **lavagna** scura di corsie a tutta
-larghezza, per la stessa ragione strutturale: una superficie scura larga che
-regge cinque stringhe corte è vuota per costruzione, e sulla carta calda di
+**Cinque forme, e le prime quattro sono l'argomento per la quinta.** Sono state
+bocciate una griglia di card **scure** e poi una **lavagna** scura di corsie a
+tutta larghezza, per la stessa ragione strutturale: una superficie scura larga
+che regge cinque stringhe corte è vuota per costruzione, e sulla carta calda di
 questa app una lastra nera legge anche come corpo estraneo. Niente in un processo
 lo rende un terminale — quell'analogia era presa in prestito ed è costata due
-iterazioni. Ora la card è la **index card della memoria** (`.cl-mcard`), su carta,
-nella lingua dell'app.
+iterazioni. La terza forma è stata la **index card della memoria** (`.cl-mcard`)
+su carta; la quarta ne ha reso **fissa l'anatomia** (stessa altezza per tutte, il
+rack finalmente con una linea di base).
 
-**Quarta forma: l'anatomia della card è FISSA.** Lasciare che il corpo fosse il
-nastro dava a ogni card un'altezza diversa — una sessione che aveva lanciato sei
-tool stava un terzo più alta di una che non ne aveva lanciato nessuno — e un rack
-così non ha una linea di base da leggere in orizzontale: il bordo inferiore
-frastagliato era la prima cosa che l'occhio doveva decifrare, e le stesse
-grandezze (orologio, gauge, conto) cadevano ad altezze diverse su card vicine.
-Ora ogni card è **gli stessi cinque blocchi alla stessa altezza** (`height: 260px`,
-`grid-template-rows: auto auto auto 1fr auto`): stato+orologio, identità, riga
-NOW, slot da tre righe, vitals. Varia **cosa** ci sta stampato, mai **dove**.
-Costo dichiarato: qualche millimetro rigato su una card tranquilla. In cambio si
-può scandire la pagina per colonne.
+**Quinta forma — design handoff _Monitor Variants_, opzione 2b: il livello lo dà
+la costruzione, non il bordo.** La card uniforme aveva risolto il rack ma
+affermava anche che una sessione che **aspetta te** e una che sta editando un
+file sono la stessa taglia di notizia — cioè l'unica cosa che questa pagina
+esiste per negare, e per questo la card bloccata aveva bisogno di un bordo accent
+da 1.5px per farsi leggere per prima. Ora:
 
-**Il nastro dice cosa la sessione ha fatto davvero.** I `TraceMark` portano il
-nome del tool **e il suo argomento** (`toolArg`, lo stesso che il digest già
-calcolava per `lastTool`): `Edit MonitorView.tsx`, `Bash npm run typecheck ✕`.
-Decisioni:
+- **chi è bloccato è una band scura a tutta larghezza** (`.cl-mxband`, `oklch(0.205
+0.008 75)` **fissa in entrambi i temi**, come la cella live della stat strip):
+  eyebrow accent pulsante `Needs you · quiet 4m`, **la domanda in display**
+  (clamp 19→27px), identità demolita a una riga mono (`progetto · titolo · pid ·
+modello · uptime`), e a destra l'**orologio accent** (fino a 52px) sotto
+  `BLOCKED FOR` con il bottone d'uscita. È la terza volta che si prova una
+  superficie scura ed è la prima che funziona, perché le due che hanno fallito
+  l'avevano resa il **default**: qui è l'eccezione, corre da bordo a bordo, e a
+  riempirla c'è l'unica stringa della pagina abbastanza lunga da meritare il
+  display — la domanda su cui la sessione è ferma. È anche l'unica cosa che pulsa;
+- **tutto il resto è una griglia a hairline senza alcun bordo di card**
+  (`.cl-mx-grid` a 3 colonne fisse → 2 → 1; `.cl-mxcell` senza raggio né
+  superficie, definita solo dai filetti verso i vicini). Colonne **fisse** e non
+  `auto-fill` perché la prima e l'ultima portano il **gutter di pagina**: con
+  `auto-fill` non c'è modo di dire "la cella al bordo" e la griglia partirebbe 32px
+  dentro rispetto a una testata che parte dal gutter. Il filetto è `border-bottom`
+  e non `border-top` — la testata si chiude già con la sua riga d'inchiostro da
+  1.5px, e un hairline subito sotto la farebbe leggere sfrangiata; rigare verso il
+  basso chiude anche l'ultima riga.
 
-- **NOW ha un blocco suo** (`.cl-mx-now`, inset su `paper-2`), non è più la prima
-  riga della lista. Quello che un processo sta facendo adesso e quello che ha
-  fatto sono due affermazioni di specie diversa, e stamparle come una lista sola
-  faceva leggere la riga più nuova come storia capitata in cima.
-  `buildTape(..., {dropNewest})` **scarta il mark più nuovo** quando la card sta
-  già stampando quella chiamata come riga NOW: senza, la stessa azione comparirebbe
-  due volte.
-- **Lo slot è tre righe, sempre** (`.cl-mx-slot`). Le righe senza niente da dire
-  restano **rigate** (tratteggio) invece di essere omesse: è ciò che rende ogni
-  card della stessa altezza, ed è anche ciò che una riga vuota dice sulla carta a
-  righe — non "qui è finito", ma "qui non è ancora stato scritto". Chi ha fatto
-  di più non cresce: lo dice con `+8` sull'ultima riga. Tre righe di undici azioni
-  stampate in silenzio si leggerebbero come una sessione tranquilla.
-- **`no transcript to tail` occupa una riga dello slot** (un background agent),
+**Il bottone della band dice cosa fa.** Il mock lo etichetta `Reply in terminal
+↗`: sarebbe una bugia, perché il prompt aspetta nella shell dell'utente e niente
+in questa app può rispondergli. Il bottone apre la sessione (`Open session ↗`) o
+instrada ad Agent View per un background agent — la stessa destinazione del click
+sulla cella.
+
+**Il nastro testuale è stato sostituito dal ribbon.** La tape a tre righe diceva
+cosa la sessione aveva fatto **a parole** (`Edit MonitorView.tsx`, `Bash npm run
+typecheck ✕`) e costava alla card quattro righe fisse: sono i 260px d'altezza che
+obbligavano il rack a colonne da 340px. 2b spende quell'altezza sulla band e dà a
+tutto il resto tre colonne, quindi la storia si comprime in una **corsia**
+(`.cl-mx-ribbon`). Decisioni:
+
+- **NOW resta a parole** (`.cl-mx-now`, inset su `paper-2`): è l'unica
+  affermazione che il ribbon non può fare — ha forma, non nomi — e resta l'unico
+  posto della cella dove un tool è scritto per esteso.
+- **La corsia è letta da timestamp veri**, non da una stringa rasterizzata:
+  posizione = quando, larghezza = quanto è durata quella corsa di lavoro. Un
+  **estremo destro vuoto** è una sessione che non fa niente da quel tanto — la
+  domanda "è piantata?" che le tre righe dicevano a parole, detta in forma.
+- **La tinta è `TOOL_TINT`**, la codifica dei tool che il transcript già usa: una
+  corsia ciano è una sessione che legge, viola una che edita.
+- **Una chiamata fallita prende la tinta `danger` invece di quella del suo tool**:
+  la tinta risponde a "che tipo di lavoro", e un errore batte quella domanda.
+- **La hairline sotto la corsia è ciò che la rende una corsia**: senza, una
+  sessione con due chiamate in due minuti non ha niente contro cui essere rada, e
+  il vuoto a destra legge come pagina bianca invece che come silenzio.
+- **`no transcript to tail` prende il posto della corsia** (background agent),
   perché "non c'è transcript" non è la stessa affermazione di "non ha fatto
-  niente" e solo una delle due si risolve aspettando.
-- **Un ripetuto esatto (stesso tool, stesso argomento) collassa in `×N`** e la
-  riga è datata dalla sua chiamata **più vecchia**: un retry loop è una cosa che
-  succede tre volte, non tre lavori diversi, e la riga deve dire da quando va
-  avanti. Due Edit di due file diversi restano due righe.
-- **La prosa marca la traccia ma non entra nel nastro**: un mark `text` fra due
-  Edit spezzerebbe la sequenza a metà senza aggiungere niente su cui agire.
-- **La colonna dei pallini è la texture della card.** La tinta è `TOOL_TINT` — la
-  codifica dei tool che il transcript già usa, riusata verbatim ora che siamo su
-  carta — su uno swatch da 5px e **non** sul nome del tool: colorare testo che
-  devi leggere è peggio che colorare un marcatore di fianco, e i pallini in
-  colonna danno a ogni card la firma del tipo di lavoro (una fila di ciano è una
-  sessione che legge, viola una che edita).
-- **La pulse strip è sparita con la lavagna.** Quello a cui rispondeva — "è
-  piantata?" — il nastro lo dice a parole: una riga in cima che segna `4m` è una
-  sessione che non fa niente da quattro minuti. Lo stato del registro ("busy") non
-  ha mai risposto da solo, perché una sessione a metà di un tool e una piantata
-  sono identiche da lì.
+  niente" e solo una delle due si risolve aspettando. Una corsia **vuota** dice
+  invece l'altra cosa (`nothing in the last 2.5 min`).
+- **La prosa non entra nel ribbon**: un mark `text` non ha tool, quindi non ha
+  tinta, e un blocco grigio fra due Edit leggerebbe come un tool senza nome.
+- Il costo dichiarato: **la storia a parole non c'è più**. Il design stesso la
+  offre come passo successivo ("aggiungi il tape di 1e nelle card"), e riportarla
+  è aggiungere un blocco alla cella, non rifare la pagina.
 
 **I vitals: le due cose azionabili solo mentre gira.** Il tail leggeva ogni riga
 assistant e **scartava `usage`**. Ora il digest porta:
@@ -399,72 +413,72 @@ assistant e **scartava `usage`**. Ora il digest porta:
   recente. È un **livello**, non un totale (ogni lettura sostituisce la
   precedente; sommare i prompt fra turni riporterebbe una finestra parecchie
   volte più piena, dato che il prompt di ogni turno contiene già quello prima). È
-  l'unica misura della card con un **denominatore vero**, quindi l'unica disegnata
-  come gauge — una barra contro un tetto inventato sarebbe decorazione travestita
-  da misura. Tre bande perché la domanda non è "quanto piena" ma "quanto
-  preoccupato": neutra sotto il 75%, `warn` fino al 90%, `danger` sopra — una
-  sessione al 94% sta per compattare e perdere fedeltà, ed è l'unica cosa in
-  pagina che puoi ancora prevenire adesso.
+  l'unica misura con un **denominatore vero**, quindi l'unica disegnata come gauge
+  — una barra contro un tetto inventato sarebbe decorazione travestita da misura.
+  Tre bande perché la domanda non è "quanto piena" ma "quanto preoccupato":
+  neutra sotto il 75%, `warn` fino al 90%, `danger` sopra — una sessione al 94%
+  sta per compattare e perdere fedeltà, ed è l'unica cosa in pagina che puoi
+  ancora prevenire adesso.
 - **SPEND** — dollari. Nessun tetto, quindi cifra e non barra. `~` davanti quando
   il modello non ha una voce esatta nella tabella prezzi (`spendEstimated`). La
   spesa è **seedata** una volta lato main da un parse completo (cached) del
   transcript, perché il cursore parte da EOF: senza seed una sessione già in corso
   avrebbe riportato il costo degli ultimi turni come totale, e una cifra in denaro
   silenziosamente parziale è peggio di nessuna cifra. Seed fallito → `spend: null`
-  → la card non stampa niente.
-- **Il conteggio dei token non è sulla card**: i dollari rispondono alla domanda
+  → non si stampa niente.
+- **Il conteggio dei token non è sulla cella**: i dollari rispondono alla domanda
   che uno si fa davvero, e i token sono lo stesso fatto in un'unità in cui nessuno
-  fa budget — su una card densa era una seconda cifra in competizione con quella
-  che significa qualcosa. Resta nel digest.
-- Un **background agent non ha vitals né nastro**: il roster non porta né usage né
+  fa budget. Sopravvive **una volta sola**, come totale di macchina in testata
+  (`.cl-mxtop-tot`, `$4.50 · 1.2m tokens`), dove smette di essere una seconda copia
+  del conto e diventa l'unica lettura di scala della pagina. Entrambe le metà
+  spariscono se nessuno le ha riportate — `$0.00 · 0 tokens` accanto a processi
+  vivi sarebbe l'unica cifra sbagliata a schermo.
+- **La band porta ribbon e vitals anche se il mock non li dà alla sua band**: la
+  sessione che stai per sbloccare è proprio quella in cui "quanto è piena la
+  finestra" e "quanto è costata" cambiano cosa fai, e la corsia piatta a destra è
+  la figura di ciò che `blocked for` dice in cifre.
+- Un **background agent non ha vitals né corsia**: il roster non porta né usage né
   conto, e il transcript sidecar che scrive non è di questa pagina. Assenti, non
-  zero — `$0.00` accanto a un worker che brucia token sarebbe l'unica cifra
-  sbagliata della pagina.
+  zero.
 
 **Al posto dell'hero, un header da console.** `Monitor.` a
 `clamp(64px, 9vw, 132px)` erano ~300px verticali sull'unica pagina il cui
 soggetto sono i prossimi minuti — e chi è lì ha appena cliccato "Monitor". Al suo
 posto (`.cl-mxtop`) un eyebrow + **una frase che cambia**: `1 waiting on you, 2
 working`, con le cifre in inchiostro pieno e la clausola che **chiede qualcosa**
-in testa e in accento. Prosa con numeri dentro, non una fascia di stat tile:
-quella fascia è già stata rimossa una volta da questa pagina perché stampava gli
-stessi numeri che le card portano.
+in testa e in accento, e all'angolo opposto il totale di macchina. Prosa con
+numeri dentro, non una fascia di stat tile: quella fascia è già stata rimossa una
+volta da questa pagina perché stampava gli stessi numeri che le celle portano.
 
-L'anatomia della card, dall'alto: **tag di stato + orologio**, poi **identità**
-(progetto in display, titolo della conversazione, riga macchina), poi il
-**nastro**, poi i **vitals** divisi da hairline.
+L'anatomia della cella, dall'alto: **identità + orologio** (tag di stato,
+progetto in display, titolo della conversazione, riga macchina | orologio a
+26px), poi la riga **NOW**, poi il **ribbon**, poi i **vitals** divisi da
+hairline e ancorati in fondo (`align-self: end`, così i gauge di due vicini
+restano sulla stessa linea di pagina).
 
 Altre decisioni:
 
-- **L'audacia si spende in un posto solo**: solo la card che ti aspetta ha il
-  bordo pesante (1.5px accent + il wash che le index card della memoria usano per
-  la prima tile) ed è l'unica che pulsa. Tutto il resto sono hairline. Una
-  sessione che lavora sta lavorando, è il caso normale.
-- **La griglia è una griglia vera**: card di altezza fissa, quindi niente
-  `align-items: start` (serviva solo a non stirare le card corte, che è un altro
-  modo di dire che il rack non aveva una linea di base). Lo slot prende l'`1fr`,
-  così l'eventuale gioco — una riga di vitals andata a capo su una card stretta —
-  viene assorbito **sotto** le righe rigate: testa, identità e vitals restano
-  dove sono su ogni card. `overflow: hidden` è la garanzia, non il layout.
+- **La riga macchina resta sulla cella** anche se il design la tiene per la sola
+  band: il pid è ciò che serve per fare `kill`, e un fatto che esiste solo nello
+  stato in cui stai già agendo è un fatto che non puoi usare.
 - **Il gauge del contesto ha perso l'etichetta `ctx`**: una barra con una
-  percentuale accanto dice già cos'è, e su una card più stretta quei tre caratteri
-  servivano alle cifre che l'unità la devono dichiarare. Resta nel caso `is-none`,
-  dove un trattino da solo non nominerebbe niente.
+  percentuale accanto dice già cos'è. Resta nel caso `is-none`, dove un trattino
+  da solo non nominerebbe niente.
 - **Il pid ha un campo suo** nella riga macchina (`pid · modello · up 2h07 ·
 ./sottocartella`): come suffisso dell'ident era rumore e un titolo lungo se lo
-  mangiava dalla coda con l'ellissi, ma è ciò che serve per fare `kill`.
-  Conseguenza: il fallback quando Claude non ha ancora nominato la sessione **non
-  è più il pid** (l'avrebbe detto due volte) ma `not named yet`. Il sottopath si
-  stampa **solo se aggiunge qualcosa** (`cwdNote`).
+  mangiava dalla coda con l'ellissi. Conseguenza: il fallback quando Claude non ha
+  ancora nominato la sessione **non è più il pid** (l'avrebbe detto due volte) ma
+  `not named yet`. Il sottopath si stampa **solo se aggiunge qualcosa**
+  (`cwdNote`).
 - **L'orologio conta dalla transizione di stato** (`statusUpdatedAt`), con
   semantica unica in ogni stato: **da quanto è in questo stato**. Contava
   dall'ultimo append e si azzerava a ogni tool, quindi non rispondeva mai a
-  "questo turno sta durando troppo?". Una card `ended` aggiunge `ago`.
+  "questo turno sta durando troppo?". Una cella `ended` aggiunge `ago`.
 - **Un sub-agente in volo è nominato, e vale come lavoro.** Il tool `Agent` è
   **asincrono** — ack immediato, poi `stop_reason: end_turn` — e il lavoro
   dell'agente vive in un transcript sidecar che il tail salta. Misurato dal vivo
   su 2.1.233: **148 s** senza un append nel transcript principale mentre il
-  sidecar accumulava **31 tool call**. La card diceva `READY · waiting for your
+  sidecar accumulava **31 tool call**. La cella diceva `READY · waiting for your
 next prompt`. Ora il digest porta `delegates`, la riga NOW stampa il **nome
   dell'agente** (`subagent_type`) e i vitals la sua età (`2m in flight`) al posto
   del silenzio. **Niente conteggio dei suoi tool** — e per la stessa ragione
@@ -480,19 +494,22 @@ next prompt`. Ora il digest porta `delegates`, la riga NOW stampa il **nome
   `name` del registry (`claudelens-b4`) è il progetto più due caratteri casuali.
   Il titolo viene da `{"type":"ai-title"}` nel transcript, letto una volta dalla
   **testa** del file (`readSessionTitle`) perché il cursore parte da EOF.
-- **Ordine**: prima chi ti aspetta, poi chi lavora, poi chi ha finito; a parità di
+- **Ordine**: la band viene prima della griglia per costruzione; dentro la
+  griglia, prima chi lavora, poi chi è pronto, poi chi ha finito, e a parità di
   stato guida chi è in quello stato da più tempo.
 - **Le sessioni finite restano** 10 minuti (`endedAt`), coi loro vitali finali:
   quanto è costata e quanto si era riempita restano la verità su di lei.
 - Il silenzio sotto i 10s non si stampa (`QUIET_FLOOR_MS`): è l'intervallo fra due
-  tool call, non un segnale.
+  tool call, non un segnale. Per una sessione bloccata è detto **nell'eyebrow
+  della band**, non nei vitals: quanto tempo è ferma sulla tua risposta non è una
+  nota a piè di pagina in grigio da 10px.
 - Il ticker da 1s gira **solo se c'è qualcosa da contare** (`cards.length > 0`).
 
 Coperta da `test/monitor-view.test.tsx` (join, stato, ordinamento, ritenzione,
-routing degli agent, riga macchina, sottopath, nastro e non-duplicazione della
-riga NOW, **slot a tre righe qualunque cosa la sessione abbia fatto** e `+N` per
-quelle non stampate, bande del gauge di contesto, spesa e stima, frase
-dell'header, teardown, modello del nastro).
+routing degli agent — band inclusa —, riga macchina, sottopath, ribbon e sua
+separazione dalla riga NOW, corsia vuota vs assente, totale di macchina in
+testata, bande del gauge di contesto, spesa e stima, frase dell'header,
+teardown, modello del ribbon).
 
 ---
 

--- a/src/components/project/monitor/MonitorView.tsx
+++ b/src/components/project/monitor/MonitorView.tsx
@@ -7,26 +7,26 @@ import {
 } from '../../../hooks/useIPC';
 import type { ActiveSession, SessionActivity, BgSession, TraceMark } from '../../../types';
 import { TopBar } from '../shared/TopBar';
-import { fmt, fmtCost, fmtModel } from '../utils';
+import { fmt, fmtCost, fmtModel, formatTokens } from '../utils';
 import { projectDisplayName } from '../shared/projectName';
 import { TOOL_TINT } from '../chat/utils';
-import { buildTape, TAPE_ROWS, TAPE_SPAN_MS } from './trace';
+import { buildRibbon, RIBBON_WINDOW } from './trace';
 
-// The Monitor: every Claude process running on this machine, as one index card
-// per process.
+// The Monitor: every Claude process running on this machine — what is blocked on
+// you as a band, everything else as one cell of a hairline grid.
 //
 // Deliberately NOT a second Agent View. That page is a ROSTER — everything you
 // dispatched, most of it finished or asleep, with the controls to act on it.
 // This one is machine state: what has a pid right now, across every project. A
 // background agent that is actually running shows up here too (it is a claude
-// process burning tokens), but as a card that ROUTES to Agent View — the
+// process burning tokens), but as a cell that ROUTES to Agent View — the
 // dispatch/stop/respawn controls stay in one place.
 //
 // Two sources, joined by sessionId: the registry says a session is busy or
 // waiting (`useActiveSessions`), the transcript tail says at what
 // (`useSessionActivity`). Neither is derived from the other.
 //
-// ── Why a card, and why its body is a tape ───────────────────────────────────
+// ── Why a band and a grid, and not a rack of cards ───────────────────────────
 // Two earlier forms were rejected as bare: a grid of dark cards, then a dark
 // board of full-width lanes. Both failed for the same structural reason — a wide
 // dark surface holding five short strings is mostly empty by construction, and
@@ -34,17 +34,25 @@ import { buildTape, TAPE_ROWS, TAPE_SPAN_MS } from './trace';
 // about a process makes it a terminal; that analogy was borrowed, and it cost
 // the page twice.
 //
-// So the card is the app's own index card, and its body is the TAPE: what the
-// session actually did, newest first, each action with the subject it acted on
-// (`Edit MonitorView.tsx`, `Bash npm run typecheck ✕`). A card whose body is
-// real text cannot look empty.
+// The third form put every process on an identical index card. It fixed the
+// ragged rack, but it also said that a session waiting on YOU and a session
+// quietly editing a file are the same size of news — which is the one thing this
+// page exists to deny. So the fourth form (design handoff *Monitor Variants*,
+// option 2b) tiers by state instead of by uniformity:
 //
-// The pulse strip went with the board. What it answered — "is this hung?" — the
-// tape answers in words: a top row that says `4m` is a session that has done
-// nothing for four minutes. A session's STATE ("busy") never answered that on
-// its own, because a session mid-tool and a session hung are identical from the
-// registry; what separates them is when it last did something, which is now
-// printed rather than drawn.
+//   - whatever is BLOCKED becomes a full-bleed dark band, edge to edge, with the
+//     question it is waiting on set at display size and the clock counting how
+//     long you have been the bottleneck. It is the only dark surface on the page
+//     and the only one that pulses;
+//   - everything else is a hairline grid with NO card borders at all: three
+//     columns divided by rules, the same anatomy in each cell, nothing raised.
+//
+// The construction carries the triage, so no cell has to shout to be read in
+// order. What a session is doing right now stays in words (the NOW line); what
+// it did compresses into the RIBBON — runs of tool-tinted blocks on a 2.5-minute
+// axis (`trace.ts`). A lane whose right-hand end is empty is a session that has
+// done nothing for that long, which is the "is this hung?" question the three
+// printed rows used to answer in prose and the strip answers in shape.
 
 type Project = { hash: string; realPath: string };
 
@@ -80,8 +88,8 @@ interface Card {
   /** Set while a sub-agent is running: it explains the silence, so it takes the
    *  slot `quiet` would have had. */
   delegateSince: number | null;
-  /** How full the window is. The one measure on the card with a real
-   *  denominator, and therefore the only one drawn as a gauge. */
+  /** How full the window is. The one measure here with a real denominator, and
+   *  therefore the only one drawn as a gauge. */
   context: { used: number; max: number } | null;
   /** Dollars, and whether the price had to be estimated. */
   spend: number | null;
@@ -89,9 +97,9 @@ interface Card {
   tokens: number;
   trace: TraceMark[];
   /** A background agent has no transcript of its own to tail, so it has no
-   *  tape. Saying so beats printing an empty body. */
+   *  ribbon. Saying so beats drawing an empty lane. */
   noTrace: boolean;
-  /** Printed where the silence figure goes, for a card that only routes. */
+  /** Printed where the silence figure goes, for a cell that only routes. */
   routeNote: string | null;
   onOpen: (() => void) | null;
 }
@@ -108,14 +116,11 @@ const STATE_LABEL: Record<State, string> = {
  *  `quiet 2s` about a session hammering the filesystem is noise. */
 const QUIET_FLOOR_MS = 10_000;
 
-/** The tape's window, in the unit the tooltip says it in. */
-const TAPE_MINUTES = Math.round(TAPE_SPAN_MS / 60_000);
-
 const ESTIMATE_NOTE =
   'Approximate: this model has no exact entry in the pricing table, so it is priced by family.';
 
 /** The dot that opens a tape row. It carries `TOOL_TINT` — the transcript's own
- *  tool encoding, reused verbatim now that the card is on paper and needs no
+ *  tool encoding, reused verbatim now that the page is on paper and needs no
  *  dark-lift variants. The colour sits on a 5px swatch rather than on the tool's
  *  name: colouring text you have to read is worse than colouring a marker beside
  *  it, and the swatches line up into a column that gives each card the signature
@@ -141,11 +146,11 @@ function contextLoad(context: { used: number; max: number }): 'ok' | 'high' | 'c
   return pct >= 75 ? 'high' : 'ok';
 }
 
-/** Note: the token tally is deliberately NOT on the card. The dollars answer the
+/** Note: the token tally is deliberately NOT on a cell. The dollars answer the
  *  question a person actually has ("what is this costing me"), and the token
- *  count is the same fact in a unit nobody budgets in — on a card this dense it
- *  was a second figure competing with the one that means something. It stays in
- *  the digest for whoever needs it. */
+ *  count is the same fact in a unit nobody budgets in — in a cell this dense it
+ *  was a second figure competing with the one that means something. It survives
+ *  once, as a machine-wide total in the header, where it is a different claim. */
 
 function clock(ms: number | null): string {
   if (ms === null || ms < 0) return '—';
@@ -533,12 +538,18 @@ export function MonitorView({
     );
   }, [sessions, activity, agents, projects, onOpenSession, onOpenAgents]);
 
-  const blocked = cards.filter(c => c.state === 'blocked').length;
+  // The two tiers of the page. Blocked is not "the first card": it is a
+  // different surface, so the split happens here rather than inside a loop.
+  const bands = cards.filter(c => c.state === 'blocked');
+  const cells = cards.filter(c => c.state !== 'blocked');
+
+  const blocked = bands.length;
   const working = cards.filter(c => c.state === 'working').length;
   const ready = cards.filter(c => c.state === 'ready').length;
   const ended = cards.filter(c => c.state === 'ended').length;
   const live = blocked + working + ready;
   const now = useTick(cards.length > 0);
+  const totals = machineTotals(cards);
 
   return (
     <div
@@ -553,11 +564,19 @@ export function MonitorView({
             is the next 90 seconds, and the reader already knows where they are.
             What earns that space is the census, which changes. */}
         <header className="cl-mxtop">
-          <div className="cl-eyebrow">
-            <span className={`pip${live > 0 ? ' live' : ''}`} />
-            <span>Monitor · this machine</span>
+          <div className="cl-mxtop-say-wrap">
+            <div className="cl-eyebrow">
+              <span className={`pip${live > 0 ? ' live' : ''}`} />
+              <span>Monitor · this machine</span>
+            </div>
+            <p className="cl-mxtop-say">{census(blocked, working, ready, ended)}</p>
           </div>
-          <p className="cl-mxtop-say">{census(blocked, working, ready, ended)}</p>
+          {/* The one figure the cells do not carry: what the whole machine is
+              burning. A per-cell token count was dropped as a unit nobody
+              budgets in, but summed over every live process it stops being a
+              second copy of the bill and becomes the only reading of scale on
+              the page. */}
+          {totals && <span className="cl-mxtop-tot">{totals}</span>}
         </header>
 
         {isLoading ? (
@@ -572,73 +591,211 @@ export function MonitorView({
             </div>
           </section>
         ) : (
-          <section className="cl-section">
-            <div className="cl-mx-grid">
-              {cards.map(card => (
-                <ProcessCard key={card.key} card={card} now={now} />
-              ))}
-            </div>
-          </section>
+          <>
+            {bands.map(card => (
+              <BlockedBand key={card.key} card={card} now={now} />
+            ))}
+            {cells.length > 0 && (
+              <div className="cl-mx-grid">
+                {cells.map(card => (
+                  <ProcessCell key={card.key} card={card} now={now} />
+                ))}
+              </div>
+            )}
+          </>
         )}
       </div>
     </div>
   );
 }
 
+/** What the silence since the last action means. A running sub-agent takes the
+ *  slot: it is the explanation, and the one thing the tail cannot see for
+ *  itself. Below the floor nothing is said — a gap of two seconds between two
+ *  tool calls is not a signal. */
+function quietNote(card: Card, now: number): string {
+  if (card.routeNote) return card.routeNote;
+  if (card.delegateSince !== null) return `${span(now - card.delegateSince)} in flight`;
+  if (card.lastAppendAt !== null && now - card.lastAppendAt >= QUIET_FLOOR_MS) {
+    return `quiet ${span(now - card.lastAppendAt)}`;
+  }
+  return '';
+}
+
+/** The header's right-hand figure: what every live process on this machine has
+ *  cost and burned, together. Both halves are omitted when nothing has reported
+ *  them — a `$0.00 · 0 tokens` beside a rack of running sessions would be the
+ *  one wrong reading on the page, for the same reason a background agent's
+ *  vitals stay blank.
+ *
+ *  Ended sessions are left out even though their cells are still on screen: the
+ *  header says what this machine is doing, and a session that finished is not
+ *  burning anything. Its own final figures stay on its cell, where they are a
+ *  claim about it rather than about the machine. */
+function machineTotals(all: Card[]): string | null {
+  const cards = all.filter(c => c.state !== 'ended');
+  const parts: string[] = [];
+  if (cards.some(c => c.spend !== null)) {
+    parts.push(fmtCost(cards.reduce((sum, c) => sum + (c.spend ?? 0), 0)));
+  }
+  const tokens = cards.reduce((sum, c) => sum + c.tokens, 0);
+  if (tokens > 0) {
+    const { value, unit } = formatTokens(tokens);
+    parts.push(`${value}${unit} tokens`);
+  }
+  return parts.length ? parts.join(' · ') : null;
+}
+
+/** The tool-tinted lane of what a session did in the last couple of minutes, or
+ *  the one sentence that says why there is no lane to draw. Shared shape between
+ *  the band and a cell: the ribbon is the same claim at both sizes, and only its
+ *  height differs. */
+function Ribbon({ card, now }: { card: Card; now: number }) {
+  const runs = buildRibbon(card.trace, now);
+  if (card.noTrace) {
+    return (
+      <div className="cl-mx-ribbon">
+        <span className="none">no transcript to tail</span>
+      </div>
+    );
+  }
+  return (
+    <div className="cl-mx-ribbon" title={`Tool calls in the last ${RIBBON_WINDOW}`}>
+      {runs.map(run => (
+        <i
+          key={`${run.tool}-${run.left}`}
+          className={run.failed ? 'failed' : undefined}
+          style={{
+            left: `${run.left}%`,
+            width: `${run.width}%`,
+            background: run.failed ? 'var(--cl-danger)' : toolTint(run.tool),
+          }}
+          title={run.failed ? `${run.tool} — came back an error` : run.tool}
+        />
+      ))}
+      {runs.length === 0 && <span className="none">nothing in the last {RIBBON_WINDOW}</span>}
+    </div>
+  );
+}
+
+/** The vitals row, identical in the band and in a cell: the context gauge, the
+ *  bill, the silence and the tally. The context is the only measure here with a
+ *  real denominator, so it is the only one drawn as a gauge; spend has no
+ *  ceiling and stays a figure — a bar against an invented ceiling would be
+ *  decoration pretending to be a measurement. */
+function Vitals({ card, quiet }: { card: Card; quiet: string }) {
+  return (
+    <div className="cl-mx-vitals">
+      {card.context ? (
+        // No `ctx` label on the gauge: a bar with a percentage beside it says
+        // what it is, and in a cell this narrow those three characters were
+        // taken from the figures that do need their unit spelled out.
+        <span
+          className="ctx"
+          data-load={contextLoad(card.context)}
+          title={`Context window: ${fmt(card.context.used)} of ${fmt(card.context.max)} tokens`}
+        >
+          <span className="bar">
+            <i style={{ width: `${contextPct(card.context)}%` }} />
+          </span>
+          <span className="v">{contextPct(card.context)}%</span>
+        </span>
+      ) : (
+        // The label survives here: a lone dash names nothing.
+        <span className="ctx is-none">
+          <span className="k">ctx</span>
+          <span className="v">—</span>
+        </span>
+      )}
+      {card.spend !== null && (
+        <span className="money" title={card.spendEstimated ? ESTIMATE_NOTE : undefined}>
+          {card.spendEstimated && '~'}
+          {fmtCost(card.spend)}
+        </span>
+      )}
+      {quiet && <span className="quiet">{quiet}</span>}
+      {card.counts && <span className="vol">{card.counts}</span>}
+    </div>
+  );
+}
+
 /**
- * One live process, as an index card.
+ * A process that is blocked on you, as a full-bleed dark band.
  *
- * The form is the memory index card (`.cl-mcard`) rather than a dark instrument
- * lane, and the reason is the same one that made two earlier attempts read as
- * bare: a wide dark band holding five short strings is mostly empty by
- * construction, and on this app's warm paper it also reads as a foreign object.
+ * It is the only dark surface on the page, and that is the whole argument for
+ * it: two earlier forms failed by making a dark slab the DEFAULT, where a wide
+ * dark band holding five short strings is mostly empty by construction. Here it
+ * is the exception, it runs edge to edge, and what fills it is the one string on
+ * this page long enough to earn display size — the question the session is
+ * waiting on.
  *
- * The card's ANATOMY IS FIXED, and that is the fourth form. Letting the body be
- * the tape made every card a different height — a session that had run six tools
- * stood a third taller than one that had run none — so a rack of them had no
- * baseline to read across and the ragged bottom edge was the first thing the eye
- * had to parse. Now every card is the same five blocks at the same height: state
- * and clock, who, the NOW line, a three-row slot, vitals. What varies is what is
- * printed IN them, never where they are: the slot is drawn whether or not there
- * is anything to put in it (empty rows stay ruled), and a busier session says so
- * with `+3` on its last row rather than by growing. The cost is honest — a few
- * ruled millimetres on a quiet card — and it buys a grid you can scan by column:
- * every clock, every gauge, every bill at the same height on the page.
- *
- * The one bold thing on the page is the border: only the card that wants
- * something from you has a heavy edge. Everything else is hairlines.
+ * What leads is therefore the QUESTION, not the project: the identity drops to
+ * one mono line under it (project · title · pid · model · uptime), because you
+ * already know which of your projects you are looking at by the time you read
+ * what it wants. The clock is the second big figure and it counts the one thing
+ * only this state can measure: how long you have been the bottleneck.
  */
-function ProcessCard({ card, now }: { card: Card; now: number }) {
+function BlockedBand({ card, now }: { card: Card; now: number }) {
   const elapsed = card.since === null ? null : Math.max(0, now - card.since);
-  // The in-flight call is already printed as the NOW line, and the newest mark
-  // IS that call: without this the card would show the same action twice.
-  const tape = buildTape(card.trace, now, { dropNewest: !!card.tool });
-  // The slot prints the newest rows and says how many it is not printing. A
-  // card that quietly showed three of eleven actions would read as a calm
-  // session; `+8` is the difference between a summary and a lie by omission.
-  const rows = tape.slice(0, TAPE_ROWS);
-  const more = tape.length - rows.length;
-  // Whatever the slot has left over stays ruled. An agent's note takes one of
-  // those lines, since "there is no transcript" is not the same claim as "it did
-  // nothing" and only one of the two can be fixed by waiting.
-  const rules = TAPE_ROWS - rows.length - (card.noTrace ? 1 : 0);
+  const quiet = quietNote(card, now);
   const open = card.onOpen;
 
-  // What the silence since the last action means. A running sub-agent takes the
-  // slot: it is the explanation, and the one thing the tail cannot see for
-  // itself. Below the floor nothing is said — a gap of two seconds between two
-  // tool calls is not a signal.
-  const quiet = card.routeNote
-    ? card.routeNote
-    : card.delegateSince !== null
-      ? `${span(now - card.delegateSince)} in flight`
-      : card.lastAppendAt !== null && now - card.lastAppendAt >= QUIET_FLOOR_MS
-        ? `quiet ${span(now - card.lastAppendAt)}`
-        : '';
+  return (
+    <section className="cl-mxband" data-state={card.state}>
+      <div className="cl-mxband-say">
+        <div className="cl-eyebrow">
+          <span className="pip" />
+          <span>Needs you{quiet && ` · ${quiet}`}</span>
+        </div>
+        <p className="ask">{card.doing}</p>
+        <div className="meta">
+          <b className="proj">{card.title}</b>
+          <i className="sep">·</i>
+          <span className={card.ident === UNNAMED ? 'is-unnamed' : undefined}>{card.ident}</span>
+          {card.machine.map(f => (
+            <span key={f}>
+              <i className="sep">·</i>
+              {f}
+            </span>
+          ))}
+        </div>
+        <Ribbon card={card} now={now} />
+        <Vitals card={card} quiet="" />
+      </div>
+
+      <div className="cl-mxband-act">
+        <div className="clk">{clock(elapsed)}</div>
+        <div className="lbl">blocked for</div>
+        {open && (
+          // Deliberately not "Reply in terminal": the prompt is waiting in the
+          // user's own shell and nothing here can answer it. The button says
+          // what it does — open this session in ClaudeLens.
+          <button type="button" onClick={open}>
+            {card.routeNote ? 'Open in Agent View ↗' : 'Open session ↗'}
+          </button>
+        )}
+      </div>
+    </section>
+  );
+}
+
+/**
+ * Every other live process, as one cell of a hairline grid.
+ *
+ * NO BORDER, NO RADIUS, NO SURFACE: a cell is defined by the rules between it
+ * and its neighbours, which is what lets the band above be the only raised thing
+ * on the page. The anatomy stays fixed across cells — state and clock, who, the
+ * NOW line, the ribbon, vitals — so the grid can be scanned by column: every
+ * clock, every gauge, every bill on the same line of the page.
+ */
+function ProcessCell({ card, now }: { card: Card; now: number }) {
+  const elapsed = card.since === null ? null : Math.max(0, now - card.since);
+  const quiet = quietNote(card, now);
+  const open = card.onOpen;
 
   return (
     <article
-      className="cl-mx"
+      className="cl-mxcell"
       data-state={card.state}
       role={open ? 'button' : undefined}
       tabIndex={open ? 0 : undefined}
@@ -651,12 +808,35 @@ function ProcessCard({ card, now }: { card: Card; now: number }) {
       }}
     >
       <div className="cl-mx-head">
-        <span className="tag">
-          <i aria-hidden />
-          {STATE_LABEL[card.state]}
-        </span>
-        {/* The clock is the card's one large figure and answers one question in
-            every state: how long it has been in THIS state. */}
+        <div className="cl-mx-who">
+          <span className="tag">
+            <i aria-hidden />
+            {STATE_LABEL[card.state]}
+          </span>
+          <h3>{card.title}</h3>
+          {/* A conversation title is a sentence, so the line will often clip it:
+              the tooltip keeps the whole of it one hover away. */}
+          <span
+            className={card.ident === UNNAMED ? 'ident is-unnamed' : 'ident'}
+            title={card.ident}
+          >
+            {card.ident}
+          </span>
+          {/* The machine facts stay on the cell even though the design keeps
+              them for the band alone: the pid is what you need to `kill`, and a
+              fact that only exists in the one state you are already acting on is
+              a fact you cannot use. */}
+          <span className="machine">
+            {card.machine.map((f, i) => (
+              <span key={f}>
+                {i > 0 && <i className="sep">·</i>}
+                {f}
+              </span>
+            ))}
+          </span>
+        </div>
+        {/* The cell's one large figure, and it answers one question in every
+            state: how long it has been in THIS state. */}
         <span
           className="clk"
           title={
@@ -668,102 +848,17 @@ function ProcessCard({ card, now }: { card: Card; now: number }) {
         </span>
       </div>
 
-      <div className="cl-mx-who">
-        <h3>{card.title}</h3>
-        {/* A conversation title is a sentence, so the line will often clip it:
-            the tooltip keeps the whole of it one hover away. */}
-        <span className={card.ident === UNNAMED ? 'ident is-unnamed' : 'ident'} title={card.ident}>
-          {card.ident}
-        </span>
-        <span className="machine">
-          {card.machine.map((f, i) => (
-            <span key={f}>
-              {i > 0 && <i className="sep">·</i>}
-              {f}
-            </span>
-          ))}
-        </span>
-      </div>
-
-      {/* NOW — what the session is doing this second, and the only line on the
-          card that is not history. It has its own inset block rather than being
-          the tape's first row: what a process is doing right now is a different
-          kind of claim from what it did, and the row it used to sit in made the
-          two look like one list. */}
+      {/* NOW — what the session is doing this second, and the only line here
+          that is not history. Its own inset block, because what a process is
+          doing right now is a different kind of claim from what it did. */}
       <div className="cl-mx-now">
         <i className="dot" style={{ background: toolTint(card.tool) }} aria-hidden />
         {card.tool && <b>{card.tool}</b>}
         <span className="arg">{card.doing}</span>
       </div>
 
-      {/* The slot: three rows, always. What it did, newest first, each with the
-          subject it acted on. Rows with nothing to say stay ruled — the card is
-          the same height either way, which is the point of the form. */}
-      <ol className="cl-mx-slot">
-        {card.noTrace && <li className="none">no transcript to tail</li>}
-        {rows.map((step, i) => (
-          <li key={`${step.at}-${i}`} className={step.failed ? 'failed' : undefined}>
-            <span className="when">{span(now - step.at) || 'now'}</span>
-            <i className="dot" style={{ background: toolTint(step.tool) }} aria-hidden />
-            <b>{step.tool}</b>
-            <span className="arg">{step.arg}</span>
-            <span className="mark">
-              {step.count > 1 && <i className="times">×{step.count}</i>}
-              {step.failed && (
-                <i className="x" title="This call came back an error">
-                  ✕
-                </i>
-              )}
-              {i === rows.length - 1 && more > 0 && (
-                <i className="more" title={`${more} more in the last ${TAPE_MINUTES} min`}>
-                  +{more}
-                </i>
-              )}
-            </span>
-          </li>
-        ))}
-        {Array.from({ length: Math.max(0, rules) }, (_, i) => (
-          <li key={`rule-${i}`} className="rule" aria-hidden>
-            <i />
-          </li>
-        ))}
-      </ol>
-
-      {/* Vitals. The context is the only measure here with a real denominator, so
-          it is the only one drawn as a gauge; spend has no ceiling and stays a
-          figure — a bar against an invented ceiling would be decoration
-          pretending to be a measurement. */}
-      <div className="cl-mx-vitals">
-        {card.context ? (
-          // No `ctx` label on the gauge: a bar with a percentage beside it says
-          // what it is, and on a card this narrow those three characters were
-          // taken from the figures that do need their unit spelled out.
-          <span
-            className="ctx"
-            data-load={contextLoad(card.context)}
-            title={`Context window: ${fmt(card.context.used)} of ${fmt(card.context.max)} tokens`}
-          >
-            <span className="bar">
-              <i style={{ width: `${contextPct(card.context)}%` }} />
-            </span>
-            <span className="v">{contextPct(card.context)}%</span>
-          </span>
-        ) : (
-          // The label survives here: a lone dash names nothing.
-          <span className="ctx is-none">
-            <span className="k">ctx</span>
-            <span className="v">—</span>
-          </span>
-        )}
-        {card.spend !== null && (
-          <span className="money" title={card.spendEstimated ? ESTIMATE_NOTE : undefined}>
-            {card.spendEstimated && '~'}
-            {fmtCost(card.spend)}
-          </span>
-        )}
-        {quiet && <span className="quiet">{quiet}</span>}
-        {card.counts && <span className="vol">{card.counts}</span>}
-      </div>
+      <Ribbon card={card} now={now} />
+      <Vitals card={card} quiet={quiet} />
     </article>
   );
 }

--- a/src/components/project/monitor/trace.ts
+++ b/src/components/project/monitor/trace.ts
@@ -1,96 +1,120 @@
 import type { TraceMark } from '../../../types';
 
-// The Monitor's tape: the last things a session actually did, newest first.
+// The Monitor's ribbon: the last two and a half minutes of a session, drawn as
+// runs of tinted blocks on a shared time axis.
 //
-// It has been a histogram (42 anonymous buckets, height by count) and then a
-// track of tinted ticks. Both answered "at what rhythm" and nothing else, and a
-// rhythm on its own is a heartbeat — it says the session is alive without ever
-// saying what it is doing. The marks carry the tool and its subject now, so the
-// same seconds can be read as prose: `Edit MonitorView.tsx`, `Bash npm run
-// typecheck ✕`. The rhythm survives in the age of each row: a tape whose top row
-// says `4m` is a session that has done nothing for four minutes, which is the
-// question the strip existed to answer, asked in words.
+// It replaces the three-row textual tape that stood here (design handoff
+// *Monitor Variants*, option 2b). The trade is explicit: the tape said what a
+// session did in words and cost the cell four fixed rows, which is what made a
+// card 260px tall and forced the rack into 340px columns. 2b spends that height
+// on a full-bleed band for the one session that is blocked and gives everything
+// else a hairline grid three columns wide — so the history had to compress into
+// a lane. What survives the compression is the shape of the work and its
+// rhythm, tinted by tool; what a session is doing RIGHT NOW is still in words,
+// in the cell's NOW line, which is the claim the strip could never make on its
+// own.
 //
-// This returns the WHOLE story in the window and caps nothing. The card's slot
-// is what decides how many rows are printed (`TAPE_ROWS`), and it needs the full
-// count to say how much it is leaving out — `+3` at the end of the last row.
-// A cap here would hide that figure from the one surface that has to state it.
-// The window itself is the bound, and the digest ships at most 160 marks.
+// The rhythm is read off real timestamps, not off a rasterised string: the
+// window is cut into equal cells, each mark falls in the cell its `at` lands in,
+// and contiguous cells of one tool collapse into a single block. A retry loop is
+// then one long block, a session hammering three different tools is three short
+// ones, and a session that has done nothing for a minute is a lane with a
+// minute of nothing at its right-hand end — which is the whole question the lane
+// exists to answer.
 //
 // Pure and separate from the view for two reasons: the repo's fast-refresh rule
 // (a component file exports only components), and because this is the part worth
-// pinning down in tests — what counts as one step, and which end of the history
-// survives.
+// pinning down in tests — where a mark lands, what counts as one block, and what
+// falls outside the window.
 
-/** How far back the tape reaches. The digest keeps a wider window than this
- *  (`TRACE_WINDOW_MS`), so the cap is what a card can show, not what is known. */
-export const TAPE_SPAN_MS = 150_000;
+/** How far back the ribbon reaches. The digest keeps a wider window than this
+ *  (`TRACE_WINDOW_MS`), so the cap is what a cell can show, not what is known. */
+export const RIBBON_SPAN_MS = 150_000;
 
-/** Rows the card's slot holds — and it holds them whether or not there is
- *  anything to put in them. That is the whole point of the fixed form: the slot
- *  is drawn either way, so a session that has done six things and one that has
- *  done none are the same size, and the grid finally has a baseline. Three is
- *  what fits under the identity block and the NOW line at this card height.
- *  The newest rows are the ones kept: what a session just did explains it
- *  better than what it started with. */
-export const TAPE_ROWS = 3;
+/** The window's grain. 48 cells over 150s is roughly three seconds each: fine
+ *  enough that two calls a few seconds apart stay two blocks, coarse enough that
+ *  a burst reads as one stretch of work rather than a picket fence. */
+export const RIBBON_CELLS = 48;
 
-export interface TapeStep {
-  /** Epoch ms of the (first) call. */
-  at: number;
+/** The window, in the words the tooltip says it in. Spelled with its half
+ *  minute rather than rounded: the figure this lane is read against is how long
+ *  its empty right-hand end has been empty, and rounding 150s up to "3 min"
+ *  overstates that by a fifth. */
+export const RIBBON_WINDOW = `${Number((RIBBON_SPAN_MS / 60_000).toFixed(1))} min`;
+
+/** Percent of the window left blank between two blocks, so runs of two
+ *  different tools never fuse into one bar. */
+const BLOCK_GAP = 0.35;
+
+/** Percent a single-cell block is never allowed to fall below: at this grain one
+ *  call is ~2% of the lane, and a block thinner than a hairline is not a mark,
+ *  it is a rendering artefact. */
+const BLOCK_MIN = 0.9;
+
+export interface RibbonRun {
   tool: string;
-  /** The one-line subject, or '' for a tool that takes nothing worth printing. */
-  arg: string;
-  /** Its result came back an error. */
+  /** Left edge, as a percentage of the window. */
+  left: number;
+  /** Width, as a percentage of the window. */
+  width: number;
+  /** At least one call in this run came back an error. A verdict on the run, so
+   *  it takes the danger hue instead of the tool's — the tint answers "what kind
+   *  of work", and a failure outranks that. */
   failed: boolean;
-  /** Consecutive identical calls collapsed into this row — a retry loop reads as
-   *  `Bash npm test ×3`, which is the truth about it, instead of three rows that
-   *  look like three different pieces of work. */
-  count: number;
 }
 
 /**
- * The last actions of a session, newest first.
- *
- * `dropNewest` is set when the card is already printing the in-flight call as
- * its "now" row: the newest mark IS that call, and a tape that repeats it above
- * its own history reads as if the session had done the same thing twice.
+ * The last actions of a session, oldest to newest, as blocks on the window.
  *
  * Marks outside the window are dropped rather than clamped — including ones
  * stamped in the future, which clock skew between the CLI and this process can
- * produce.
+ * produce. Prose marks are dropped too: they have no tool, so they have no
+ * tint, and a grey block between two edits would read as a tool nobody can name.
  */
-export function buildTape(
-  marks: TraceMark[],
-  now: number,
-  options: { dropNewest?: boolean } = {}
-): TapeStep[] {
-  const { dropNewest = false } = options;
-  const start = now - TAPE_SPAN_MS;
+export function buildRibbon(marks: TraceMark[], now: number): RibbonRun[] {
+  const start = now - RIBBON_SPAN_MS;
+  const step = RIBBON_SPAN_MS / RIBBON_CELLS;
+  const cells: ({ tool: string; failed: boolean } | null)[] = Array.from(
+    { length: RIBBON_CELLS },
+    () => null
+  );
 
-  // Prose marks the trace but is not a step of the story: "wrote some text"
-  // between two edits would break the sequence in half without adding anything a
-  // reader could act on.
-  const tools = marks
-    .filter(m => m.kind === 'tool' && m.at >= start && m.at <= now)
-    .sort((a, b) => b.at - a.at);
-
-  const steps: TapeStep[] = [];
-  for (const mark of tools.slice(dropNewest ? 1 : 0)) {
-    const previous = steps[steps.length - 1];
-    const tool = mark.tool ?? 'unknown';
-    const arg = mark.arg ?? '';
-    // Collapse only an EXACT repeat (same tool, same subject): two edits of two
-    // different files are two pieces of work, two runs of the same command are
-    // one thing happening twice.
-    if (previous && previous.tool === tool && previous.arg === arg) {
-      previous.count += 1;
-      previous.failed = previous.failed || !!mark.failed;
-      // The row is dated by its oldest call: it says when this started.
-      previous.at = mark.at;
+  for (const mark of marks) {
+    if (mark.kind !== 'tool') continue;
+    if (mark.at < start || mark.at > now) continue;
+    const index = Math.min(RIBBON_CELLS - 1, Math.floor((mark.at - start) / step));
+    const cell = cells[index];
+    if (cell) {
+      // Two tools in one cell: the first keeps the tint (the lane is read left
+      // to right, so the earlier call is what that position means) and the
+      // failure is carried either way — it is the fact worth not losing.
+      cell.failed = cell.failed || !!mark.failed;
       continue;
     }
-    steps.push({ at: mark.at, tool, arg, failed: !!mark.failed, count: 1 });
+    cells[index] = { tool: mark.tool ?? 'unknown', failed: !!mark.failed };
   }
-  return steps;
+
+  const runs: RibbonRun[] = [];
+  let i = 0;
+  while (i < RIBBON_CELLS) {
+    const cell = cells[i];
+    if (!cell) {
+      i += 1;
+      continue;
+    }
+    let j = i;
+    let failed = false;
+    while (j < RIBBON_CELLS && cells[j]?.tool === cell.tool) {
+      failed = failed || !!cells[j]?.failed;
+      j += 1;
+    }
+    runs.push({
+      tool: cell.tool,
+      left: (i / RIBBON_CELLS) * 100,
+      width: Math.max(BLOCK_MIN, ((j - i) / RIBBON_CELLS) * 100 - BLOCK_GAP),
+      failed,
+    });
+    i = j;
+  }
+  return runs;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -15977,11 +15977,32 @@ select.cl-opt-input {
    and in the accent. Not a band of stat tiles — those were removed from this
    page once already, for printing the same numbers the cards carry. */
 .cl-mxtop {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 10px 28px;
   padding: 30px var(--cl-gutter) 24px;
   border-bottom: 1.5px solid var(--cl-ink);
 }
+.cl-mxtop-say-wrap {
+  min-width: 0;
+}
 .cl-mxtop .cl-eyebrow {
   margin-bottom: 11px;
+}
+/* What the whole machine is burning, in the corner opposite the sentence that
+   says what it is doing. It is the only place a token count survives on this
+   page: per process it was a second figure competing with the bill, summed over
+   every live one it is the only reading of scale there is. */
+.cl-mxtop-tot {
+  padding-bottom: 5px;
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  color: var(--cl-ink-4);
 }
 .cl-mxtop .cl-eyebrow .pip {
   background: var(--cl-ink-4);
@@ -16025,93 +16046,301 @@ select.cl-opt-input {
   color: var(--cl-ink-4);
 }
 
-/* ── The grid ──
-   Every card is the same height, so this is a real grid: rows line up, and the
-   clock, the gauge and the bill of any two cards sit on the same line of the
-   page. The earlier form let the body set the height and needed
-   `align-items: start` to avoid stretching short cards — which is another way of
-   saying the rack had no baseline at all. */
-.cl-mx-grid {
+/* ── The blocked band ──
+   Design handoff *Monitor Variants*, option 2b. The one process that is waiting
+   on YOU stops being a card in the rack and becomes a full-bleed dark band.
+
+   This is the third time a dark surface has been tried on this page, and the
+   first time it works — because the two that failed made it the DEFAULT. A wide
+   dark band holding five short strings is mostly empty by construction, and a
+   grid of them on warm paper reads as a foreign object. Here it is the
+   exception, it runs edge to edge, and what fills it is the one string on this
+   page long enough to earn display size: the question the session is waiting on.
+
+   Fixed dark in BOTH themes, like the live cell of the stat strip: the band is
+   not "the dark variant of a cell", it is the page's one negative surface, and a
+   surface that flips with the theme would stop being that. */
+.cl-mxband {
+  /* The band is fixed dark in a theme that is usually light, so the semantic
+     tokens inside it are re-bound to the lifts the DARK theme already declares —
+     same hues, higher lightness. Not new colours: `--cl-accent` at L 0.575 on a
+     surface at L 0.205 is ~3.9:1, which passes for the 52px clock and fails for
+     the 9.5px eyebrow and the 11.5px button beside it. */
+  --cl-accent: oklch(0.72 0.14 40);
+  --cl-warn: oklch(0.78 0.14 75);
+  --cl-danger: oklch(0.68 0.19 25);
+  --cl-ok: oklch(0.72 0.1 145);
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
-  gap: 18px;
-  padding-top: 4px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 20px 32px;
+  padding: 24px var(--cl-gutter) 26px;
+  background: oklch(0.205 0.008 75);
+  box-shadow: inset 0 -1px 0 oklch(0 0 0 / 0.35);
+}
+.cl-mxband + .cl-mxband {
+  box-shadow:
+    inset 0 1px 0 oklch(1 0 0 / 0.07),
+    inset 0 -1px 0 oklch(0 0 0 / 0.35);
+}
+.cl-mxband-say {
+  min-width: 0;
+}
+/* The eyebrow is the only place the silence is said for a blocked session: the
+   vitals row below it would print `quiet 4m` in 10px grey, and how long a
+   session has been sitting on your answer is not a footnote. */
+.cl-mxband .cl-eyebrow {
+  gap: 10px;
+  margin-bottom: 12px;
+  font-size: 9.5px;
+  letter-spacing: 0.2em;
+  color: var(--cl-accent);
+}
+.cl-mxband .cl-eyebrow .pip {
+  background: var(--cl-accent);
+  animation: cl-mx-beat 2.2s ease-out infinite;
+}
+/* What it is waiting on, at display size. It leads the band instead of the
+   project name because by the time you are reading a band you already know
+   which of your projects raised it — what you do not know is what it wants. */
+.cl-mxband .ask {
+  margin: 0;
+  font-family: var(--font-sans);
+  font-size: clamp(19px, 2.1vw, 27px);
+  font-weight: 600;
+  line-height: 1.2;
+  letter-spacing: -0.03em;
+  color: oklch(0.95 0.006 85);
+  text-wrap: pretty;
+}
+/* Identity demoted to one mono line: project, conversation title, then the
+   machine facts — pid first, because it is what you need to `kill`. */
+.cl-mxband .meta {
+  margin-top: 12px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: oklch(0.66 0.009 75);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.cl-mxband .meta .proj {
+  font-weight: 600;
+  color: oklch(0.87 0.006 80);
+}
+.cl-mxband .meta .sep {
+  margin: 0 7px;
+  font-style: normal;
+  opacity: 0.5;
+}
+.cl-mxband .meta .is-unnamed {
+  font-style: italic;
+  opacity: 0.8;
+}
+/* The ribbon and the vitals ride the band too. The design's band carries
+   neither, but the session you are about to answer is the one where "how full
+   is the window" and "what has this cost" actually change what you do — and a
+   flatlined right-hand end of the lane is the picture of what `blocked for`
+   says in figures. */
+.cl-mxband .cl-mx-ribbon {
+  margin-top: 14px;
+}
+.cl-mxband .cl-mx-ribbon::after {
+  background: oklch(1 0 0 / 0.12);
+}
+.cl-mxband .cl-mx-ribbon .none {
+  color: oklch(0.63 0.008 75);
+}
+.cl-mxband .cl-mx-vitals {
+  margin-top: 12px;
+  border-top-color: oklch(1 0 0 / 0.1);
+  color: oklch(0.66 0.008 75);
+}
+.cl-mxband .cl-mx-vitals .ctx .bar {
+  background: oklch(1 0 0 / 0.14);
+}
+/* Only the neutral band is re-tinted: warn and danger already read on a dark
+   surface, and overriding them would silence the one gauge that is allowed to
+   raise its voice. */
+.cl-mxband .cl-mx-vitals .ctx[data-load='ok'] .bar i {
+  background: oklch(0.72 0.01 75);
+}
+.cl-mxband .cl-mx-vitals .ctx[data-load='ok'] .v {
+  color: oklch(0.72 0.01 75);
+}
+.cl-mxband .cl-mx-vitals .ctx.is-none .k,
+.cl-mxband .cl-mx-vitals .ctx.is-none .v {
+  color: oklch(0.63 0.008 75);
+}
+.cl-mxband .cl-mx-vitals .money {
+  color: oklch(0.93 0.005 85);
+}
+/* The clock is the band's second big figure, and the only one that measures the
+   thing this state is about: how long you have been the bottleneck. */
+.cl-mxband-act {
+  text-align: right;
+}
+.cl-mxband-act .clk {
+  font-family: var(--font-mono);
+  font-size: clamp(34px, 4vw, 52px);
+  line-height: 1;
+  letter-spacing: -0.045em;
+  font-variant-numeric: tabular-nums;
+  color: var(--cl-accent);
+}
+.cl-mxband-act .lbl {
+  margin-top: 8px;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: oklch(0.65 0.009 70);
+}
+.cl-mxband-act button {
+  margin-top: 14px;
+  padding: 9px 15px;
+  border-radius: 12px;
+  cursor: pointer;
+  border: 1px solid color-mix(in oklch, var(--cl-accent) 55%, transparent);
+  background: color-mix(in oklch, var(--cl-accent) 14%, transparent);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  letter-spacing: 0.06em;
+  white-space: nowrap;
+  color: var(--cl-accent);
+  transition:
+    background 120ms,
+    border-color 120ms;
+}
+.cl-mxband-act button:hover {
+  background: color-mix(in oklch, var(--cl-accent) 26%, transparent);
+  border-color: var(--cl-accent);
+}
+.cl-mxband-act button:focus-visible {
+  outline: 2px solid var(--cl-accent);
+  outline-offset: 2px;
+}
+/* Side by side, the clock needs a column of its own; stacked, it does not. */
+@media (max-width: 820px) {
+  .cl-mxband {
+    grid-template-columns: minmax(0, 1fr);
+  }
+  .cl-mxband-act {
+    text-align: left;
+  }
 }
 
-/* ── The card ──
-   FIXED ANATOMY: five rows, one height, whatever the session has been up to.
-   The slot takes the `1fr`, so any slack (a vitals line that wrapped, a card
-   with fewer machine facts) is absorbed BELOW the ruled rows — the head, the
-   identity block and the vitals stay where they are on every card in the rack.
-   `overflow: hidden` is the guarantee, not the layout: nothing inside is allowed
-   to grow the frame, and everything that could is already ellipsized. */
-.cl-mx {
+/* ── The grid ──
+   NO card borders at all: a cell is defined by the rules between it and its
+   neighbours, which is exactly what lets the band above be the only raised
+   thing on the page. The rack of bordered cards it replaces had to spend a
+   heavy accent edge on the blocked card to be read in order — and once the
+   blocked process has a band of its own, everything left is by definition the
+   normal case and none of it has to shout.
+
+   The columns are fixed rather than auto-filled because the first and last of
+   them carry the page gutter: with `auto-fill` there is no way to say "the cell
+   at the edge", and the grid would start 32px in from a header that starts at
+   the gutter. */
+.cl-mx-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+/* ── The cell ──
+   FIXED ANATOMY: head, NOW, ribbon, vitals — in that order, in every cell. The
+   vitals take the `1fr` and sit at the bottom, so any slack (a wrapped vitals
+   line, a cell with fewer machine facts) is absorbed above them and the gauges
+   of two neighbours stay on one line of the page. */
+.cl-mxcell {
   --mx: var(--cl-ok);
   display: grid;
-  grid-template-rows: auto auto auto 1fr auto;
-  height: 260px;
-  padding: 14px 16px 12px;
+  grid-template-rows: auto auto auto 1fr;
+  min-width: 0;
+  padding: 18px 22px 16px;
+  /* Bottom, not top: the header already closes itself with a 1.5px ink rule, and
+     a hairline immediately under it would read as that rule fraying. Ruling
+     downwards also closes the last row, so the grid ends on a line instead of
+     trailing off. */
+  border-bottom: 1px solid var(--cl-line);
+  border-left: 1px solid var(--cl-line);
   overflow: hidden;
-  border: 1px solid var(--cl-line);
-  border-radius: 14px;
-  background: var(--cl-paper);
   text-align: left;
-  transition:
-    border-color 120ms,
-    box-shadow 120ms;
+  transition: background 120ms;
 }
-.cl-mx[role='button'] {
+.cl-mxcell:nth-child(3n + 1) {
+  border-left: none;
+  padding-left: var(--cl-gutter);
+}
+.cl-mxcell:nth-child(3n) {
+  padding-right: var(--cl-gutter);
+}
+.cl-mxcell[role='button'] {
   cursor: pointer;
 }
-.cl-mx[role='button']:hover {
-  border-color: color-mix(in oklch, var(--cl-accent) 30%, var(--cl-line));
-  box-shadow: 0 2px 12px -6px oklch(0 0 0 / 0.18);
+.cl-mxcell[role='button']:hover {
+  background: color-mix(in oklch, var(--cl-ink) 3.5%, transparent);
 }
-:root[data-theme='dark'] .cl-mx[role='button']:hover {
-  box-shadow: 0 2px 12px -6px oklch(0 0 0 / 0.5);
-}
-.cl-mx[role='button']:focus-visible {
+.cl-mxcell[role='button']:focus-visible {
   outline: 2px solid var(--cl-accent);
   outline-offset: -2px;
 }
-/* The one bold thing on the page. A 1.5px accent edge plus the wash the memory
-   cards use for their first tile: the card that wants something is the only one
-   that raises its voice, and it does it once. */
-.cl-mx[data-state='blocked'] {
-  --mx: var(--cl-accent);
-  border-width: 1.5px;
-  border-color: color-mix(in oklch, var(--cl-accent) 46%, var(--cl-line));
-  background: linear-gradient(180deg, var(--cl-accent-soft), var(--cl-paper) 58%);
-}
-:root[data-theme='dark'] .cl-mx[data-state='blocked'] {
-  background: linear-gradient(
-    180deg,
-    color-mix(in oklch, var(--cl-accent) 12%, var(--cl-paper)),
-    var(--cl-paper) 58%
-  );
-}
-/* Alive, turn finished. Not muted like an ended card — it is still a process you
+/* Alive, turn finished. Not muted like an ended cell — it is still a process you
    can talk to — but it does not get the working hue either, because it is not
    working. */
-.cl-mx[data-state='ready'] {
+.cl-mxcell[data-state='ready'] {
   --mx: var(--cl-ink-3);
 }
-.cl-mx[data-state='ended'] {
+.cl-mxcell[data-state='ended'] {
   --mx: var(--cl-ink-4);
   background: var(--cl-paper-2);
 }
-.cl-mx[data-state='ended'] .cl-mx-who h3 {
+.cl-mxcell[data-state='ended'] .cl-mx-who h3 {
   color: var(--cl-ink-2);
+}
+.cl-mxcell .cl-mx-vitals {
+  align-self: end;
+}
+@media (max-width: 1240px) {
+  .cl-mx-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .cl-mxcell:nth-child(3n + 1),
+  .cl-mxcell:nth-child(3n) {
+    border-left: 1px solid var(--cl-line);
+    padding-left: 22px;
+    padding-right: 22px;
+  }
+  .cl-mxcell:nth-child(2n + 1) {
+    border-left: none;
+    padding-left: var(--cl-gutter);
+  }
+  .cl-mxcell:nth-child(2n) {
+    padding-right: var(--cl-gutter);
+  }
+}
+@media (max-width: 760px) {
+  .cl-mx-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+  .cl-mx-grid .cl-mxcell {
+    border-left: none;
+    padding-left: var(--cl-gutter);
+    padding-right: var(--cl-gutter);
+  }
 }
 
 /* ── Head: what it is, and for how long ── */
 .cl-mx-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
   gap: 12px;
 }
-.cl-mx-head .tag {
+.cl-mx-who {
+  min-width: 0;
+}
+.cl-mx-who .tag {
   display: inline-flex;
   align-items: center;
   gap: 7px;
@@ -16121,73 +16350,34 @@ select.cl-opt-input {
   white-space: nowrap;
   color: var(--mx);
 }
-.cl-mx[data-state='blocked'] .tag {
-  color: var(--cl-accent-ink);
-}
-.cl-mx-head .tag i {
+.cl-mx-who .tag i {
   width: 7px;
   height: 7px;
   border-radius: 50%;
   background: var(--mx);
   flex-shrink: 0;
 }
-/* Only what is blocked pulses. A working session is expected to be working; a
-   halo on every card would make the page loud and say nothing. */
-.cl-mx[data-state='blocked'] .tag i {
-  animation: cl-mx-beat 2.2s ease-out infinite;
-}
+/* Nothing in the grid pulses. The halo belongs to the band, which is the only
+   thing on this page still asking for something; a working session is expected
+   to be working. */
 @keyframes cl-mx-beat {
   0% {
     box-shadow: 0 0 0 0 color-mix(in oklch, var(--cl-accent) 55%, transparent);
   }
   70% {
-    box-shadow: 0 0 0 8px transparent;
+    box-shadow: 0 0 0 9px transparent;
   }
   100% {
     box-shadow: 0 0 0 0 transparent;
   }
 }
-/* The card's one large figure, and it answers one question in every state: how
-   long it has been in THIS state. */
-.cl-mx-head .clk {
-  display: inline-flex;
-  align-items: baseline;
-  gap: 5px;
-  font-family: var(--font-mono);
-  font-size: 19px;
-  line-height: 1;
-  letter-spacing: -0.03em;
-  font-variant-numeric: tabular-nums;
-  color: var(--cl-ink);
-}
-.cl-mx[data-state='blocked'] .clk {
-  color: var(--cl-accent-ink);
-}
-.cl-mx[data-state='ready'] .clk,
-.cl-mx[data-state='ended'] .clk {
-  color: var(--cl-ink-3);
-}
-/* For a card that has ended, that state is over: the clock needs the one word
-   the tag cannot supply. */
-.cl-mx-head .clk .ago {
-  font-style: normal;
-  font-size: 9px;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: var(--cl-ink-4);
-}
-
-/* ── Who ── */
-.cl-mx-who {
-  margin-top: 11px;
-}
 .cl-mx-who h3 {
-  margin: 0;
+  margin: 8px 0 0;
   font-family: var(--font-sans);
-  font-size: 15px;
+  font-size: 18px;
   font-weight: 600;
-  letter-spacing: -0.02em;
-  line-height: 1.2;
+  letter-spacing: -0.028em;
+  line-height: 1.12;
   color: var(--cl-ink);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -16195,9 +16385,9 @@ select.cl-opt-input {
 }
 .cl-mx-who .ident {
   display: block;
-  margin-top: 2px;
+  margin-top: 3px;
   font-family: var(--font-mono);
-  font-size: 10.5px;
+  font-size: 10px;
   color: var(--cl-ink-3);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -16228,18 +16418,44 @@ select.cl-opt-input {
   font-style: normal;
   opacity: 0.55;
 }
+/* The cell's one large figure, and it answers one question in every state: how
+   long it has been in THIS state. */
+.cl-mx-head .clk {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 5px;
+  font-family: var(--font-mono);
+  font-size: 26px;
+  line-height: 1;
+  letter-spacing: -0.04em;
+  font-variant-numeric: tabular-nums;
+  color: var(--cl-ink);
+}
+.cl-mxcell[data-state='ready'] .clk,
+.cl-mxcell[data-state='ended'] .clk {
+  color: var(--cl-ink-3);
+}
+/* For a cell that has ended, that state is over: the clock needs the one word
+   the tag cannot supply. */
+.cl-mx-head .clk .ago {
+  font-style: normal;
+  font-size: 9px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--cl-ink-4);
+}
 
 /* ── NOW: what it is doing this second ──
-   Its own inset block, not the first row of the list below it. What a process is
-   doing right now and what it did are different kinds of claim, and printing
-   them as one list made the newest row look like history that happened to be at
-   the top. One line, ellipsized: the subject is the freest string on the card
-   and must never be the reason a card is taller than its neighbour. */
+   Its own inset block, not a row of the ribbon below it. What a process is doing
+   right now and what it did are different kinds of claim, and the ribbon cannot
+   make the first one at all — it has shape, not words. One line, ellipsized: the
+   subject is the freest string in the cell and must never be the reason one cell
+   is taller than its neighbour. */
 .cl-mx-now {
   display: flex;
   align-items: baseline;
   gap: 8px;
-  margin-top: 11px;
+  margin-top: 12px;
   padding: 8px 10px;
   border-radius: 9px;
   background: var(--cl-paper-2);
@@ -16265,108 +16481,54 @@ select.cl-opt-input {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-/* An ended card is already on paper-2: the inset needs the other surface or it
+/* An ended cell is already on paper-2: the inset needs the other surface or it
    disappears into its own background. */
-.cl-mx[data-state='ended'] .cl-mx-now {
+.cl-mxcell[data-state='ended'] .cl-mx-now {
   background: var(--cl-paper);
 }
-.cl-mx[data-state='blocked'] .cl-mx-now {
-  background: color-mix(in oklch, var(--cl-accent) 9%, var(--cl-paper));
-}
-.cl-mx[data-state='blocked'] .cl-mx-now b {
-  color: var(--cl-accent-ink);
-}
 
-/* ── The slot: what it did, newest first ──
-   THREE ROWS, ALWAYS. A row with nothing to say is drawn as a rule rather than
-   left out, which is what makes every card the same height — the one thing the
-   previous form could not do, since its body grew a line per tool call. Fixed
-   columns so the ages line up down the left and the tool names down the middle:
-   a tape you can scan by column is the difference between a log and a list of
-   sentences. */
-.cl-mx-slot {
-  margin: 10px 0 0;
-  padding: 0;
-  list-style: none;
+/* ── The ribbon: what it did, as shape ──
+   Runs of tool-tinted blocks on a 2.5-minute axis, oldest at the left. The tint
+   is `TOOL_TINT` — the transcript's own tool encoding — so a lane of cyan is a
+   session reading and a lane of violet one editing, and the width of a block is
+   how long that stretch of work lasted.
+
+   The hairline underneath is what makes it a LANE rather than a scatter of
+   marks: without it a session with two calls in two minutes has nothing to be
+   sparse against, and the empty right-hand end — which is the whole picture of
+   a session that has gone quiet — reads as blank page instead of as silence. */
+.cl-mx-ribbon {
+  position: relative;
+  margin-top: 12px;
+  min-height: 22px;
+}
+.cl-mx-ribbon::after {
+  content: '';
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 1px;
+  background: var(--cl-line-soft);
+}
+.cl-mx-ribbon i {
+  position: absolute;
+  top: 4px;
+  bottom: 5px;
+  border-radius: 1px;
+  opacity: 0.9;
+}
+/* A failed call takes the danger hue instead of its tool's: the tint answers
+   "what kind of work", and a call that came back an error outranks that. */
+.cl-mx-ribbon i.failed {
+  opacity: 1;
+}
+/* "No transcript to tail" is not the same claim as "did nothing", and only one
+   of the two can be fixed by waiting — so a lane that cannot exist says so, and
+   an empty one says the other thing. */
+.cl-mx-ribbon .none {
+  display: block;
   font-family: var(--font-mono);
-  font-size: 10.5px;
-}
-.cl-mx-slot li {
-  display: grid;
-  grid-template-columns: 26px 5px auto minmax(0, 1fr) auto;
-  align-items: center;
-  gap: 0 7px;
-  height: 18px;
-  color: var(--cl-ink-3);
-}
-.cl-mx-slot .when {
-  text-align: right;
-  font-size: 9px;
-  letter-spacing: 0.02em;
-  color: var(--cl-ink-4);
-  font-variant-numeric: tabular-nums;
-}
-/* The tint column. `TOOL_TINT` — the transcript's own tool encoding — on a 5px
-   swatch rather than on the tool's name: colouring text you have to read is
-   worse than colouring a marker beside it, and the swatches stack into a column
-   that gives each card the signature of the kind of work it is doing. A run of
-   cyan is a session reading, violet a session editing. */
-.cl-mx-slot .dot {
-  width: 5px;
-  height: 5px;
-  border-radius: 1.5px;
-}
-.cl-mx-slot b {
-  font-weight: 500;
-  color: var(--cl-ink-2);
-  white-space: nowrap;
-}
-/* The subject truncates rather than wrapping: inside a fixed row it is the one
-   string that could otherwise push the card past its frame. */
-.cl-mx-slot .arg {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-/* One trailing cell for every verdict a row can carry — `×3`, `✕`, `+2` — so two
-   of them never fight over the same column. */
-.cl-mx-slot .mark {
-  grid-column: 5;
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  font-style: normal;
-}
-.cl-mx-slot .times,
-.cl-mx-slot .more {
-  font-style: normal;
-  font-size: 9px;
-  color: var(--cl-ink-4);
-}
-.cl-mx-slot .x {
-  font-style: normal;
-  font-size: 9.5px;
-  color: var(--cl-danger);
-}
-.cl-mx-slot li.failed b {
-  color: var(--cl-danger);
-}
-/* The ruled empty row. It is deliberately visible: a blank gap would read as the
-   card having ended early, where a rule reads as a line nothing has been written
-   on yet — the same thing ruled paper says. */
-.cl-mx-slot li.rule {
-  display: block;
-}
-.cl-mx-slot li.rule i {
-  display: block;
-  margin: 8px 0 0 33px;
-  border-top: 1px dotted var(--cl-line);
-}
-/* An agent's note: "no transcript to tail" is not the same claim as "it did
-   nothing", and only one of the two can be fixed by waiting. */
-.cl-mx-slot li.none {
-  display: block;
-  padding-left: 33px;
   font-size: 9.5px;
   line-height: 18px;
   font-style: italic;
@@ -16383,6 +16545,7 @@ select.cl-opt-input {
   align-items: center;
   flex-wrap: wrap;
   gap: 5px 12px;
+  margin-top: 12px;
   padding-top: 10px;
   border-top: 1px solid var(--cl-line-soft);
   font-family: var(--font-mono);
@@ -16448,15 +16611,12 @@ select.cl-opt-input {
   font-variant-numeric: tabular-nums;
   color: var(--cl-ink);
 }
-/* No `margin-left: auto` here any more: on a card this narrow the row can take a
+/* No `margin-left: auto` here any more: in a cell this narrow the row can take a
    second line, and an item pushed to the right edge of a wrapped line reads as
    belonging to nothing. Left to right, in the order they were decided: the
    measures first, then what they mean. */
 .cl-mx-vitals .quiet {
   white-space: nowrap;
-}
-.cl-mx[data-state='blocked'] .cl-mx-vitals .quiet {
-  color: var(--cl-accent-ink);
 }
 .cl-mx-vitals .vol {
   overflow: hidden;
@@ -16465,7 +16625,7 @@ select.cl-opt-input {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .cl-mx[data-state='blocked'] .tag i,
+  .cl-mxband .cl-eyebrow .pip,
   .cl-mxtop .cl-eyebrow .pip.live {
     animation: none;
   }

--- a/test/monitor-view.test.tsx
+++ b/test/monitor-view.test.tsx
@@ -18,7 +18,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, cleanup, waitFor, fireEvent } from '@testing-library/react';
 
 import { MonitorView } from '../src/components/project/monitor/MonitorView';
-import { buildTape } from '../src/components/project/monitor/trace';
+import { buildRibbon, RIBBON_CELLS } from '../src/components/project/monitor/trace';
 import { installFakeElectronAPI, ok, type FakeBridge } from './helpers/fake-electron-api';
 import type { ActiveSession, SessionActivity, BgSession } from '../src/types';
 
@@ -223,9 +223,27 @@ describe('MonitorView', () => {
     const view = mount();
 
     expect(await screen.findByText('permission prompt')).toBeTruthy();
-    expect(screen.getByText('NEEDS YOU')).toBeTruthy();
-    expect(view.container.querySelector('[data-state="blocked"]')).toBeTruthy();
+    // It is not a cell of the grid at all: what is blocked gets the band.
+    expect(view.container.querySelector('.cl-mxband[data-state="blocked"]')).toBeTruthy();
+    expect(view.container.querySelector('.cl-mxcell')).toBeNull();
+    expect(screen.getByText(/Needs you/)).toBeTruthy();
     expect(view.container.querySelector('[data-state="working"]')).toBeNull();
+  });
+
+  // The band's one action. Deliberately not labelled "Reply in terminal": the
+  // prompt is waiting in the user's own shell, and nothing in this app can
+  // answer it — the button says what it actually does.
+  it('routes from the band to the blocked session, saying only what it does', async () => {
+    bridge.api.live.getActiveSessions.mockResolvedValue(
+      ok([activeSession({ status: 'waiting', waitingFor: 'permission prompt' })])
+    );
+    bridge.api.live.getActivity.mockResolvedValue(ok([activity()]));
+    mount();
+
+    fireEvent.click(await screen.findByText('Open session ↗'));
+
+    expect(onOpenSession).toHaveBeenCalledWith(PROJECT, 'sess-1');
+    expect(screen.queryByText(/Reply in terminal/)).toBeNull();
   });
 
   it('sorts what needs you ahead of what is merely running', async () => {
@@ -244,7 +262,11 @@ describe('MonitorView', () => {
     const view = mount();
     await screen.findByText('beta');
 
-    const names = [...view.container.querySelectorAll('.cl-mx-who h3')].map(n => n.textContent);
+    // Document order across both tiers: the band comes before the grid, so the
+    // blocked project leads whatever the sort does inside the cells.
+    const names = [...view.container.querySelectorAll('.cl-mxband .proj, .cl-mxcell h3')].map(
+      n => n.textContent
+    );
     expect(names).toEqual(['beta', 'acme']);
   });
 
@@ -563,15 +585,16 @@ describe('MonitorView', () => {
 
     expect(screen.getByText('no transcript to tail')).toBeTruthy();
     expect(screen.getByText('open in Agent View ↗')).toBeTruthy();
-    // The note takes a slot row; the rest stay ruled, so the card is the same
-    // height as one that has a transcript to show.
-    expect(view.container.querySelectorAll('.cl-mx-slot li')).toHaveLength(3);
-    expect(view.container.querySelectorAll('.cl-mx-slot li.rule')).toHaveLength(2);
+    // The note takes the lane's place; no blocks are drawn, because an empty
+    // lane would say "did nothing" about work this page simply cannot see.
+    expect(view.container.querySelectorAll('.cl-mx-ribbon i')).toHaveLength(0);
+    expect(screen.queryByText(/nothing in the last/)).toBeNull();
   });
 
-  // The card says what the session is doing NOW in its own block, and what it
-  // did in the slot below it. The in-flight call must never appear in both.
-  it('prints the tape of what it did, with subjects, and never twice', async () => {
+  // The cell says what the session is doing NOW in words, and what it did as
+  // shape. The two claims must not be confused: the ribbon has no names in it,
+  // so the NOW line is the only place a tool is ever spelled out.
+  it('draws what the session did as a lane of tool-tinted blocks', async () => {
     const now = Date.now();
     bridge.api.live.getActiveSessions.mockResolvedValue(ok([activeSession()]));
     bridge.api.live.getActivity.mockResolvedValue(
@@ -596,83 +619,63 @@ describe('MonitorView', () => {
     const view = mount();
     await screen.findByText('acme');
 
-    const label = (n: Element) =>
-      [...n.querySelectorAll('b, .arg')].map(c => c.textContent).join(' ');
-    // NOW is its own block, not the first row of the history.
-    expect(label(view.container.querySelector('.cl-mx-now')!)).toBe('Bash npm test');
-    // The history, newest first — and `Bash npm test` is not repeated in it.
-    expect([...view.container.querySelectorAll('.cl-mx-slot li:not(.rule)')].map(label)).toEqual([
-      'Bash npm run typecheck',
-      'Edit trace.ts',
-      'Read src/index.css',
+    // NOW is words, in its own block.
+    const nowBlock = view.container.querySelector('.cl-mx-now')!;
+    expect([...nowBlock.querySelectorAll('b, .arg')].map(n => n.textContent)).toEqual([
+      'Bash',
+      'npm test',
     ]);
-    // Only the call whose result came back an error.
-    expect(view.container.querySelectorAll('.cl-mx-slot li.failed')).toHaveLength(1);
+    // Four calls at four moments, so four blocks — left to right, oldest first.
+    const blocks = [...view.container.querySelectorAll('.cl-mx-ribbon i')];
+    expect(blocks).toHaveLength(4);
+    const lefts = blocks.map(b => parseFloat((b as HTMLElement).style.left));
+    expect([...lefts].sort((a, b) => a - b)).toEqual(lefts);
+    // Only the call whose result came back an error is marked, and it takes the
+    // danger hue instead of its tool's.
+    const failed = blocks.filter(b => b.classList.contains('failed'));
+    expect(failed).toHaveLength(1);
+    expect((failed[0] as HTMLElement).style.background).toContain('--cl-danger');
   });
 
-  // The whole point of the fixed form. A session that has run ten tools and one
-  // that has run one are the same size on the page: the slot is three rows
-  // either way, and the empty ones are ruled rather than left out.
-  it('draws the same three rows whether the session did ten things or one', async () => {
-    const now = Date.now();
-    bridge.api.live.getActiveSessions.mockResolvedValue(
-      ok([
-        activeSession({ sessionId: 'busy', pid: 1 }),
-        activeSession({ sessionId: 'calm', pid: 2 }),
-      ])
-    );
-    bridge.api.live.getActivity.mockResolvedValue(
-      ok([
-        activity({
-          sessionId: 'busy',
-          lastTool: null,
-          recent: Array.from({ length: 10 }, (_, i) => ({
-            at: now - (10 - i) * 5_000,
-            kind: 'tool' as const,
-            tool: 'Edit',
-            arg: `f${i}.ts`,
-          })),
-        }),
-        activity({
-          sessionId: 'calm',
-          lastTool: null,
-          recent: [{ at: now - 4_000, kind: 'tool', tool: 'Read', arg: 'a.ts' }],
-        }),
-      ])
-    );
-    const view = mount();
-    await screen.findAllByText('acme');
-
-    const slots = [...view.container.querySelectorAll('.cl-mx-slot')];
-    expect(slots.map(slot => slot.querySelectorAll('li').length)).toEqual([3, 3]);
-    // The busy one fills its three; the calm one rules the two it cannot fill.
-    expect(slots.map(slot => slot.querySelectorAll('li.rule').length)).toEqual([0, 2]);
-  });
-
-  // Three of eleven actions, printed silently, would read as a calm session.
-  it('says how many actions it is not showing', async () => {
-    const now = Date.now();
+  // A lane with nothing in it and a lane that cannot exist are different
+  // claims, and only one of the two is fixed by waiting.
+  it('says the last two minutes were empty rather than drawing a blank lane', async () => {
     bridge.api.live.getActiveSessions.mockResolvedValue(ok([activeSession()]));
-    bridge.api.live.getActivity.mockResolvedValue(
-      ok([
-        activity({
-          lastTool: null,
-          recent: Array.from({ length: 11 }, (_, i) => ({
-            at: now - (11 - i) * 5_000,
-            kind: 'tool' as const,
-            tool: 'Edit',
-            arg: `f${i}.ts`,
-          })),
-        }),
-      ])
-    );
+    bridge.api.live.getActivity.mockResolvedValue(ok([activity({ recent: [] })]));
     const view = mount();
     await screen.findByText('acme');
 
-    expect(screen.getByText('+8')).toBeTruthy();
-    // On the last row, where it reads as the end of the list — not the top.
-    const rows = [...view.container.querySelectorAll('.cl-mx-slot li')];
-    expect(rows[2].querySelector('.more')?.textContent).toBe('+8');
+    expect(screen.getByText(/nothing in the last 2.5 min/)).toBeTruthy();
+    expect(view.container.querySelectorAll('.cl-mx-ribbon i')).toHaveLength(0);
+  });
+
+  // The one figure no cell carries any more: what the machine as a whole is
+  // burning. Per session the token count was a second figure competing with the
+  // bill; summed over every live process it is the only reading of scale.
+  it('totals the whole machine in the header, and only what was reported', async () => {
+    bridge.api.live.getActiveSessions.mockResolvedValue(
+      ok([activeSession({ sessionId: 'a', pid: 1 }), activeSession({ sessionId: 'b', pid: 2 })])
+    );
+    bridge.api.live.getActivity.mockResolvedValue(
+      ok([
+        activity({ sessionId: 'a', spend: 1.2, tokens: 400_000 }),
+        activity({ sessionId: 'b', spend: 3.3, tokens: 840_000 }),
+      ])
+    );
+    const view = mount();
+    await waitFor(() =>
+      expect(view.container.querySelector('.cl-mxtop-tot')?.textContent).toBe('$4.50 · 1.2m tokens')
+    );
+  });
+
+  it('prints no machine total when nothing has reported one', async () => {
+    bridge.api.live.getSessions.mockResolvedValue(ok([bgSession()]));
+    const view = mount();
+    await screen.findByText('agent docs-sweeper');
+
+    // A background agent carries neither usage nor a bill, and `$0.00 · 0
+    // tokens` beside a worker burning tokens would be the one wrong figure here.
+    expect(view.container.querySelector('.cl-mxtop-tot')).toBeNull();
   });
 
   // CONTEXT is the one fact on this page you can only act on while the session
@@ -783,78 +786,77 @@ describe('MonitorView', () => {
   });
 });
 
-// The tape is the card's body and the reason the form is not empty: it says what
-// the session DID, with the subject of each action. Worth pinning: what counts as
-// one step, which end survives the cap, and that the in-flight call is never
-// printed twice.
-describe('buildTape', () => {
+// The ribbon is what a cell says about the past, and it says it in shape rather
+// than words. Worth pinning: where a mark lands on the axis, what counts as one
+// block, and what falls outside the window entirely.
+describe('buildRibbon', () => {
   const NOW = 1_800_000_000_000;
-  const mark = (secondsAgo: number, tool: string, arg = '', failed = false) => ({
+  const CELL_MS = 150_000 / RIBBON_CELLS;
+  const mark = (secondsAgo: number, tool: string, failed = false) => ({
     at: NOW - secondsAgo * 1000,
     kind: 'tool' as const,
     tool,
-    arg,
+    arg: '',
     ...(failed ? { failed } : {}),
   });
 
-  it('reads newest first, with the subject of each action', () => {
-    const tape = buildTape([mark(40, 'Read', 'src/index.css'), mark(10, 'Edit', 'trace.ts')], NOW);
-    expect(tape.map(s => [s.tool, s.arg])).toEqual([
-      ['Edit', 'trace.ts'],
-      ['Read', 'src/index.css'],
-    ]);
+  it('lays the window out oldest to newest, left to right', () => {
+    const runs = buildRibbon([mark(140, 'Read'), mark(10, 'Edit')], NOW);
+    expect(runs.map(r => r.tool)).toEqual(['Read', 'Edit']);
+    expect(runs[0].left).toBeLessThan(runs[1].left);
+    // The oldest call sits near the left edge, the newest near the right.
+    expect(runs[0].left).toBeLessThan(10);
+    expect(runs[1].left).toBeGreaterThan(90);
   });
 
-  // The newest mark IS the call the card is already printing as its `now` row.
-  // Without this the card shows the same action twice, once as "now" and once as
-  // the top of its own history.
-  it('drops the in-flight call when the card is already printing it', () => {
-    const marks = [mark(30, 'Read', 'a.ts'), mark(2, 'Bash', 'npm test')];
-    expect(buildTape(marks, NOW, { dropNewest: true }).map(s => s.tool)).toEqual(['Read']);
-    expect(buildTape(marks, NOW).map(s => s.tool)).toEqual(['Bash', 'Read']);
+  // A retry loop is one stretch of work, not three marks: contiguous cells of
+  // one tool are a single block, and its width is how long it went on.
+  it('collapses a contiguous run of one tool into a single block', () => {
+    const at = (cell: number) => ({
+      at: NOW - 150_000 + cell * CELL_MS + CELL_MS / 2,
+      kind: 'tool' as const,
+      tool: 'Bash',
+      arg: '',
+    });
+    const runs = buildRibbon([at(10), at(11), at(12)], NOW);
+    expect(runs).toHaveLength(1);
+    expect(runs[0].width).toBeGreaterThan((1 / RIBBON_CELLS) * 100);
   });
 
-  // A retry loop is one thing happening three times, not three pieces of work.
-  it('collapses an exact repeat and dates the row by its oldest call', () => {
-    const tape = buildTape(
-      [mark(30, 'Bash', 'npm test'), mark(20, 'Bash', 'npm test'), mark(10, 'Bash', 'npm test')],
+  it('keeps two different tools apart, with a gap between them', () => {
+    const at = (cell: number, tool: string) => ({
+      at: NOW - 150_000 + cell * CELL_MS + CELL_MS / 2,
+      kind: 'tool' as const,
+      tool,
+      arg: '',
+    });
+    const runs = buildRibbon([at(20, 'Read'), at(21, 'Edit')], NOW);
+    expect(runs.map(r => r.tool)).toEqual(['Read', 'Edit']);
+    expect(runs[0].left + runs[0].width).toBeLessThan(runs[1].left);
+  });
+
+  // A verdict on the run, so a lane whose blocks are all one tint still shows
+  // where it went wrong.
+  it('carries a failure onto its block', () => {
+    const runs = buildRibbon([mark(10, 'Bash', true)], NOW);
+    expect(runs[0].failed).toBe(true);
+  });
+
+  // Prose has no tool, so it has no tint: a grey block between two edits would
+  // read as a tool nobody can name.
+  it('leaves prose off the lane', () => {
+    const runs = buildRibbon(
+      [mark(100, 'Edit'), { at: NOW - 50_000, kind: 'text' as const }, mark(10, 'Edit')],
       NOW
     );
-    expect(tape).toHaveLength(1);
-    expect(tape[0].count).toBe(3);
-    // The row says when the loop started, not when it last spun.
-    expect(tape[0].at).toBe(NOW - 30_000);
-  });
-
-  it('keeps two different subjects apart even for the same tool', () => {
-    const tape = buildTape([mark(20, 'Edit', 'a.ts'), mark(10, 'Edit', 'b.ts')], NOW);
-    expect(tape.map(s => s.arg)).toEqual(['b.ts', 'a.ts']);
-  });
-
-  it('carries a failure onto its row', () => {
-    const tape = buildTape([mark(10, 'Bash', 'npm test', true)], NOW);
-    expect(tape[0].failed).toBe(true);
-  });
-
-  // Prose marks the trace but is not a step of the story: a `text` mark between
-  // two edits would break the sequence in half without adding anything to act on.
-  it('leaves prose off the tape', () => {
-    const tape = buildTape(
-      [
-        mark(30, 'Edit', 'a.ts'),
-        { at: NOW - 20_000, kind: 'text' as const },
-        mark(10, 'Edit', 'b.ts'),
-      ],
-      NOW
-    );
-    expect(tape.map(s => s.tool)).toEqual(['Edit', 'Edit']);
+    expect(runs.map(r => r.tool)).toEqual(['Edit', 'Edit']);
   });
 
   it('ignores marks outside the window instead of clamping them into it', () => {
     expect(
-      buildTape(
+      buildRibbon(
         [
-          mark(9_000, 'Read', 'old.ts'), // long before the window starts
+          mark(9_000, 'Read'), // long before the window starts
           { at: NOW + 5_000, kind: 'tool' as const, tool: 'Bash' }, // clock skew
         ],
         NOW
@@ -862,14 +864,10 @@ describe('buildTape', () => {
     ).toEqual([]);
   });
 
-  // The cap lives on the card, not here: the slot prints three and has to say
-  // how many it is leaving out, which it can only do if this hands over the
-  // whole story. Newest first, so the rows the card keeps are the newest.
-  it('returns the whole window, newest first, and caps nothing', () => {
-    const marks = Array.from({ length: 10 }, (_, i) => mark(90 - i * 5, 'Edit', `f${i}.ts`));
-    const tape = buildTape(marks, NOW);
-    expect(tape).toHaveLength(10);
-    expect(tape[0].arg).toBe('f9.ts');
-    expect(tape[9].arg).toBe('f0.ts');
+  // Two blocks a hairline wide are a rendering artefact, not a reading.
+  it('never draws a block thinner than it can be seen', () => {
+    for (const run of buildRibbon([mark(75, 'Read')], NOW)) {
+      expect(run.width).toBeGreaterThanOrEqual(0.9);
+    }
   });
 });


### PR DESCRIPTION
## Highlights

Design handoff **_Monitor Variants_, option 2b**: the Monitor stops being a rack of identical cards and gets two tiers, because the level should come from the construction rather than from a border.

- **Whatever is blocked leaves the grid and becomes a full-bleed dark band** — pulsing accent eyebrow carrying the silence, the question it waits on at display size, identity demoted to one mono line (`project · title · pid · model · uptime`), and the accent clock counting how long you have been the bottleneck. Fixed dark in both themes, like the stat strip's live cell. It is the page's only raised surface and the only thing that pulses.
- **Everything else is a hairline grid with no card borders at all** — three fixed columns (then two, then one), cells defined only by the rules between them.
- **The three-row textual tape becomes a ribbon** — runs of tool-tinted blocks on a 2.5-minute axis.
- **The header gains a machine-wide total** (`$4.50 · 1.2m tokens`), the one place a token count survives.

## Why

The uniform index card (#221) fixed the ragged rack, but it also claimed that a session waiting on **you** and a session quietly editing a file are the same size of news — which is the one thing this page exists to deny, and why the blocked card needed a 1.5px accent edge to be read first. Once the blocked process has a surface of its own, everything left is by definition the normal case and none of it has to shout.

This is the third time a dark surface has been tried here and the first time it works: the two that failed made it the **default**, and a wide dark band holding five short strings is empty by construction. As the exception, running edge to edge, what fills it is the one string on the page long enough to earn display size.

## Notes

**The grid.** Columns are fixed rather than `auto-fill` because the first and last carry the page gutter — with `auto-fill` there is no way to say "the cell at the edge" and the grid would start 32px in from a header that starts at the gutter. Cells rule **downwards** (`border-bottom`), since the header already closes itself with a 1.5px ink rule and a hairline immediately under it reads as that rule fraying; ruling down also closes the last row.

**The ribbon** (`buildTape` → `buildRibbon`). The window is cut into 48 cells, each `TraceMark` lands in the cell of its timestamp, and contiguous cells of one tool collapse into a single block — a retry loop is one long block, a session hammering three tools is three short ones, and a quiet session is an empty right-hand end, which is the "is this hung?" question the printed rows answered in prose. Tinted with `TOOL_TINT`; a failed call takes the danger hue instead of its tool's, since the tint answers "what kind of work" and an error outranks that. The hairline under the lane is what makes it a lane: without it a session with two calls in two minutes has nothing to be sparse against.

**What this costs.** The textual tape is what 2b replaces in that slot, so the history is no longer in words (`Edit trace.ts`, `Bash npm run typecheck ✕`). The NOW line still is — the claim shape can never make. The design itself offers the tape back as a next step ("aggiungi il tape di 1e nelle card"): that is one more block in the cell, not a redesign.

**Two deliberate departures from the mock,** both because it omits rather than replaces:

- the **machine row stays on the cell** (the mock keeps it for the band alone). The pid is what you need to `kill`, and a fact that only exists in the state you are already acting on is a fact you cannot use;
- the **band carries the ribbon and vitals**. The session you are about to unblock is exactly where "how full is the window" and "what has this cost" change what you do, and a flat right-hand end of the lane is the picture of what `blocked for` says in figures.

**Honest labels.** The band's button says `Open session ↗`, not the mock's `Reply in terminal ↗`: the prompt is waiting in the user's own shell and nothing in this app can answer it. The per-cell token count stays gone and survives once as the header total, where it stops being a second copy of the bill; both halves are omitted when nothing reported them, and ended sessions are excluded — a finished session is not burning anything.

**Contrast.** The band re-binds `--cl-accent` / `--cl-warn` / `--cl-danger` / `--cl-ok` to the lifts the dark theme already declares (same hues, higher lightness). No new colours: `--cl-accent` at L 0.575 on a surface at L 0.205 is ~3.9:1, which passes for the 52px clock and fails for the 9.5px eyebrow and the 11.5px button beside it.

## Testing

`typecheck` + `lint` (`--max-warnings 0`) + `format:check` + `build` clean; `npm test` 66 files pass. `test/monitor-view.test.tsx` extended: band vs grid (a blocked session renders no cell at all), routing from the band's button, the ribbon and its separation from the NOW line, an empty lane vs a lane that cannot exist, the machine total and its absence, and `describe('buildRibbon')` in place of `buildTape`.

Layout and styling have no automated coverage here — the visual pass is manual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)