### PR TITLE
test: make every test an independent claim, and randomise the order

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,16 @@ and the chat `utils`.
 real Agent SDK (files on disk, no model turn, no API key): they pin the transcript
 read path, the `dir` narrowing hint and its empty-result fallback, and the read
 cache's invalidation. CI (`.github/workflows/ci.yml`) runs format:check +
-typecheck + lint + test + build on every push/PR. The style gate is strict:
+typecheck + lint + test + build on every push/PR. **Test order is randomised**
+(`sequence.shuffle` in `vitest.config.ts`): every `it` has to be an independent
+claim, and three files had quietly stopped being that — one test created the
+workflow the next edited, another appended to a transcript a later one measured,
+a third left an entry in `cost-tracker`'s append-only parse cache under a path it
+then rewrote with different content. Each passed in file order and failed as soon
+as two tests swapped places. So a fixture belongs in `beforeEach`, never in the
+test that happens to run first, and module-level state (`resetParseCache`,
+`resetSessionTails`, `resetSessionReadCache`, …) is reset there too. A red CI run
+is reproduced with the seed it prints: `npx vitest run --sequence.seed=<n>`. The style gate is strict:
 Prettier formatting is enforced repo-wide and `lint` runs with
 `--max-warnings 0`, so a new warning fails the build — fix it or add an inline
 `eslint-disable` with a reason. `typecheck` covers three projects: the renderer,

