### PR TITLE
fix(agents): give the global Agents tile a view to land on

### DIFF
--- a/src/components/project/agents/GlobalAgentsView.tsx
+++ b/src/components/project/agents/GlobalAgentsView.tsx
@@ -1,0 +1,140 @@
+import { useGlobalAgents, Agent } from '../../../hooks/useIPC';
+import { fmtModel } from '../utils';
+import { Lens } from '../overview/Lens';
+import { TopBar } from '../shared/TopBar';
+
+const GLYPHS = ['◐', '◑', '◒', '◓'];
+
+/** The two ways an agent file can be invalid, told where the agent is listed. */
+function agentIssues(agent: Agent) {
+  return [
+    ...(agent.missingRequired.length > 0
+      ? [
+          {
+            label: `missing ${agent.missingRequired.join(', ')}`,
+            title: `Missing required frontmatter: ${agent.missingRequired.join(', ')}`,
+          },
+        ]
+      : []),
+    ...(agent.filenameHasSpaces
+      ? [
+          {
+            label: 'spaces in filename',
+            title:
+              'Claude Code requires agent file names without spaces — this agent may not be loaded.',
+          },
+        ]
+      : []),
+  ];
+}
+
+function AgentTile({
+  agent,
+  index,
+  onClick,
+}: {
+  agent: Agent;
+  index: number;
+  onClick: () => void;
+}) {
+  const mode = agent.disableModelInvocation ? 'manual' : 'auto';
+  return (
+    <button type="button" className={`cl-tile ${index === 0 ? 'accent' : ''}`} onClick={onClick}>
+      <span className="glyph">{GLYPHS[index % GLYPHS.length]}</span>
+      <div style={{ minWidth: 0 }}>
+        <div className="t-name" style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+          {agent.name}
+          {agentIssues(agent).map(issue => (
+            <span
+              key={issue.label}
+              title={issue.title}
+              style={{
+                fontSize: 10,
+                fontFamily: 'var(--font-mono)',
+                background: 'color-mix(in srgb, var(--cl-warn) 20%, transparent)',
+                color: 'var(--cl-warn)',
+                padding: '1px 5px',
+                borderRadius: 4,
+                letterSpacing: '0.05em',
+                lineHeight: 1.4,
+              }}
+            >
+              {issue.label}
+            </span>
+          ))}
+        </div>
+        <div className="t-desc">{agent.description || '—'}</div>
+      </div>
+      <span className="t-meta">
+        {agent.model ? `${fmtModel(agent.model)} · ` : ''}
+        <b>{mode}</b>
+      </span>
+    </button>
+  );
+}
+
+export function GlobalAgentsView({
+  onBack,
+  onSelectAgent,
+  onCreate,
+}: {
+  onBack: () => void;
+  onSelectAgent: (agent: Agent) => void;
+  onCreate: () => void;
+}) {
+  const { data: agents, isLoading } = useGlobalAgents();
+  const total = agents?.length ?? 0;
+
+  return (
+    <div className="h-full flex flex-col" style={{ background: 'var(--cl-paper)' }}>
+      <TopBar onBack={onBack} crumbs={[{ label: 'Global · Agents' }]} />
+
+      <div className="flex-1 overflow-y-auto">
+        <section className="cl-hero">
+          <Lens />
+          <div className="cl-hero-actions">
+            <button type="button" className="cl-btn cl-btn--primary" onClick={onCreate}>
+              + New Agent
+            </button>
+          </div>
+          <div className="cl-eyebrow">
+            <span className="pip" />
+            <span>Global · ~/.claude/agents</span>
+          </div>
+          <h1 className="cl-h-name static">
+            <span className="label-name">Agents</span>
+            <span className="glyph">.</span>
+          </h1>
+          <div className="cl-h-meta">
+            <span>
+              <b>{total}</b> {total === 1 ? 'agent' : 'agents'}
+            </span>
+            <span className="sep">·</span>
+            <span>delegate-and-summarize</span>
+          </div>
+        </section>
+
+        {isLoading ? (
+          <section className="cl-section">
+            <p style={{ color: 'var(--cl-ink-3)', fontSize: 13 }}>Loading…</p>
+          </section>
+        ) : total === 0 ? (
+          <section className="cl-section">
+            <div className="cl-empty">
+              No agents found. Add <code style={{ fontFamily: 'var(--font-mono)' }}>*.md</code>{' '}
+              files in <code style={{ fontFamily: 'var(--font-mono)' }}>~/.claude/agents/</code>.
+            </div>
+          </section>
+        ) : (
+          <section className="cl-section">
+            <div className="cl-tile-grid cl-tile-grid--list">
+              {(agents ?? []).map((a, i) => (
+                <AgentTile key={a.path} agent={a} index={i} onClick={() => onSelectAgent(a)} />
+              ))}
+            </div>
+          </section>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/tabs/ProjectOverview.tsx
+++ b/src/tabs/ProjectOverview.tsx
@@ -37,6 +37,7 @@ import { GlobalSkillsView } from '../components/project/skills/GlobalSkillsView'
 import { SkillDetailView } from '../components/project/skills/SkillDetailView';
 import { CreateSkillPage } from '../components/project/skills/CreateSkillPage';
 // ─── Agents
+import { GlobalAgentsView } from '../components/project/agents/GlobalAgentsView';
 import { AgentDetailView } from '../components/project/agents/AgentDetailView';
 import { CreateAgentPage } from '../components/project/agents/CreateAgentPage';
 // ─── MCP
@@ -471,16 +472,22 @@ export default function ProjectOverview() {
           />
         );
       case 'global-agents':
-        if (selected) setView({ type: 'project-agents', project: selected });
-        else goGlobal();
-        return null;
+        return (
+          <GlobalAgentsView
+            onBack={goGlobal}
+            onSelectAgent={agent => setView({ type: 'agent-detail', agent })}
+            onCreate={() => setView({ type: 'agent-create' })}
+          />
+        );
       case 'agent-detail':
         return (
           <AgentDetailView
             agent={view.agent}
             project={selected ?? undefined}
             onBack={() =>
-              selected ? setView({ type: 'project-agents', project: selected }) : goGlobal()
+              scope === 'project' && selected
+                ? setView({ type: 'project-agents', project: selected })
+                : setView({ type: 'global-agents' })
             }
             onNavigateLive={
               selected ? () => setView({ type: 'agents-live', project: selected }) : undefined
@@ -492,10 +499,14 @@ export default function ProjectOverview() {
           <CreateAgentPage
             project={view.project}
             onBack={() =>
-              view.project ? setView({ type: 'project-agents', project: view.project }) : goGlobal()
+              view.project
+                ? setView({ type: 'project-agents', project: view.project })
+                : setView({ type: 'global-agents' })
             }
             onSaved={() =>
-              view.project ? setView({ type: 'project-agents', project: view.project }) : goGlobal()
+              view.project
+                ? setView({ type: 'project-agents', project: view.project })
+                : setView({ type: 'global-agents' })
             }
           />
         );


### PR DESCRIPTION
## Il bug

Nella home globale, sezione **Configuration**, la tile **Agents** non fa niente.

`GlobalAgentsView` è stata cancellata in 54c62c2 (_scope agents to project_), ma la tile ha continuato a navigare a `global-agents`. Il case rimasto in `ProjectOverview.tsx` non renderizzava nulla:

```ts
case 'global-agents':
  if (selected) setView({ type: 'project-agents', project: selected });
  else goGlobal();
  return null;
```

Senza progetto selezionato ripiegava su `goGlobal()`, cioè la stessa home da cui era arrivato il click; con un progetto in memoria teleportava dentro quel progetto senza cambiare scope. In entrambi i casi la tile — che conta gli agent globali di `~/.claude/agents/` — non portava da nessuna parte.

## Il fix

- **Ripristinata `GlobalAgentsView`** come gemello di `GlobalSkillsView`: `TopBar` condivisa, hero + `Lens`, tile-list, `+ New Agent`, empty state che nomina `~/.claude/agents/`. **Solo scope globale** — la lista per-progetto resta in `ProjectView` (`section === 'agents'`), che è la ragione per cui la vecchia vista fu rimossa.
- Le tile portano gli **avvisi di validità** che la lista di progetto già mostra (frontmatter richiesto mancante, spazi nel filename), dipinti col token esistente `--cl-warn` invece del `#f59e0b` fuori palette che il file cancellato usava.
- Il **back segue lo scope** da cui il dettaglio è stato aperto: un agent globale torna alla lista globale invece di saltare nell'ultimo progetto visitato. Stessa cosa per `agent-create` senza progetto.

## Verifica

`typecheck` + `lint` + `format` + `npm test` (1173 test) verdi. La verifica visiva resta manuale, come da convenzione del repo per layout e chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYZ6a5zVHe2cjDuphUDRWu