### PR TITLE
Recover the frontmatter fields around a bad line instead of dropping them all

### DIFF
--- a/electron/modules/frontmatter.ts
+++ b/electron/modules/frontmatter.ts
@@ -10,7 +10,7 @@ import { load, dump } from 'js-yaml';
  *
  * Robust by design:
  * - no frontmatter block        -> { frontmatter: {}, body: content }
- * - malformed YAML / load throws -> { frontmatter: {}, body }
+ * - malformed YAML / load throws -> line-by-line recovery, see `recoverFields`
  * - YAML parses to a non-object  -> { frontmatter: {}, body }
  */
 export function parseFrontmatter(content: string): {
@@ -33,10 +33,87 @@ export function parseFrontmatter(content: string): {
       return { frontmatter: parsed as Record<string, unknown>, body };
     }
   } catch {
-    // Malformed frontmatter: fall through to the empty result, keeping the body.
+    // Malformed frontmatter: recover what the block still says instead of
+    // dropping every field because of one bad line.
+    return { frontmatter: recoverFields(match[1]), body };
   }
 
   return { frontmatter: {}, body };
+}
+
+/**
+ * A YAML indicator in first position means the value opens a flow collection, a
+ * block scalar, an anchor/alias or a directive — something whose meaning spans
+ * more than the line it starts on. Those we cannot recover by hand, so a value
+ * starting with one is dropped rather than kept as prose.
+ */
+const YAML_INDICATOR = /^[[{|>&*!%@`]/;
+
+/**
+ * Last-resort reader for a frontmatter block js-yaml refused to load. Skill and
+ * agent files are hand-written, and the single most common mistake is a `: `
+ * inside an unquoted description ("Serve anche per chiamare un'istanza: fa
+ * login da sé") — YAML reads that as a nested mapping and throws, which used to
+ * cost the file its name, description and every other field. Here each
+ * top-level `key: value` line is read on its own, so one bad line loses only
+ * itself. Claude Code shows those descriptions; ClaudeLens showing an empty
+ * one was our parse being stricter than the tool whose data we display.
+ *
+ * Values are still handed to js-yaml one line at a time, so `true`, `7`,
+ * `[a, b]` and quoted strings keep their type; only a line that fails on its
+ * own falls back to its raw text. Block lists (`- item` under a bare key) are
+ * collected; anything else indented is skipped.
+ */
+function recoverFields(block: string): Record<string, unknown> {
+  const fields: Record<string, unknown> = {};
+  let listKey: string | null = null;
+
+  for (const line of block.split('\n')) {
+    if (!line.trim() || line.trimStart().startsWith('#')) continue;
+
+    const item = line.match(/^\s*-\s+(.*)$/);
+    if (item && listKey) {
+      const value = scalar(item[1].trim());
+      if (value !== undefined) (fields[listKey] as unknown[]).push(value);
+      continue;
+    }
+
+    const field = line.match(/^([\w.-]+):\s*(.*)$/);
+    if (!field) continue;
+    const [, key, raw] = field;
+
+    if (!raw.trim()) {
+      // A bare key opens a block list; an empty value is nothing to record.
+      fields[key] = [];
+      listKey = key;
+      continue;
+    }
+    listKey = null;
+
+    const value = scalar(raw.trim());
+    if (value !== undefined) fields[key] = value;
+  }
+
+  // A bare key that no `- item` followed was not a list after all.
+  for (const [key, value] of Object.entries(fields)) {
+    if (Array.isArray(value) && value.length === 0) delete fields[key];
+  }
+  return fields;
+}
+
+/** Read one line's value as YAML, falling back to its raw text as a string. */
+function scalar(raw: string): unknown {
+  try {
+    const value = load(raw);
+    if (value === null) return undefined;
+    // A value that reads back as a mapping is the colon-space case itself:
+    // `Serve a questo: leggere` is valid YAML on its own line, just not the
+    // mapping the author meant. Only `{a: 1}` really asked to be one.
+    if (typeof value === 'object' && !Array.isArray(value) && !raw.startsWith('{')) return raw;
+    return value;
+  } catch {
+    return YAML_INDICATOR.test(raw) ? undefined : raw;
+  }
 }
 
 /**

--- a/test/frontmatter.test.ts
+++ b/test/frontmatter.test.ts
@@ -69,3 +69,67 @@ describe('frontmatter parsing under the YAML 1.2 core schema', () => {
     expect(getNumber(frontmatter, 'b')).toBe(8);
   });
 });
+
+// Skill and agent files are hand-written, and an unquoted `: ` inside a long
+// description is the mistake authors actually make. js-yaml reads it as a
+// nested mapping and throws — which used to cost the file every field it had,
+// so ClaudeLens showed a skill with no description at all while Claude Code
+// showed it fine. These pin the line-by-line recovery.
+describe('frontmatter recovery when js-yaml refuses the block', () => {
+  it('recovers a description carrying an unquoted colon-space, and the fields around it', () => {
+    const { frontmatter, body } = parseFrontmatter(
+      '---\n' +
+        'name: sara-legacy-db\n' +
+        'description: Interroga il database del Legacy. Le modifiche controllate: la lettura è libera, la scrittura no.\n' +
+        'model: sonnet\n' +
+        '---\n# Database\n'
+    );
+    expect(getString(frontmatter, 'name')).toBe('sara-legacy-db');
+    expect(getString(frontmatter, 'description')).toBe(
+      'Interroga il database del Legacy. Le modifiche controllate: la lettura è libera, la scrittura no.'
+    );
+    expect(getString(frontmatter, 'model')).toBe('sonnet');
+    expect(body).toBe('# Database\n');
+  });
+
+  it('keeps the type of the lines that are valid on their own', () => {
+    const { frontmatter } = parseFrontmatter(
+      '---\n' +
+        'background: true\n' +
+        'max-turns: 7\n' +
+        'paths: [src/api/**, src/db/**]\n' +
+        'quoted: "a: b"\n' +
+        'broken: Use when: the user asks\n' +
+        '---\nbody'
+    );
+    expect(getBoolean(frontmatter, 'background')).toBe(true);
+    expect(getNumber(frontmatter, 'max-turns')).toBe(7);
+    expect(getStringArray(frontmatter, 'paths')).toEqual(['src/api/**', 'src/db/**']);
+    expect(getString(frontmatter, 'quoted')).toBe('a: b');
+    expect(getString(frontmatter, 'broken')).toBe('Use when: the user asks');
+  });
+
+  it('recovers a block list, and drops a bare key no item followed', () => {
+    const { frontmatter } = parseFrontmatter(
+      '---\n' +
+        'allowed-tools:\n' +
+        '  - Read\n' +
+        '  - Bash\n' +
+        'empty:\n' +
+        'description: Serve a questo: leggere\n' +
+        '---\nbody'
+    );
+    expect(getStringArray(frontmatter, 'allowed-tools')).toEqual(['Read', 'Bash']);
+    expect(frontmatter).not.toHaveProperty('empty');
+    expect(getString(frontmatter, 'description')).toBe('Serve a questo: leggere');
+  });
+
+  it('drops only the field whose value opens a structure it cannot close', () => {
+    const { frontmatter } = parseFrontmatter(
+      '---\nname: api\npaths: [src/**\ndescription: Regole: quelle di sempre\n---\nbody'
+    );
+    expect(getString(frontmatter, 'name')).toBe('api');
+    expect(frontmatter).not.toHaveProperty('paths');
+    expect(getString(frontmatter, 'description')).toBe('Regole: quelle di sempre');
+  });
+});


### PR DESCRIPTION
## Il difetto

Due delle quattro skill di un plugin installato su questa macchina si mostravano in ClaudeLens **senza descrizione**, mentre Claude Code le legge entrambe senza problemi.

La causa è un `: ` (due punti + spazio) non quotato dentro la `description`, che è prosa scritta a mano:

```yaml
description: Serve anche per chiamare davvero un'istanza: fa login e sessione da sé.
```

Per YAML quello è una mappa annidata: `load()` lancia, e il `catch` di `parseFrontmatter` restituiva `{}` — il file perdeva `name`, `description`, `model`, **ogni** campo, per una riga sola. Il commento di `yamlScalar` documentava già il rischio, ma la protezione esisteva solo in scrittura.

## Il fix

Un blocco che js-yaml rifiuta viene ora riletto riga per riga (`recoverFields`), così una riga rotta perde solo se stessa:

- ogni `key: value` di primo livello passa a js-yaml **da sola**, quindi `true`, `7`, `[a, b]` e le stringhe quotate mantengono il tipo;
- un valore che rileggendolo risulta una **mappa** è proprio il caso colon-space (`Serve a questo: leggere` è YAML valido, solo non quello che l'autore intendeva) → si tiene il testo grezzo;
- un valore che apre una struttura che non chiude (`[src/**`, un block scalar, un anchor) viene **scartato** invece di essere tenuto come prosa: il suo significato sta su righe che non stiamo leggendo;
- le liste a blocco sotto una chiave nuda vengono raccolte; una chiave nuda che nessun `- item` segue non viene registrata.

Il percorso valido non cambia: il fallback si attiva solo dopo che `load()` ha lanciato.

## Verifica

`npm run format:check` + `typecheck` + `lint` + `test` (1199 passed). Quattro nuovi test in `test/frontmatter.test.ts` pinnano il recupero, la conservazione dei tipi, le liste a blocco e lo scarto selettivo; provato anche sui file reali del plugin, dove ora tutte e quattro le skill riportano nome e descrizione.

Il lato autore è sistemato a parte nel repo del plugin (description quotate), ma questo resta: ClaudeLens mostra i dati di Claude Code e non deve essere più severo di lui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014udKJTJXgJEearTn1VJrNa