--- a/test/session-sdk-cache.test.ts
+++ b/test/session-sdk-cache.test.ts
@@ -82,6 +82,22 @@ beforeAll(() => {
   mkdirSync(join(projDir, SESSION_ID, 'subagents'), { recursive: true });
 
   transcript = join(projDir, `${SESSION_ID}.jsonl`);
+  subagentTranscript = join(projDir, SESSION_ID, 'subagents', `agent-${AGENT_ID}.jsonl`);
+  source = { projectDir: projDir, cwd: CWD };
+});
+
+/**
+ * The transcripts every test reads, back at their starting length.
+ *
+ * They are fixtures, not accumulated state — but two tests here append to
+ * them on purpose (that IS what they assert: a grown transcript must
+ * invalidate its cache), and what they leave behind changed the answer for
+ * whoever ran next. In file order the growers happen to run last; reordered,
+ * a sub-agent that had answered once reported two messages. Written from
+ * `beforeEach` alongside the cache resets, so each test starts from the same
+ * disk as well as the same cache.
+ */
+function writeFixtures(): void {
   writeFileSync(
     transcript,
     jsonl([
@@ -94,7 +110,6 @@ beforeAll(() => {
     ])
   );
 
-  subagentTranscript = join(projDir, SESSION_ID, 'subagents', `agent-${AGENT_ID}.jsonl`);
   writeFileSync(
     subagentTranscript,
     jsonl([
@@ -127,11 +142,10 @@ beforeAll(() => {
       assistantLine('n2', 'n1', [{ type: 'text', text: 'answered directly' }]),
     ])
   );
-
-  source = { projectDir: projDir, cwd: CWD };
-});
+}
 
 beforeEach(() => {
+  writeFixtures();
   resetSessionReadCache();
   resetSubagentsCache();
 });

--- a/test/session-tails-seed.test.ts
+++ b/test/session-tails-seed.test.ts
@@ -50,6 +50,10 @@ vi.mock('../electron/modules/cost-tracker', async () => {
 });
 
 const tails = await import('../electron/modules/session-tails');
+// See the note in `session-tails.test.ts`: the seed reads through cost-tracker's
+// parse cache, and these tests rewrite one path with different content, which is
+// the one thing an append-only cache may not be asked to survive.
+const { resetParseCache } = await import('../electron/modules/cost-tracker');
 const { syncSessionTails, onTranscriptChanged, getSessionActivity, resetSessionTails } = tails;
 type ActiveSession = import('../electron/modules/sessions-registry-reader').ActiveSession;
 
@@ -68,6 +72,7 @@ function transcript(content: string): string {
 
 beforeEach(() => {
   resetSessionTails();
+  resetParseCache();
   written.length = 0;
   rmSync(projectsDir, { recursive: true, force: true });
   mkdirSync(projectsDir, { recursive: true });

--- a/test/session-tails.test.ts
+++ b/test/session-tails.test.ts
@@ -8,6 +8,17 @@ const configDir = mkdtempSync(join(homedir(), '.cl-tails-test-'));
 process.env.CLAUDE_CONFIG_DIR = configDir;
 
 const tails = await import('../electron/modules/session-tails');
+// The spend seed runs through cost-tracker's parse cache, which is module state
+// this file shares across its tests — and it is keyed on the assumption that a
+// transcript only ever grows. These tests rewrite the SAME path with different
+// content, which breaks that assumption: a shorter parse left cached under the
+// path, then a longer file written over it, and the incremental read resumes at
+// an offset that now falls mid-line, folding a fragment into nothing. Real
+// transcripts are append-only, so the cache is right and the fixture is the odd
+// one out; it just has to leave no state behind. Without this the file passed
+// only in its declared order (`--sequence.shuffle --sequence.seed=42` was enough
+// to reorder two tests and report a seeded session's spend as zero).
+const { resetParseCache } = await import('../electron/modules/cost-tracker');
 const {
   toolArg,
   foldEvents,
@@ -115,6 +126,7 @@ const EMPTY: SessionActivity = {
 
 beforeEach(() => {
   resetSessionTails();
+  resetParseCache();
   rmSync(projectsDir, { recursive: true, force: true });
   mkdirSync(projectsDir, { recursive: true });
 });

--- a/test/studio-io.test.ts
+++ b/test/studio-io.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterAll } from 'vitest';
+import { describe, it, expect, afterAll, beforeEach } from 'vitest';
 import { mkdtempSync, mkdirSync, rmSync, readFileSync, existsSync, writeFileSync } from 'fs';
 import { homedir } from 'os';
 import { join } from 'path';
@@ -15,6 +15,23 @@ const compiler = await import('../electron/modules/studio-compiler');
 afterAll(() => {
   delete process.env.CLAUDE_CONFIG_DIR;
   rmSync(configDir, { recursive: true, force: true });
+});
+
+// The workflows dir IS the state under test here — the modules keep none of
+// their own, the `.js` files on disk are the source of truth — so a test that
+// leaves one behind is setting up the next one. Several did: the duplicate-name
+// check and the visual save both read the script the first test creates, and the
+// project-scope block wrote a blueprint in one test, listed it in the second and
+// deleted it in the last. That reads as a story and passes in file order, but
+// each `it` is supposed to be its own claim; reordering them (a plain
+// `--sequence.shuffle`) turned four of them red. Wipe the dir before each test
+// and let every test state its own precondition.
+beforeEach(() => {
+  rmSync(join(configDir, 'workflows'), { recursive: true, force: true });
+  // Recreated empty rather than just removed: several tests drop a `.js` in
+  // there with a plain `writeFileSync`, which until now relied on an earlier
+  // test's `createBlueprint` having made the directory.
+  mkdirSync(join(configDir, 'workflows'), { recursive: true });
 });
 
 function blueprint(name = 'release-triage'): Blueprint {
@@ -38,6 +55,29 @@ function blueprint(name = 'release-triage'): Blueprint {
   };
 }
 
+/** A representable native script, written straight to disk with no ClaudeLens
+ *  involvement — the shape the reader has to project, and the file the
+ *  raw-source tests edit. Shared because both blocks need it on disk; it used to
+ *  be left there by whichever test ran first. */
+const EXTERNAL_REVIEW = `export const meta = {
+  name: "external-review",
+  description: "review a patch",
+  whenToUse: "Inspect a supplied patch",
+  phases: [{ title: "Review" }],
+}
+
+phase("Review")
+const reviewer = await agent(\`Review \${args}\`, { label: "reviewer", model: "sonnet" })
+
+return reviewer
+`;
+
+function writeGlobalScript(fileName: string, source: string): string {
+  const path = join(configDir, 'workflows', fileName);
+  writeFileSync(path, source, 'utf-8');
+  return path;
+}
+
 function firstStep(bp: Blueprint | null | undefined) {
   const node = bp?.phases[0]?.nodes[0];
   return node?.kind === 'step' ? node.step : undefined;
@@ -59,6 +99,7 @@ describe('script-only Agent Studio persistence', () => {
   });
 
   it('refuses duplicate creation and traversal names', async () => {
+    await writer.createBlueprint(blueprint());
     await expect(writer.createBlueprint(blueprint())).rejects.toThrow(/already exists/);
     await expect(writer.saveBlueprint(blueprint('../evil'))).rejects.toThrow(
       /Invalid workflow name/
@@ -69,6 +110,7 @@ describe('script-only Agent Studio persistence', () => {
   });
 
   it('saves visual edits back to the same script file', async () => {
+    await writer.createBlueprint(blueprint());
     const changed = (await reader.readBlueprint('release-triage'))!;
     firstStep(changed)!.prompt = 'Collect carefully for ${args}';
     const result = await writer.saveBlueprint(changed, 'release-triage.js');
@@ -109,19 +151,8 @@ describe('script-only Agent Studio persistence', () => {
 
 describe('native script parsing', () => {
   it('projects an external representable workflow into the same Brief and Flow model', async () => {
-    const source = `export const meta = {
-  name: "external-review",
-  description: "review a patch",
-  whenToUse: "Inspect a supplied patch",
-  phases: [{ title: "Review" }],
-}
-
-phase("Review")
-const reviewer = await agent(\`Review \${args}\`, { label: "reviewer", model: "sonnet" })
-
-return reviewer
-`;
-    writeFileSync(join(configDir, 'workflows', 'external-review.js'), source, 'utf-8');
+    const source = EXTERNAL_REVIEW;
+    writeGlobalScript('external-review.js', source);
 
     const detail = await reader.getBlueprintDetail('external-review.js');
     expect(detail?.structured).toBe(true);
@@ -528,6 +559,10 @@ describe('round-trip corruption guards', () => {
 });
 
 describe('raw source operations', () => {
+  // These edit a script that is already on disk; which one is not the point, so
+  // it is written here rather than inherited from the parsing block above.
+  beforeEach(() => writeGlobalScript('external-review.js', EXTERNAL_REVIEW));
+
   it('reads and overwrites an existing workflow verbatim', async () => {
     const before = (await reader.getBlueprintDetail('external-review.js'))!;
     const changed = `${before.source}\n// manual edit\n`;
@@ -561,6 +596,7 @@ describe('raw source operations', () => {
   });
 
   it('deletes the native script itself', async () => {
+    await writer.createBlueprint(blueprint());
     writer.deleteBlueprint('release-triage.js');
     expect(existsSync(join(configDir, 'workflows', 'release-triage.js'))).toBe(false);
     expect(await reader.readBlueprint('release-triage')).toBeNull();
@@ -571,6 +607,14 @@ describe('project-local workflows (.claude/workflows in the project cwd)', () =>
   const projectDir = mkdtempSync(join(homedir(), '.cl-studio-proj-'));
   const projectWorkflows = join(projectDir, '.claude', 'workflows');
   afterAll(() => rmSync(projectDir, { recursive: true, force: true }));
+
+  // One project-scope blueprint, present for every test in the block: the
+  // listing reads it, the overwrite edits it and the delete removes it, so
+  // whichever runs first cannot be the one that creates it.
+  beforeEach(async () => {
+    rmSync(projectWorkflows, { recursive: true, force: true });
+    await writer.saveBlueprint(blueprint('proj-flow'), undefined, projectDir);
+  });
 
   it('saves and reads back a blueprint in the project scope', async () => {
     const { scriptPath } = await writer.saveBlueprint(
@@ -587,6 +631,8 @@ describe('project-local workflows (.claude/workflows in the project cwd)', () =>
   });
 
   it('lists global and project scripts together, tagged with their scope', async () => {
+    // The global half of the claim needs a global script to exist.
+    await writer.createBlueprint(blueprint());
     const all = await reader.getBlueprints([projectDir]);
     const projFlow = all.find(bp => bp.name === 'proj-flow');
     expect(projFlow).toMatchObject({ scope: 'project', projectPath: projectDir });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,5 +5,18 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['test/**/*.{test,spec}.{ts,tsx}'],
+    // Run files and tests in a random order. Not a preference — it is the only
+    // thing that keeps each `it` an independent claim. Three files had quietly
+    // stopped being that: one test created the workflow the next one edited,
+    // another appended to a transcript a later test measured, and a third left
+    // an entry in cost-tracker's (append-only) parse cache under a path it then
+    // rewrote with different content. All three passed in file order and failed
+    // the moment two tests swapped places, which is a suite that verifies a
+    // sequence rather than a set of facts.
+    //
+    // The order is not lost when it matters: vitest prints `Running tests with
+    // seed "<n>"`, so a red CI run is reproduced with
+    // `npx vitest run --sequence.seed=<n>`.
+    sequence: { shuffle: true },
   },
 });


### PR DESCRIPTION
Follow-up to the flakiness noted while merging #229. Three test files had quietly become a **sequence** rather than a set of independent facts: they passed in file order and went red as soon as two tests swapped places. A plain `--sequence.shuffle --sequence.seed=42` turned six tests red on `main`.

## What was wrong

**`studio-io.test.ts`** — the workflows dir *is* the state under test (these modules keep none of their own; the `.js` files on disk are the source of truth), and tests were handing it to each other:
- `refuses duplicate creation` and `saves visual edits` both read the script the **first** test creates;
- the project-scope block **wrote** a blueprint in one test, **listed** it in the second and **deleted** it in the last;
- `raw source operations` edited a script left behind by the parsing block above it.

Now: the dir is wiped and recreated empty before each test, each test states its own precondition, and the external native script two blocks need became a shared fixture (`EXTERNAL_REVIEW` + `writeGlobalScript`) instead of a leftover.

**`session-sdk-cache.test.ts`** — two tests append to the fixtures *on purpose* (that is their claim: a grown transcript must invalidate its cache), and what they left behind changed the answer for whoever ran next — a sub-agent that had answered once reported two messages. The fixture writes moved out of `beforeAll` into a `writeFixtures()` called from `beforeEach`, so each test starts from the same disk as well as the same cache.

**`session-tails.test.ts`** (and the seed file from #229) — the most interesting one. The spend seed reads through `cost-tracker`'s parse cache, which is keyed on the assumption that **a transcript only ever grows**. These tests rewrite one path with different content: a shorter parse cached under it, then a longer file written over it, and the incremental read resumed at an offset that now fell **mid-line** — folding a fragment into nothing and reporting a seeded session's spend as **zero**.

Traced with a temporary probe in `parseSession`:

```
[dbg] size 241  mtime …642  cached { consumed: 164, partial: 0, tok: 0 }
```

Worth stating plainly: **the cache is right and the fixture is the odd one out.** Real transcripts are append-only, so this is not a production defect — it is module-level state the tests share and never reset. `resetParseCache()` now joins `resetSessionTails()` in `beforeEach`.

## Keeping it fixed

`sequence: { shuffle: true }` in `vitest.config.ts`. Randomised order is the only thing that stops this returning silently, and nothing is lost when a run does go red: vitest prints `Running tests with seed "<n>"`, so it reproduces with `npx vitest run --sequence.seed=<n>`.

If you would rather not have a randomised order in CI, it is the one line to drop — the three files are independent either way.

## Verification

- 8 fixed seeds (42, 7, 1, 99, 3, 55, 123, 2024) — 1100 passing each;
- 5 further runs with vitest's own random seed — 1100 passing each;
- `format:check` + `typecheck` + `lint` + `build` green.

No production code touched: the diff is the three test files, the seed test from #229, `vitest.config.ts` and the testing section of CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FoALgTVrkL63Xs44ac6gMK