### PR TITLE
Name each CLAUDE.md layer by its path, and order them like the cascade

### DIFF
--- a/src/components/project/CLAUDE.md
+++ b/src/components/project/CLAUDE.md
@@ -812,7 +812,24 @@ la usa la toolbar della subtab.
 (ancora) nessun ingresso di creazione memoria, solo l'IPC `memory:createTopic`
 e l'hook `useCreateTopic` inutilizzato; sarebbe una feature, non un cambio di
 layout. Fuori scope anche la «context chain» che collassa CLAUDE.md sotto
-l'hero: la sezione CLAUDE.md resta la tile-grid attuale.
+l'hero.
+
+La sezione **CLAUDE.md** ha invece lasciato la tile-grid per una **cascata a
+una colonna** (`.cl-md-cascade`/`.cl-md-layer`): ogni layer è un file con lo
+stesso nome, quindi lo scope da solo non distingue una riga dall'altra — con
+sei layer quattro righe si chiamavano `Subdir` e il path stava nella riga
+smorzata sotto. Ora **il path è il nome della riga**, spezzato da
+`claudeMdPathParts` in genitori smorzati + segmento identificante in evidenza +
+nome file smorzato (`src/components/`**`project/`**`CLAUDE.md`), e la parola
+generica scende a **chip di larghezza fissa** che allinea tutti i path sulla
+stessa colonna. L'ordine segue la cascata che la testata annuncia (global →
+project → local → subdir, i subdir per profondità poi alfabetici): la riga di
+intestazione fa da legenda solo se la lista la segue, mentre prima partiva dal
+project. L'accento passa quindi **dalla prima riga al layer `project`**, che
+resta quello che si apre più spesso. Una **barra proporzionale** dà la scala
+(36 righe contro 882) che una colonna di cifre lascia fare a mente; sotto i
+760px sparisce. Una colonna sola perché la cascata è una sequenza ordinata e la
+griglia a due colonne la faceva leggere a zig-zag.
 La sezione **Teams** conserva l'hero compatto (`cl-hero--compact`) e la
 vecchia meta-riga: è una vista operativa, non una landing di progetto.
 Il **filtro per tag** (`sessions/TagBar`) non è più una banda sotto il titolo:

--- a/src/components/project/overview/ProjectOverviewContent.tsx
+++ b/src/components/project/overview/ProjectOverviewContent.tsx
@@ -31,7 +31,7 @@ import {
   formatTokens,
   buildModelMix,
 } from '../utils';
-import type { SessionSummary, MemoryTopic } from '../../../types';
+import type { SessionSummary, MemoryTopic, ClaudeMdLayer } from '../../../types';
 import { Lens } from './Lens';
 import { ProjectDescription } from './ProjectDescription';
 import { McpServerGrid } from '../mcp/McpServerGrid';
@@ -303,6 +303,30 @@ const CLAUDE_MD_SCOPE_LABEL: Record<'global' | 'project' | 'local' | 'subdir', s
   subdir: 'Subdir',
   global: 'Global',
 };
