### PR TITLE
Recover the transcript rows the SDK read drops: mid-turn messages, and skills read as skills

### DIFF
--- a/electron/modules/session-reader.ts
+++ b/electron/modules/session-reader.ts
@@ -2,7 +2,8 @@ import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import { glob } from 'glob';
 import { stripFramingTags } from '../utils';
-import { StampCache, firstFileStamp, treeStamp } from './session-read-cache';
+import { StampCache, fileStamp, firstFileStamp, treeStamp } from './session-read-cache';
+import { mergeTranscriptExtras, readTranscriptExtras } from './transcript-extras';
 import type { ChatContentBlock, ChatMessage, MessageUsage } from '../shared/chat-types';
 
 // The message shapes live in the shared module (single definition for main and
@@ -270,6 +271,19 @@ function transcriptCandidates(projectDir: string, sessionId: string): string[] {
   ];
 }
 
+/** The session's transcript on disk, or `null` when neither layout holds it.
+ *  Probed in the same order as `sessionTranscriptStamp`, so the file we read the
+ *  SDK-invisible rows from is the file whose stamp invalidates that read. */
+async function firstExistingTranscript(
+  projectDir: string,
+  sessionId: string
+): Promise<string | null> {
+  for (const candidate of transcriptCandidates(projectDir, sessionId)) {
+    if (await fileStamp(candidate)) return candidate;
+  }
+  return null;
+}
+
 /** `subagents/` sidecar dir of a session, whose tree feeds the sub-agent readers. */
 export function subagentsDirFor(projectDir: string, sessionId: string): string {
   return join(projectDir, sessionId, 'subagents');
@@ -380,9 +394,20 @@ export async function readChatSessionViaSdk(
   source: SessionSource = {}
 ): Promise<ChatMessage[]> {
   const stamp = await sessionTranscriptStamp(sessionId, source);
-  return chatCache.read(sessionCacheKey(sessionId, source), stamp, async () =>
-    mapSdkMessagesToChat(await getSessionMessagesScoped(sessionId, source, stamp))
-  );
+  return chatCache.read(sessionCacheKey(sessionId, source), stamp, async () => {
+    const messages = mapSdkMessagesToChat(await getSessionMessagesScoped(sessionId, source, stamp));
+    // `getSessionMessages` returns chat rows only, so a second pass over the same
+    // file recovers what it cannot see: the messages typed mid-turn (#245) and the
+    // skill expansion that identifies a `/foo` skill (#246). It rides this cache
+    // entry, whose stamp is that very file's `size:mtimeMs` — a new row there
+    // invalidates both passes together. Without a `projectDir` we don't know which
+    // file the SDK read, so the read stays SDK-only rather than guessing.
+    const transcript = source.projectDir
+      ? await firstExistingTranscript(source.projectDir, sessionId)
+      : null;
+    if (!transcript) return messages;
+    return mergeTranscriptExtras(messages, await readTranscriptExtras(transcript));
+  });
 }
 
 // Transcript interno di un sub-agente via SDK (`getSubagentMessages`), in luogo

--- a/electron/modules/transcript-extras.ts
+++ b/electron/modules/transcript-extras.ts
@@ -1,0 +1,176 @@
+// Le righe di transcript che l'Agent SDK non restituisce.
+//
+// Lo storico chat è letto via `getSessionMessages`, che dà SOLO messaggi di
+// chat: tutto ciò che Claude Code scrive nel `.jsonl` fuori da `type: "user" |
+// "assistant"` (e ogni riga `isMeta`) è irraggiungibile da quella lettura. Due
+// di quelle righe però contano per il transcript:
+//
+//   - `queue-operation` — un messaggio digitato mentre un turno era in corso.
+//     Claude Code lo assorbe nel turno e lo registra SOLO qui, mai come riga
+//     `user`: senza questa passata il transcript mostra Claude che risponde a
+//     una domanda che non c'è (#245).
+//   - la riga `isMeta` "Base directory for this skill: …" — l'espansione che
+//     segue una slash command, e l'unico segnale che dice che quella `/foo` era
+//     una skill e non un comando builtin (#246).
+//
+// Il modulo si limita a riferire cosa dice il file; cosa sia ridondante lo
+// decide `mergeTranscriptExtras`, che ha sotto gli occhi i messaggi dell'SDK.
+import { readTextFile } from './safe-fs';
+import type { ChatMessage } from '../shared/chat-types';
+
+/** Prima riga dell'espansione che Claude Code inietta dopo una skill. */
+const SKILL_EXPANSION_PREFIX = 'Base directory for this skill:';
+
+export interface TranscriptExtras {
+  /** Prosa dell'utente digitata a turno in corso e assorbita in esso. */
+  queued: ChatMessage[];
+  /** uuid della riga `user` che ha invocato una skill → base dir della skill.
+   *  Il `parentUuid` dell'espansione è sempre quella riga: la `<command-name>`
+   *  per una slash command, il `tool_result` per il tool `Skill`. */
+  skillPathByParentUuid: Map<string, string>;
+}
+
+const EMPTY: TranscriptExtras = { queued: [], skillPathByParentUuid: new Map() };
+
+/** Il testo di un messaggio di chat, per confronti di contenuto. */
+function messageText(msg: ChatMessage): string {
+  return msg.content
+    .filter((b): b is Extract<typeof b, { type: 'text' }> => b.type === 'text')
+    .map(b => b.text)
+    .join('\n')
+    .trim();
+}
+
+/** Il primo blocco di testo di una riga `.jsonl` grezza (content stringa o array). */
+function rawFirstText(message: unknown): string {
+  if (!message || typeof message !== 'object') return '';
+  const content = (message as { content?: unknown }).content;
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  for (const block of content) {
+    if (block && typeof block === 'object') {
+      const b = block as { type?: unknown; text?: unknown };
+      if (b.type === 'text' && typeof b.text === 'string') return b.text;
+    }
+  }
+  return '';
+}
+
+/**
+ * Una passata sul `.jsonl` per le sole righe che l'SDK scarta.
+ *
+ * Materializza **solo** le `queue-operation` con `operation: "remove"`: la
+ * coppia `enqueue`/`dequeue` è il caso normale — un messaggio accodato e poi
+ * consegnato come turno proprio, quindi già nel transcript — e renderla
+ * duplicherebbe i turni. Una `remove` invece dice che quel messaggio non è
+ * diventato un turno: `reason: "absorbed_mid_turn"` sulle versioni recenti,
+ * nessun `reason` sulle più vecchie, `delivered_to_agent` quando è finito a un
+ * sub-agente. Il timestamp mostrato è quello della `enqueue` gemella (quando
+ * l'utente ha scritto), non quello dell'assorbimento.
+ *
+ * Tollerante come gli altri lettori di transcript: reject a stringa prima di
+ * `JSON.parse`, errori per riga ignorati, e un file illeggibile vale "niente da
+ * aggiungere" invece di far cadere la lettura dello storico.
+ */
+export async function readTranscriptExtras(filePath: string): Promise<TranscriptExtras> {
+  let raw: string;
+  try {
+    raw = await readTextFile(filePath);
+  } catch {
+    return EMPTY;
+  }
+
+  const queued: ChatMessage[] = [];
+  const skillPathByParentUuid = new Map<string, string>();
+  // Quando l'utente ha scritto il messaggio, per contenuto: la `remove` porta
+  // l'ora dell'assorbimento, la `enqueue` quella della digitazione.
+  const enqueuedAt = new Map<string, string>();
+
+  for (const line of raw.split('\n')) {
+    if (!line) continue;
+    const isQueue = line.includes('"queue-operation"');
+    const isSkillExpansion = line.includes(SKILL_EXPANSION_PREFIX);
+    if (!isQueue && !isSkillExpansion) continue;
+
+    let json: Record<string, unknown>;
+    try {
+      json = JSON.parse(line) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+
+    if (isQueue && json.type === 'queue-operation') {
+      const content = typeof json.content === 'string' ? json.content.trim() : '';
+      const timestamp = String(json.timestamp ?? '');
+      if (!content) continue;
+      if (json.operation === 'enqueue') {
+        if (!enqueuedAt.has(content)) enqueuedAt.set(content, timestamp);
+      } else if (json.operation === 'remove') {
+        const typedAt = enqueuedAt.get(content) ?? timestamp;
+        queued.push({
+          // Le righe di coda non hanno uuid: ne serve uno stabile tra due
+          // letture, perché è la key React della bolla.
+          uuid: `queued-${typedAt}-${queued.length}`,
+          role: 'user',
+          timestamp: typedAt,
+          content: [{ type: 'text', text: content }],
+          queued: true,
+        });
+      }
+      continue;
+    }
+
+    if (isSkillExpansion && json.isMeta === true && typeof json.parentUuid === 'string') {
+      const text = rawFirstText(json.message).trim();
+      if (!text.startsWith(SKILL_EXPANSION_PREFIX)) continue;
+      const path = text.slice(SKILL_EXPANSION_PREFIX.length).split('\n')[0].trim();
+      if (path) skillPathByParentUuid.set(json.parentUuid, path);
+    }
+  }
+
+  return { queued, skillPathByParentUuid };
+}
+
+/**
+ * Rimette nel transcript ciò che l'SDK ha perso: i messaggi accodati al loro
+ * posto cronologico e la base dir della skill sul messaggio che l'ha invocata.
+ *
+ * Un messaggio accodato il cui testo è già quello di un messaggio utente viene
+ * scartato: sui transcript osservati non capita (una `remove` non è mai anche
+ * una riga `user`), ma è ciò che separa "assorbito" da "consegnato" e non vale
+ * la pena fidarsi della sola `operation`.
+ */
+export function mergeTranscriptExtras(
+  messages: ChatMessage[],
+  extras: TranscriptExtras
+): ChatMessage[] {
+  const { queued, skillPathByParentUuid } = extras;
+  if (queued.length === 0 && skillPathByParentUuid.size === 0) return messages;
+
+  const stamped =
+    skillPathByParentUuid.size === 0
+      ? messages
+      : messages.map(msg => {
+          const skillPath = skillPathByParentUuid.get(msg.uuid);
+          return skillPath ? { ...msg, skillPath } : msg;
+        });
+  if (queued.length === 0) return stamped;
+
+  const alreadyShown = new Set(messages.filter(m => m.role === 'user').map(m => messageText(m)));
+  const pending = queued
+    .filter(m => !alreadyShown.has(messageText(m)))
+    .sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+  if (pending.length === 0) return stamped;
+
+  // I messaggi dell'SDK sono già in ordine cronologico: un merge lineare basta.
+  const merged: ChatMessage[] = [];
+  let next = 0;
+  for (const msg of stamped) {
+    while (next < pending.length && pending[next].timestamp <= msg.timestamp) {
+      merged.push(pending[next++]);
+    }
+    merged.push(msg);
+  }
+  while (next < pending.length) merged.push(pending[next++]);
+  return merged;
+}

--- a/electron/shared/chat-types.ts
+++ b/electron/shared/chat-types.ts
@@ -34,6 +34,16 @@ export interface ChatMessage {
   model?: string;
   content: ChatContentBlock[];
   usage?: MessageUsage;
+  /** Typed while a turn was already running, and absorbed into it. Claude Code
+   *  keeps such a message ONLY in the transcript's `queue-operation` rows, so it
+   *  reaches the renderer through `transcript-extras`, not through the SDK read
+   *  (#245). Shown as a normal user message wearing a "sent mid-turn" chip. */
+  queued?: true;
+  /** Base directory of the skill this user message expanded into — recovered
+   *  from the `isMeta` expansion row the SDK read drops. Present only on the
+   *  `<command-name>`/`tool_result` row that invoked a skill, and it is what
+   *  tells a `/foo` skill apart from a built-in command (#246). */
+  skillPath?: string;
 }
 
 /** Live tool indicator for the in-flight turn (`sessions:chatToolActivity`):

--- a/src/components/project/chat/ChatView.tsx
+++ b/src/components/project/chat/ChatView.tsx
@@ -19,6 +19,7 @@ import { useThoughtStream } from './useThoughtStream';
 import { trackEvent } from '../../../lib/telemetry';
 import {
   buildProcessedMessages,
+  buildSkillIndex,
   correlateSessionAgents,
   correlateSessionSkills,
   ChatDetailsFilter,
@@ -131,12 +132,12 @@ export function ChatView({
   }, [globalAgents, projectAgents]);
 
   // Resolve a skill's full definition by name (the slash-command id) — feeds both
-  // the inline skill card link and the footer skill dock.
+  // the inline skill card link and the footer skill dock, through the same index
+  // the dock uses, so a plugin skill (`plugin:leaf`) resolves on both surfaces.
   const skillOf = useMemo(() => {
-    const byName = new Map<string, Skill>();
-    for (const s of allSkills ?? []) byName.set(s.name, s);
-    return (name: string) => byName.get(name);
-  }, [allSkills]);
+    const resolve = buildSkillIndex(allSkills, plugins);
+    return (name: string) => resolve(name) ?? undefined;
+  }, [allSkills, plugins]);
   const [viewMode, setViewMode] = useState<ViewMode>('chat');
   const [detailsFilter, setDetailsFilter] = useState<ChatDetailsFilter>('minimal');
   const [selectedTool, setSelectedTool] = useState<ToolGroup | null>(null);

--- a/src/components/project/chat/MessageBubble.tsx
+++ b/src/components/project/chat/MessageBubble.tsx
@@ -767,6 +767,17 @@ export const MessageBubble = memo(function MessageBubble({
             </button>
           )}
           <span className="cl-turn-who">{roleLabel}</span>
+          {msg.queued && (
+            // Typed while Claude was already working, and absorbed into that
+            // turn — so it was never a turn of its own, and the reply to it sits
+            // inside the turn above rather than below (#245).
+            <span
+              className="cl-turn-queued-badge"
+              title="Typed while Claude was working on the previous turn"
+            >
+              sent mid-turn
+            </span>
+          )}
           {timestamp &&
             !(showTools && textBlocks.length === 0 && thinkingBlocks.length === 0) &&
             !(showAgentStrip && textBlocks.length === 0) && (

--- a/src/components/project/chat/export.tsx
+++ b/src/components/project/chat/export.tsx
@@ -254,7 +254,10 @@ function buildTurnMarkdown(
 ): string[] {
   const { msg, toolGroups } = processed;
   const who = processed.notification ? 'Task event' : roleLabel(msg.role);
-  const heading = `### ${String(index + 1).padStart(2, '0')} ${who}${turnTime(msg.timestamp) ? ` - ${turnTime(msg.timestamp)}` : ''}`;
+  // A message absorbed into the running turn is marked here too: without it the
+  // export reads as if Claude answered something nobody asked (#245).
+  const provenance = msg.queued ? ' (sent mid-turn)' : '';
+  const heading = `### ${String(index + 1).padStart(2, '0')} ${who}${provenance}${turnTime(msg.timestamp) ? ` - ${turnTime(msg.timestamp)}` : ''}`;
   const lines = [heading, ''];
 
   // Command / notification turns replace their raw text blocks (which carry
@@ -527,6 +530,7 @@ function renderTurnHtml(
     <article class="turn ${msg.role === 'user' ? 'is-user' : 'is-assistant'}">
       <header class="turn-head">
         <span class="turn-who">${escapeHtml(role)}</span>
+        ${msg.queued ? '<span class="turn-queued">sent mid-turn</span>' : ''}
         ${time ? `<span class="turn-sep">·</span><time>${escapeHtml(time)}</time>` : ''}
         ${model ? `<span class="turn-sep">·</span>${model}` : ''}
       </header>
@@ -618,6 +622,11 @@ function buildHtml(input: BuildChatExportInput, options: ExportOptions): string 
     .message-text { margin-bottom: 8px; }
     .message-text > :first-child { margin-top: 0; }
     .message-text > :last-child { margin-bottom: 0; }
+    /* Message typed while Claude was working, absorbed into the running turn. */
+    .turn-queued {
+      margin-left: 8px; padding: 2px 7px; border: 1px dashed #c9c3b6; border-radius: 999px;
+      font-size: 9px; text-transform: uppercase; letter-spacing: 0.08em; color: #7c7669;
+    }
     /* Slash-command turn: the compact command chip (mirrors the live view). */
     .command-line { margin-bottom: 8px; }
     .command-line code { font-weight: 700; }

--- a/src/components/project/chat/utils.ts
+++ b/src/components/project/chat/utils.ts
@@ -166,13 +166,15 @@ export function buildProcessedMessages(messages: ChatMessage[]): ProcessedMessag
         Extract<ChatContentBlock, { type: 'text' }> | undefined;
       if (text) {
         command = parseClaudeSlashCommand(text.text) ?? undefined;
-        // A skill invocation is a slash command immediately followed by Claude
-        // Code's skill-expansion message — peek the next raw message to tell a
-        // skill apart from a plain built-in command.
+        // A skill invocation is a slash command whose skill-expansion message
+        // Claude Code injects right after. On a stored transcript that row is
+        // `isMeta` and the SDK read never returns it, so the main process hands
+        // us its base dir on the command message itself (`skillPath`, #246); the
+        // next-message peek stays for the live stream, which can still carry it.
         if (
           command &&
-          i + 1 < messages.length &&
-          SKILL_EXPANSION_RE.test(firstText(messages[i + 1]))
+          (msg.skillPath ||
+            (i + 1 < messages.length && SKILL_EXPANSION_RE.test(firstText(messages[i + 1]))))
         ) {
           command.isSkill = true;
         }
@@ -766,19 +768,32 @@ export function skillHasViewableOutput(group: ToolGroup | undefined): boolean {
   return !isSkillLaunchOutput(content);
 }
 
+/**
+ * Resolver from an invoked skill name to its definition. Plain names come from
+ * the project/global registry; a plugin skill is invoked namespaced —
+ * `${plugin.name}:${skill.name}` (e.g. `document-skills:pdf`) — and never
+ * matches a plain registry name, so it resolves against the installed plugins.
+ *
+ * Shared so the footer dock and the turn's own card cannot disagree on what a
+ * name means: the card used to index the registry alone, which is why a plugin
+ * skill was listed in the dock and still drawn as a plain command.
+ */
+export function buildSkillIndex(
+  skills: Skill[] = [],
+  plugins: InstalledPlugin[] = []
+): (name: string) => Skill | null {
+  const byName = new Map(skills.map(s => [s.name, s]));
+  const byNamespaced = new Map<string, Skill>();
+  for (const pl of plugins) for (const s of pl.skills) byNamespaced.set(`${pl.name}:${s.name}`, s);
+  return (name: string) => byName.get(name) ?? byNamespaced.get(name) ?? null;
+}
+
 export function correlateSessionSkills(
   processed: ProcessedMessage[],
   skills: Skill[],
   plugins: InstalledPlugin[] = []
 ): SessionSkill[] {
-  const byName = new Map(skills.map(s => [s.name, s]));
-  // Plugin skills are invoked namespaced — `${plugin.name}:${skill.name}` (e.g.
-  // `document-skills:pdf`) — so they never match a plain registry name; resolve
-  // them against the installed plugins instead.
-  const byNamespaced = new Map<string, Skill>();
-  for (const pl of plugins) for (const s of pl.skills) byNamespaced.set(`${pl.name}:${s.name}`, s);
-  const resolve = (name: string): Skill | null =>
-    byName.get(name) ?? byNamespaced.get(name) ?? null;
+  const resolve = buildSkillIndex(skills, plugins);
 
   const out: SessionSkill[] = [];
   processed.forEach((p, idx) => {

--- a/src/index.css
+++ b/src/index.css
@@ -5166,6 +5166,20 @@ body {
   background: var(--cl-ink-4);
   flex-shrink: 0;
 }
+/* A message typed while Claude was working, absorbed into the running turn:
+   same neutral header pill as the hidden-tools badge, without the dot — it
+   states a provenance, not a count. */
+.cl-turn-queued-badge {
+  display: inline-flex;
+  align-items: center;
+  font: 500 10px/1 var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--cl-ink-4);
+  padding: 4px 9px;
+  border: 1px dashed var(--cl-line);
+  border-radius: 999px;
+}
 /* Multiplier chip for a collapsed run of tool-only turns ("× 4"). */
 .cl-turn-tools-hidden-x {
   font-weight: 700;

--- a/test/chat-utils.test.ts
+++ b/test/chat-utils.test.ts
@@ -596,7 +596,18 @@ describe('parseClaudeSlashCommand — namespaced (plugin) skills', () => {
 });
 
 describe('skill detection in buildProcessedMessages', () => {
-  it('flags a slash command followed by the skill-expansion message as a skill', () => {
+  it('flags a slash command carrying the skill path recovered from the transcript', () => {
+    // The stored-transcript signal: the expansion row is `isMeta` and the SDK
+    // read never returns it, so the main process hands us its base dir on the
+    // command message itself (#246).
+    const command = msg('user', [text('<command-name>/build-dmg</command-name>')]);
+    const processed = buildProcessedMessages([
+      { ...command, skillPath: '/Users/x/.claude/skills/build-dmg' },
+    ]);
+    expect(processed[0].command?.isSkill).toBe(true);
+  });
+
+  it('still flags a slash command followed by the expansion message (live stream)', () => {
     const processed = buildProcessedMessages([
       msg('user', [text('<command-name>/build-dmg</command-name>')]),
       msg('user', [skillExpansion('build-dmg')]),
@@ -604,7 +615,7 @@ describe('skill detection in buildProcessedMessages', () => {
     expect(processed[0].command?.isSkill).toBe(true);
   });
 
-  it('does not flag a plain command not followed by a skill expansion', () => {
+  it('does not flag a plain command with neither signal', () => {
     const processed = buildProcessedMessages([
       msg('user', [text('<command-name>/clear</command-name>')]),
       msg('user', [text('hello')]),

--- a/test/message-bubble-markers.test.tsx
+++ b/test/message-bubble-markers.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+//
+// Two claims about what a turn's header says about the turn's provenance, both
+// of which used to be silently wrong (#245, #246):
+//
+//  - a message typed while Claude was working was invisible, so the transcript
+//    showed Claude answering nobody; now it is a normal user bubble wearing a
+//    "sent mid-turn" chip;
+//  - a slash command that expanded into a skill was drawn as a plain command,
+//    because the only signal for it (`isSkill`) is set from a transcript row
+//    the SDK read drops.
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+import { MessageBubble } from '../src/components/project/chat/MessageBubble';
+import { buildProcessedMessages } from '../src/components/project/chat/utils';
+import type { ChatMessage } from '../src/types';
+
+afterEach(cleanup);
+
+function userMessage(text: string, extra: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    uuid: 'u1',
+    role: 'user',
+    timestamp: '2026-09-08T15:53:19.660Z',
+    content: [{ type: 'text', text }],
+    ...extra,
+  };
+}
+
+function mount(message: ChatMessage) {
+  const [processed] = buildProcessedMessages([message]);
+  return render(
+    <MessageBubble processed={processed} detailsFilter="minimal" onOpenToolDetail={() => {}} />
+  );
+}
+
+describe('a message absorbed into the running turn', () => {
+  it('wears the mid-turn chip', () => {
+    const { container } = mount(userMessage('metti anche il changelog', { queued: true }));
+
+    const chip = container.querySelector('.cl-turn-queued-badge');
+    expect(chip?.textContent).toBe('sent mid-turn');
+    expect(container.querySelector('.cl-message-text--user')?.textContent).toBe(
+      'metti anche il changelog'
+    );
+  });
+
+  it('leaves an ordinary user turn unmarked', () => {
+    const { container } = mount(userMessage('fai la cosa'));
+    expect(container.querySelector('.cl-turn-queued-badge')).toBeNull();
+  });
+});
+
+describe('a slash command that expanded into a skill', () => {
+  const commandText = '<command-name>/build-dmg</command-name>';
+
+  it('is drawn as a skill once the transcript hands over its path', () => {
+    const { container } = mount(
+      userMessage(commandText, { skillPath: '/Users/x/.claude/skills/build-dmg' })
+    );
+
+    expect(container.querySelector('.cl-skill-card')).not.toBeNull();
+    expect(container.querySelector('.cl-skill-tag')?.textContent).toBe('Skill');
+  });
+
+  it('stays a plain command when nothing says it was a skill', () => {
+    const { container } = mount(userMessage(commandText));
+
+    expect(container.querySelector('.cl-skill-card')).toBeNull();
+    expect(container.querySelector('.cl-command-card')).not.toBeNull();
+  });
+});

--- a/test/session-sdk-cache.test.ts
+++ b/test/session-sdk-cache.test.ts
@@ -24,6 +24,10 @@ const SESSION_ID = '11111111-2222-3333-4444-555555555555';
 /** A session in the SAME project that dispatched no sub-agent — the common case,
  *  and the one where an empty scoped read has to be believed rather than retried. */
 const SESSION_NO_SUB = '66666666-7777-8888-9999-000000000000';
+/** A session carrying the two kinds of row `getSessionMessages` never returns: a
+ *  `queue-operation` (a message absorbed mid-turn, #245) and the `isMeta` skill
+ *  expansion that identifies a slash-command skill (#246). */
+const SESSION_EXTRAS = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
 const AGENT_ID = 'abc123';
 const DISPATCH_PROMPT = 'Investigate the flaky test in the parser suite';
 const CWD = join(tmpdir(), 'cl-cache-proj');
@@ -142,6 +146,68 @@ function writeFixtures(): void {
       assistantLine('n2', 'n1', [{ type: 'text', text: 'answered directly' }]),
     ])
   );
+
+  // A `/build-dmg` skill invocation followed by a message typed while the turn
+  // was running. Both signals live in rows the SDK read drops, so this fixture
+  // is what proves the second pass puts them back.
+  writeFileSync(
+    join(projDir, `${SESSION_EXTRAS}.jsonl`),
+    jsonl([
+      { type: 'mode', mode: 'normal', sessionId: SESSION_EXTRAS, cwd: CWD },
+      {
+        parentUuid: null,
+        isSidechain: false,
+        type: 'user',
+        uuid: 'x1',
+        cwd: CWD,
+        timestamp: '2026-06-17T11:00:00.000Z',
+        message: { role: 'user', content: '<command-name>/build-dmg</command-name>' },
+      },
+      {
+        parentUuid: 'x1',
+        isSidechain: false,
+        type: 'user',
+        uuid: 'xmeta',
+        isMeta: true,
+        cwd: CWD,
+        timestamp: '2026-06-17T11:00:01.000Z',
+        message: {
+          role: 'user',
+          content: [{ type: 'text', text: 'Base directory for this skill: /skills/build-dmg' }],
+        },
+      },
+      {
+        type: 'queue-operation',
+        operation: 'enqueue',
+        timestamp: '2026-06-17T11:00:20.000Z',
+        sessionId: SESSION_EXTRAS,
+        content: 'metti anche il changelog',
+      },
+      {
+        type: 'queue-operation',
+        operation: 'remove',
+        timestamp: '2026-06-17T11:00:40.000Z',
+        sessionId: SESSION_EXTRAS,
+        content: 'metti anche il changelog',
+        reason: 'absorbed_mid_turn',
+      },
+      {
+        parentUuid: 'xmeta',
+        isSidechain: false,
+        type: 'assistant',
+        uuid: 'x2',
+        cwd: CWD,
+        timestamp: '2026-06-17T11:01:00.000Z',
+        message: {
+          model: 'claude-opus-4-8',
+          id: 'msg_x2',
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'text', text: 'built, changelog included' }],
+        },
+      },
+    ])
+  );
 }
 
 beforeEach(() => {
@@ -236,6 +302,51 @@ describe('readChatSessionViaSdk — change-stamped cache', () => {
 // common case is a session with no sub-agents, and retrying that unscoped runs
 // the cross-project scan the hint exists to avoid — on every flush of a live
 // session, since each append invalidates the entry.
+describe('readChatSessionViaSdk — the rows the SDK read cannot see', () => {
+  it('puts back the message typed while the turn was running', async () => {
+    const messages = await readChatSessionViaSdk(SESSION_EXTRAS, source);
+    const queued = messages.filter(m => m.queued);
+
+    expect(queued).toHaveLength(1);
+    expect(queued[0].content).toEqual([{ type: 'text', text: 'metti anche il changelog' }]);
+    // At the moment it was typed: after the command, before the answer.
+    expect(messages.map(m => m.uuid)).toEqual([messages[0].uuid, queued[0].uuid, 'x2']);
+  });
+
+  it('marks the slash command that expanded into a skill', async () => {
+    const messages = await readChatSessionViaSdk(SESSION_EXTRAS, source);
+
+    expect(messages[0].skillPath).toBe('/skills/build-dmg');
+    expect(messages.find(m => m.uuid === 'x2')?.skillPath).toBeUndefined();
+    // The expansion itself stays out of the transcript — it is Claude Code
+    // talking to the model, not a turn.
+    expect(messages.some(m => m.uuid === 'xmeta')).toBe(false);
+  });
+
+  it('serves both passes from one cache entry, until the file changes', async () => {
+    const first = await readChatSessionViaSdk(SESSION_EXTRAS, source);
+    expect(await readChatSessionViaSdk(SESSION_EXTRAS, source)).toBe(first);
+
+    appendFileSync(
+      join(projDir, `${SESSION_EXTRAS}.jsonl`),
+      jsonl([
+        {
+          type: 'queue-operation',
+          operation: 'remove',
+          timestamp: '2026-06-17T11:02:00.000Z',
+          sessionId: SESSION_EXTRAS,
+          content: 'e anche i test',
+          reason: 'absorbed_mid_turn',
+        },
+      ])
+    );
+
+    const after = await readChatSessionViaSdk(SESSION_EXTRAS, source);
+    expect(after).not.toBe(first);
+    expect(after.filter(m => m.queued)).toHaveLength(2);
+  });
+});
+
 describe('dir narrowing — a proven scope spares the cross-project retry', () => {
   it('retries while the scope is unproven', async () => {
     const metas = await readSessionSubagentsViaSdk(SESSION_NO_SUB, source);

--- a/test/transcript-extras.test.ts
+++ b/test/transcript-extras.test.ts
@@ -1,0 +1,212 @@
+import { readTranscriptExtras, mergeTranscriptExtras } from '../electron/modules/transcript-extras';
+import type { ChatMessage } from '../electron/shared/chat-types';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+let dir: string;
+
+function writeJsonl(lines: unknown[]): string {
+  const p = join(dir, 'session.jsonl');
+  writeFileSync(p, lines.map(l => (typeof l === 'string' ? l : JSON.stringify(l))).join('\n'));
+  return p;
+}
+
+/** A `queue-operation` row as Claude Code writes it (no uuid, no parentUuid). */
+function queueRow(
+  operation: 'enqueue' | 'dequeue' | 'remove',
+  content: string,
+  timestamp: string,
+  reason?: string
+): Record<string, unknown> {
+  return {
+    type: 'queue-operation',
+    operation,
+    timestamp,
+    sessionId: 's1',
+    content,
+    ...(reason ? { reason } : {}),
+  };
+}
+
+function userRow(uuid: string, text: string, timestamp = '2026-09-08T10:00:00.000Z') {
+  return { type: 'user', uuid, timestamp, message: { role: 'user', content: text } };
+}
+
+/** The skill expansion Claude Code injects after an invocation: `isMeta`, and
+ *  parented to the row that invoked the skill. */
+function skillExpansionRow(parentUuid: string, path: string) {
+  return {
+    type: 'user',
+    uuid: `meta-${parentUuid}`,
+    parentUuid,
+    isMeta: true,
+    timestamp: '2026-09-08T10:00:01.000Z',
+    message: {
+      role: 'user',
+      content: `Base directory for this skill: ${path}\n\n# The skill body`,
+    },
+  };
+}
+
+function msg(
+  uuid: string,
+  role: 'user' | 'assistant',
+  text: string,
+  timestamp: string
+): ChatMessage {
+  return { uuid, role, timestamp, content: [{ type: 'text', text }] };
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'cl-extras-'));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('readTranscriptExtras', () => {
+  it('reports nothing for a file that is not there', async () => {
+    const extras = await readTranscriptExtras(join(dir, 'nope.jsonl'));
+    expect(extras.queued).toEqual([]);
+    expect(extras.skillPathByParentUuid.size).toBe(0);
+  });
+
+  it('materializes a message absorbed mid-turn', async () => {
+    const p = writeJsonl([
+      queueRow('enqueue', 'aggiungi anche il grafico', '2026-09-08T10:00:00.000Z'),
+      queueRow(
+        'remove',
+        'aggiungi anche il grafico',
+        '2026-09-08T10:00:30.000Z',
+        'absorbed_mid_turn'
+      ),
+    ]);
+    const { queued } = await readTranscriptExtras(p);
+    expect(queued).toHaveLength(1);
+    expect(queued[0].role).toBe('user');
+    expect(queued[0].queued).toBe(true);
+    expect(queued[0].content).toEqual([{ type: 'text', text: 'aggiungi anche il grafico' }]);
+  });
+
+  it('shows when the message was typed, not when it was absorbed', async () => {
+    const p = writeJsonl([
+      queueRow('enqueue', 'ciao', '2026-09-08T10:00:00.000Z'),
+      queueRow('remove', 'ciao', '2026-09-08T10:00:30.000Z', 'absorbed_mid_turn'),
+    ]);
+    const { queued } = await readTranscriptExtras(p);
+    expect(queued[0].timestamp).toBe('2026-09-08T10:00:00.000Z');
+  });
+
+  it('falls back to the removal time when no enqueue carried the text', async () => {
+    const p = writeJsonl([
+      queueRow('remove', 'ciao', '2026-09-08T10:00:30.000Z', 'absorbed_mid_turn'),
+    ]);
+    const { queued } = await readTranscriptExtras(p);
+    expect(queued[0].timestamp).toBe('2026-09-08T10:00:30.000Z');
+  });
+
+  it('keeps a removal that carries no reason (older Claude Code)', async () => {
+    const p = writeJsonl([queueRow('remove', 'mando io, tu verifica', '2026-09-08T10:00:30.000Z')]);
+    const { queued } = await readTranscriptExtras(p);
+    expect(queued.map(m => m.content)).toEqual([[{ type: 'text', text: 'mando io, tu verifica' }]]);
+  });
+
+  it('ignores a queued message that was delivered as its own turn', async () => {
+    // enqueue + dequeue is the normal path: the message becomes a real `user`
+    // row, so materializing it here would show the turn twice.
+    const p = writeJsonl([
+      queueRow('enqueue', 'poi committa', '2026-09-08T10:00:00.000Z'),
+      queueRow('dequeue', 'poi committa', '2026-09-08T10:00:05.000Z'),
+      userRow('u1', 'poi committa'),
+    ]);
+    const { queued } = await readTranscriptExtras(p);
+    expect(queued).toEqual([]);
+  });
+
+  it('gives each recovered message a distinct id', async () => {
+    const p = writeJsonl([
+      queueRow('remove', 'primo', '2026-09-08T10:00:00.000Z', 'absorbed_mid_turn'),
+      queueRow('remove', 'secondo', '2026-09-08T10:00:00.000Z', 'absorbed_mid_turn'),
+    ]);
+    const { queued } = await readTranscriptExtras(p);
+    expect(new Set(queued.map(m => m.uuid)).size).toBe(2);
+  });
+
+  it('maps a skill expansion to the row that invoked it', async () => {
+    const p = writeJsonl([
+      userRow('cmd1', '<command-name>/sara:sara-legacy-db</command-name>'),
+      skillExpansionRow('cmd1', '/Users/x/.claude/plugins/cache/isi/sara/skills/sara-legacy-db'),
+    ]);
+    const { skillPathByParentUuid } = await readTranscriptExtras(p);
+    expect(skillPathByParentUuid.get('cmd1')).toBe(
+      '/Users/x/.claude/plugins/cache/isi/sara/skills/sara-legacy-db'
+    );
+  });
+
+  it('survives a malformed line', async () => {
+    const p = writeJsonl([
+      '{"type":"queue-operation","operation":"remove",',
+      queueRow('remove', 'ok', '2026-09-08T10:00:00.000Z', 'absorbed_mid_turn'),
+    ]);
+    const { queued } = await readTranscriptExtras(p);
+    expect(queued).toHaveLength(1);
+  });
+});
+
+describe('mergeTranscriptExtras', () => {
+  const extrasOf = (queued: ChatMessage[], skills: [string, string][] = []) => ({
+    queued,
+    skillPathByParentUuid: new Map(skills),
+  });
+
+  it('leaves the transcript untouched when there is nothing to add', () => {
+    const messages = [msg('a', 'user', 'hi', '2026-09-08T10:00:00.000Z')];
+    expect(mergeTranscriptExtras(messages, extrasOf([]))).toBe(messages);
+  });
+
+  it('splices a recovered message at the moment it was typed', () => {
+    const messages = [
+      msg('a', 'user', 'fai la cosa', '2026-09-08T10:00:00.000Z'),
+      msg('b', 'assistant', 'fatto', '2026-09-08T10:05:00.000Z'),
+    ];
+    const queued = [
+      {
+        ...msg('q', 'user', 'anche il grafico', '2026-09-08T10:02:00.000Z'),
+        queued: true as const,
+      },
+    ];
+    expect(mergeTranscriptExtras(messages, extrasOf(queued)).map(m => m.uuid)).toEqual([
+      'a',
+      'q',
+      'b',
+    ]);
+  });
+
+  it('appends a recovered message that came after the last turn on record', () => {
+    const messages = [msg('a', 'assistant', 'fatto', '2026-09-08T10:00:00.000Z')];
+    const queued = [
+      { ...msg('q', 'user', 'grazie', '2026-09-08T10:09:00.000Z'), queued: true as const },
+    ];
+    expect(mergeTranscriptExtras(messages, extrasOf(queued)).map(m => m.uuid)).toEqual(['a', 'q']);
+  });
+
+  it('drops a recovered message the transcript already shows', () => {
+    const messages = [msg('a', 'user', 'poi committa', '2026-09-08T10:00:00.000Z')];
+    const queued = [
+      { ...msg('q', 'user', 'poi committa', '2026-09-08T09:59:00.000Z'), queued: true as const },
+    ];
+    expect(mergeTranscriptExtras(messages, extrasOf(queued)).map(m => m.uuid)).toEqual(['a']);
+  });
+
+  it('stamps the skill path on the message that invoked it, and only on it', () => {
+    const messages = [
+      msg('cmd1', 'user', '<command-name>/build-dmg</command-name>', '2026-09-08T10:00:00.000Z'),
+      msg('a', 'assistant', 'via', '2026-09-08T10:00:01.000Z'),
+    ];
+    const merged = mergeTranscriptExtras(messages, extrasOf([], [['cmd1', '/skills/build-dmg']]));
+    expect(merged[0].skillPath).toBe('/skills/build-dmg');
+    expect(merged[1].skillPath).toBeUndefined();
+  });
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -18,5 +18,9 @@
     "checkJs": false,
     "types": ["node", "vitest/globals", "vite/client"]
   },
-  "include": ["test"]
+  // `src/icons.d.ts` declares the `~icons/*` virtual modules unplugin-icons
+  // serves: a renderer test that mounts a chat component pulls in `fileIcons.tsx`,
+  // which imports them, and the renderer project gets the declaration for free
+  // from its own `include`.
+  "include": ["test", "src/icons.d.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vitest/config';
+import Icons from 'unplugin-icons/vite';
 
 export default defineConfig({
+  // Same icon plugin as the app build: the `~icons/*` imports in `fileIcons.tsx`
+  // are virtual modules, so without it any renderer test that mounts a chat
+  // component fails to resolve them. JSX itself needs no plugin here (esbuild
+  // reads `jsx: react-jsx` from the tsconfig).
+  plugins: [Icons({ compiler: 'jsx', jsx: 'react' })],
   test: {
     globals: true,
     environment: 'node',


### PR DESCRIPTION
Closes #245, closes #246.

The transcript view reads history through the Agent SDK alone, and `getSessionMessages` answers with chat rows only. Everything else Claude Code writes into a `.jsonl` is invisible to it — including two rows that carry things the view is supposed to show.

## What was wrong

| | on disk | in the view, before |
| --- | --- | --- |
| a message typed while Claude was working | `queue-operation` rows (`enqueue` + `remove`, usually `reason: "absorbed_mid_turn"`), never a `user` row | absent — Claude answers a question that is not on screen |
| a `/foo` slash command that was a skill | `<command-name>` row + an `isMeta` `Base directory for this skill: …` expansion | drawn as a plain built-in command: `isSkill` never set, so variant, orb and label are the generic command ones |

**43 of the 241 transcripts** on the machine this was found on hold at least one absorbed message (**85 messages**, Claude Code 2.1.247 → 2.1.263); **23** hold a skill expansion. The reported symptom — "the transcript doesn't match reality, my message is missing, it's as if invoking a skill broke everything" — is the first row of that table, seen next to a `Skill` card.

## What this does

A new `electron/modules/transcript-extras.ts` makes **one tolerant pass** over the same file and reports only what the SDK could not see; `readChatSessionViaSdk` merges it:

- absorbed messages spliced **at the moment they were typed** (the `enqueue` timestamp — the `remove` one is when the turn swallowed it), marked `queued`
- the skill's base dir stamped on the row that invoked it, as `skillPath`

It rides the existing cache entry, whose stamp is that file's `size:mtimeMs`, so a new row invalidates both passes together. With no `projectDir` we cannot know which file the SDK read, and the read stays SDK-only rather than guessing.

Only `operation: "remove"` rows are materialized. `enqueue`/`dequeue` is the *normal* path — a queued message later delivered as its own turn (166 enqueues with content here, 82 delivered) — and rendering those would show the same turn twice; a content check against the transcript's own user messages is kept as belt-and-braces.

In the renderer: a recovered message is an ordinary user bubble wearing a **"sent mid-turn"** chip in the turn header (the neutral header pill of the hidden-tools badge, dashed rather than dotted — it states a provenance, not a count), and the export carries the same marker in the markdown heading and the HTML turn head. `command.isSkill` now comes from `skillPath`, keeping the next-message peek for the live stream. While there, `skillOf` in `ChatView` is built from the same index the footer dock uses (`buildSkillIndex`, extracted from `correlateSessionSkills`) — the card resolved names against the project/global registry only, so a plugin skill was listed in the dock and drawn as a plain command a few hundred pixels above it.

## Tests

- `test/transcript-extras.test.ts` — the pass and the merge: reason-ful and reason-less removals, `enqueue`/`dequeue` ignored, the typed-at timestamp, the duplicate guard, the skill mapping, a malformed line
- `test/session-sdk-cache.test.ts` — end-to-end against the **real SDK** on a fixture carrying both rows: the message lands in chronological place, the command message carries its `skillPath`, the expansion itself stays out, and one cache entry serves both passes until the file grows
- `test/message-bubble-markers.test.tsx` — first test to mount `MessageBubble`: the chip appears (and doesn't on an ordinary turn), and a `skillPath` command renders the skill card instead of the plain one
- `test/chat-utils.test.ts` — the two `isSkill` claims were passing on a fixture production no longer produces (the `isMeta` row as the next message); rewritten on `skillPath`, with one kept on the peek for the live path

`typecheck` + `lint` + `format:check` + `test` (1195 passing) + `build` all green. Verified against real data too: the pass recovers 85 messages across 43 transcripts, and a full read of the session that surfaced the bug puts the lost message back between the tool result at 15:40:17 and the answer at 15:41:15.

Not in scope: `LiveChatView` and `SubagentTranscriptPanel` pass no `skillOf`, so a skill still reads as a command there; the `user` rows carrying `promptSource: "queued"` (a queued message that *was* delivered) are already visible and could wear the same chip later. The `electron/modules/CLAUDE.md` entry for the new module is left out of this branch on purpose — that file is mid-refactor in the working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