+
+/** Ogni layer è un CLAUDE.md, quindi lo scope da solo non distingue una riga
+ *  dall'altra: quattro righe su sei si chiamavano "Subdir". Quello che le
+ *  distingue è la cartella che governano, così il path diventa il nome della
+ *  riga e viene spezzato in genitori (smorzati) + segmento identificante +
+ *  nome file (smorzato): la lista si legge sul segmento in evidenza senza
+ *  perdere il path intero. */
+function claudeMdPathParts(layer: ClaudeMdLayer, rootPath: string) {
+  if (layer.scope === 'global') {
+    return { prefix: '~/.claude/', focus: 'CLAUDE.md', suffix: '' };
+  }
+  const rel = layer.filePath.startsWith(rootPath + '/')
+    ? layer.filePath.slice(rootPath.length + 1)
+    : layer.filePath;
+  const cut = rel.lastIndexOf('/');
+  if (cut === -1) return { prefix: '', focus: rel, suffix: '' };
+  const dir = rel.slice(0, cut);
+  const up = dir.lastIndexOf('/');
+  return {
+    prefix: up === -1 ? '' : dir.slice(0, up + 1),
+    focus: dir.slice(up + 1) + '/',
+    suffix: rel.slice(cut + 1),
+  };
+}
 
 // Ripulisce la sintassi markdown e tronca per un'anteprima pulita.
 function memPreview(raw: string, max: number = MEM_PREVIEW_MAX): string {
@@ -745,9 +769,22 @@ export function ProjectView({
   }, [mcpData, project.realPath]);
 
   const claudeMdLayers = claudeMd?.layers.length ?? 0;
+  // Ordinati come la cascata che l'intestazione annuncia (global → project →
+  // local → subdir), non con il project in testa: la riga d'intestazione fa da
+  // legenda della lista solo se la lista la segue. I subdir vengono dopo, per
+  // profondità e poi alfabetici, così il ramo si legge dall'alto.
   const claudeMdLayerList = useMemo(() => {
-    const order = { project: 0, local: 1, subdir: 2, global: 3 } as const;
-    return [...(claudeMd?.layers ?? [])].sort((a, b) => order[a.scope] - order[b.scope]);
+    const order = { global: 0, project: 1, local: 2, subdir: 3 } as const;
+    const rows = [...(claudeMd?.layers ?? [])]
+      .map(layer => ({ layer, lines: layer.content.split('\n').length }))
+      .sort((a, b) => {
+        const byScope = order[a.layer.scope] - order[b.layer.scope];
+        if (byScope !== 0) return byScope;
+        const depth = a.layer.filePath.split('/').length - b.layer.filePath.split('/').length;
+        return depth !== 0 ? depth : a.layer.filePath.localeCompare(b.layer.filePath);
+      });
+    const maxLines = rows.reduce((m, r) => Math.max(m, r.lines), 1);
+    return rows.map(r => ({ ...r, weight: r.lines / maxLines }));
   }, [claudeMd]);
   const skillCount = allSkills.length;
   const agents = useMemo(() => {
@@ -1078,32 +1115,36 @@ export function ProjectView({
             {claudeMdLayers === 0 ? (
               <div className="cl-empty">No CLAUDE.md instructions for this project.</div>
             ) : (
-              <div className="cl-tile-grid">
-                {claudeMdLayerList.map((l, i) => {
-                  const lines = l.content.split('\n').length;
-                  const path =
-                    l.scope === 'global'
-                      ? '~/.claude/CLAUDE.md'
-                      : l.filePath.startsWith(project.realPath + '/')
-                        ? l.filePath.slice(project.realPath.length + 1)
-                        : l.filePath;
+              /* Una colonna sola: la cascata è una sequenza ordinata, e la
+                 griglia a due colonne la faceva leggere a zig-zag. */
+              <div className="cl-md-cascade">
+                {claudeMdLayerList.map(({ layer: l, lines, weight }) => {
+                  const { prefix, focus, suffix } = claudeMdPathParts(l, project.realPath);
                   return (
                     <button
                       key={l.filePath}
                       type="button"
-                      className={`cl-tile ${i === 0 ? 'accent' : ''}`}
+                      className="cl-md-layer"
+                      data-scope={l.scope}
+                      title={l.scope === 'global' ? '~/.claude/CLAUDE.md' : l.filePath}
                       onClick={() =>
                         l.scope === 'global'
                           ? onNavigate({ type: 'global-claudemd' })
                           : onNavigate({ type: 'project-claudemd', project, layer: l })
                       }
                     >
-                      <span className="glyph">M</span>
-                      <div style={{ minWidth: 0 }}>
-                        <div className="t-name">{CLAUDE_MD_SCOPE_LABEL[l.scope]}</div>
-                        <div className="t-desc">{path}</div>
-                      </div>
-                      <span className="t-meta">
+                      <span className="scope">{CLAUDE_MD_SCOPE_LABEL[l.scope]}</span>
+                      <span className="path">
+                        {prefix && <span className="dim">{prefix}</span>}
+                        <span className="focus">{focus}</span>
+                        {suffix && <span className="dim">{suffix}</span>}
+                      </span>
+                      {/* 36 righe contro 882: la barra dice a colpo d'occhio
+                          quale layer pesa davvero nel contesto. */}
+                      <span className="weight" aria-hidden="true">
+                        <i style={{ width: `${Math.max(4, Math.round(weight * 100))}%` }} />
+                      </span>
+                      <span className="lines">
                         <b>{lines}</b> lines
                       </span>
                     </button>

--- a/src/index.css
+++ b/src/index.css
@@ -11315,6 +11315,115 @@ button.cl-sw-member:focus-visible,
   letter-spacing: 0.02em;
 }
 
+/* ── CLAUDE.md cascade (landing di progetto) ──────────────────────────────
+   Sei layer sono sei file con lo stesso nome: l'unica cosa che li distingue è
+   la cartella che governano, quindi il path è il nome della riga e lo scope
+   scende a chip. Come tile-grid quattro righe su sei si chiamavano "Subdir" e
+   il path stava nella riga smorzata sotto; qui la parola generica è un chip di
+   larghezza fissa che allinea tutti i path sulla stessa colonna, il segmento
+   identificante è in evidenza fra genitori e nome file smorzati, e la barra a
+   destra dà la scala (36 righe contro 882) che una colonna di cifre lascia
+   fare a mente. Una colonna sola: la cascata è una sequenza ordinata e le due
+   colonne la facevano leggere a zig-zag. */
+.cl-md-cascade {
+  border-top: 1px solid var(--cl-ink);
+  border-bottom: 1px solid var(--cl-line-soft);
+}
+.cl-md-layer {
+  display: grid;
+  grid-template-columns: 76px minmax(0, 1fr) 88px auto;
+  align-items: center;
+  gap: 20px;
+  width: 100%;
+  padding: 14px 2px 14px 0;
+  border: none;
+  border-bottom: 1px solid var(--cl-line-soft);
+  background: transparent;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  transition: background 100ms;
+}
+.cl-md-layer:last-child {
+  border-bottom: none;
+}
+.cl-md-layer:hover {
+  background: var(--cl-glass-hover-bg);
+}
+.cl-md-layer .scope {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  font-weight: 500;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+  text-align: center;
+  color: var(--cl-ink-4);
+  border: 1px solid var(--cl-line);
+  border-radius: var(--cl-r-pill);
+  padding: 3px 0 4px;
+}
+/* Il CLAUDE.md del progetto è quello che si apre più spesso: l'accento sta lì
+   e non sulla prima riga, che ora è il globale. */
+.cl-md-layer[data-scope='project'] .scope {
+  color: var(--cl-accent-ink);
+  border-color: var(--cl-accent);
+  background: var(--cl-accent-soft);
+}
+.cl-md-layer .path {
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  line-height: 1.4;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.cl-md-layer .path .dim {
+  color: var(--cl-ink-4);
+}
+.cl-md-layer .path .focus {
+  color: var(--cl-ink);
+  font-weight: 600;
+}
+.cl-md-layer .weight {
+  height: 3px;
+  border-radius: 2px;
+  background: var(--cl-line-soft);
+  overflow: hidden;
+}
+.cl-md-layer .weight i {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: color-mix(in oklch, var(--cl-accent) 42%, transparent);
+}
+.cl-md-layer:hover .weight i,
+.cl-md-layer[data-scope='project'] .weight i {
+  background: var(--cl-accent);
+}
+.cl-md-layer .lines {
+  min-width: 66px;
+  text-align: right;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+  color: var(--cl-ink-4);
+}
+.cl-md-layer .lines b {
+  color: var(--cl-ink-2);
+  font-weight: 500;
+}
+@media (max-width: 760px) {
+  .cl-md-layer {
+    grid-template-columns: 68px minmax(0, 1fr) auto;
+    gap: 14px;
+  }
+  .cl-md-layer .weight {
+    display: none;
+  }
+}
+
 /* Dense, single-line "file row" variant (skill supporting files): smaller
    glyph, name left, size right — reads like a file manager instead of a card. */
 .cl-tile--file {


### PR DESCRIPTION
## What

The project landing's **CLAUDE.md** section leaves the two-column tile grid for a single-column cascade (`.cl-md-cascade` / `.cl-md-layer`).

Every layer is a file called `CLAUDE.md`, so the scope word alone never told one row from another: with six layers, four of them read **Subdir**, and the only thing separating them — the directory they govern — sat in the dimmed line underneath.

## Changes

- **The path is the name of the row.** `claudeMdPathParts` splits it into dimmed parents + the identifying segment in full ink + the dimmed filename (`src/components/`**`project/`**`CLAUDE.md`), and the generic scope word drops to a fixed-width chip that lines every path up on the same column.
- **Ordered like the cascade the caption announces** — global → project → local → subdir, subdirs by depth then alphabetically — instead of starting at the project layer. A header only reads as a legend if the list follows it, so the accent moves off "the first row" and onto the `project` layer itself, the one actually opened most often.
- **A proportional bar** carries the scale a column of figures leaves the reader to work out (36 lines against 882). Dropped below 760px, where the path needs the width more.
- **One column**, because a cascade is an ordered sequence and the two-column grid made it read in a zig-zag.

No shared classes were touched: `.cl-tile` / `.cl-tile-grid` keep every other call site (Skills, Agents, Plugins, memory) exactly as they were, and the new rules use only existing brand tokens — no new hue.

## Verification

`npm run typecheck`, `npm run lint` and `npm test` (1199 passing) are green; formatting passes `prettier --check`. Visual/layout behaviour has no automated coverage in this repo, so the rendering itself still wants a human look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJ5zH8yCPBK4Khn4auYzgw
