### PR TITLE
perf: stop the incremental parse caches from pinning whole transcripts

### DIFF
--- a/electron/modules/cost-tracker.ts
+++ b/electron/modules/cost-tracker.ts
@@ -455,8 +455,22 @@ const parseStats = {
 
 export function getParseStats() {
   let cachedFiles = 0;
-  for (const byFile of parseCache.values()) cachedFiles += byFile.size;
-  return { ...parseStats, cachedFiles };
+  // `retainedPartialBytes` is what the cache costs in `external` memory, and it
+  // is the number whose absence let a `subarray` view pin whole transcripts
+  // unnoticed. Distinct backing stores, not view lengths: small copies come out
+  // of Node's shared 8 KB buffer pool, so billing every entry for its
+  // `buffer.byteLength` would count that one slab once per cached file.
+  const backings = new Set<ArrayBufferLike>();
+  let retainedPartialBytes = 0;
+  for (const byFile of parseCache.values()) {
+    cachedFiles += byFile.size;
+    for (const { partial } of byFile.values()) {
+      if (backings.has(partial.buffer)) continue;
+      backings.add(partial.buffer);
+      retainedPartialBytes += partial.buffer.byteLength;
+    }
+  }
+  return { ...parseStats, cachedFiles, retainedPartialBytes };
 }
 
 export function resetParseCache() {
@@ -670,7 +684,14 @@ async function parseSession(filePath: string): Promise<ParsedSession> {
     }
   }
 
-  entry.partial = combined.subarray(start);
+  // A *copy* of the trailing partial line, not a view onto it. `subarray` shares
+  // the backing ArrayBuffer, so parking that view in a process-lifetime cache
+  // pins everything `combined` was read from — on a full parse, the entire
+  // transcript. Measured on a real `~/.claude` (92 transcripts, 419 MB of
+  // JSONL): the main process held 333 MB of `external` memory and its RSS fell
+  // from 520 MB to 179 MB the moment the cache was cleared by hand. The bytes
+  // we actually need are the ones after the last newline, usually a few dozen.
+  entry.partial = Buffer.from(combined.subarray(start));
   entry.consumed += chunk.length;
   entry.mtimeMs = st.mtimeMs;
   cacheSet(filePath, entry);

--- a/electron/modules/plans-reader.ts
+++ b/electron/modules/plans-reader.ts
@@ -138,8 +138,19 @@ const refStats = { cacheHits: 0, fullParses: 0, incrementalParses: 0, fileReads:
 
 export function getPlanRefStats() {
   let cachedFiles = 0;
-  for (const byFile of refCache.values()) cachedFiles += byFile.size;
-  return { ...refStats, cachedFiles };
+  // See `getParseStats` in cost-tracker: distinct backing stores, because a
+  // small copy is pooled and would otherwise be billed once per cached file.
+  const backings = new Set<ArrayBufferLike>();
+  let retainedPartialBytes = 0;
+  for (const byFile of refCache.values()) {
+    cachedFiles += byFile.size;
+    for (const { partial } of byFile.values()) {
+      if (backings.has(partial.buffer)) continue;
+      backings.add(partial.buffer);
+      retainedPartialBytes += partial.buffer.byteLength;
+    }
+  }
+  return { ...refStats, cachedFiles, retainedPartialBytes };
 }
 
 export function resetPlanRefCache() {
@@ -255,7 +266,10 @@ export async function readPlanRefs(sessionFilePath: string): Promise<PlanRef[]> 
       start = i + 1;
     }
   }
-  entry.partial = combined.subarray(start);
+  // A copy, not a view — same reason as `cost-tracker.parseSession`: `subarray`
+  // shares the backing ArrayBuffer, so keeping it in `refCache` for the life of
+  // the process would pin every byte this parse read, not the unterminated tail.
+  entry.partial = Buffer.from(combined.subarray(start));
   entry.consumed += chunk.length;
   entry.mtimeMs = st.mtimeMs;
   cacheSet(sessionFilePath, entry);

--- a/test/cost-tracker.test.ts
+++ b/test/cost-tracker.test.ts
@@ -930,3 +930,63 @@ describe('pricing table — rates verified against the official pricing page', (
     expect(getPricingMeta().knownModels).toContain('claude-sonnet-5');
   });
 });
+
+// ─── Parse cache: what the cached entry is allowed to keep alive ──────────────
+
+describe('parse cache — retained bytes', () => {
+  it('keeps the unterminated tail, not the transcript it was read from', async () => {
+    resetParseCache();
+    // A transcript whose last line has no newline yet, which is the only reason
+    // the cache holds bytes at all: the tail is folded once the rest arrives.
+    const lines: string[] = [];
+    for (let i = 0; i < 4000; i++) {
+      lines.push(
+        assistantLine({
+          model: 'claude-sonnet-4-5',
+          input: 10,
+          output: 5,
+          id: `m${i}`,
+          requestId: `r${i}`,
+        })
+      );
+    }
+    const unterminated = '{"type":"assistant","message":{"id":"tail"';
+    const body = lines.join('\n') + '\n' + unterminated;
+    writeFileSync(join(tmp, 'a.jsonl'), body, 'utf-8');
+    expect(body.length).toBeGreaterThan(512 * 1024);
+
+    const [session] = await getSessionList(tmp);
+    const stats = getParseStats();
+
+    // The tail is buffered rather than folded or dropped…
+    expect(session.messageCount).toBe(4000);
+    expect(stats.cachedFiles).toBe(1);
+    // …and it is a copy: a `subarray` view would pin all 512 KB+ of `combined`
+    // for the life of the process, once per cached transcript.
+    expect(stats.retainedPartialBytes).toBeLessThan(64 * 1024);
+  });
+
+  it('drops the retained bytes with the entry when the transcript vanishes', async () => {
+    resetParseCache();
+    writeFileSync(
+      join(tmp, 'a.jsonl'),
+      assistantLine({
+        model: 'claude-sonnet-4-5',
+        input: 10,
+        output: 5,
+        id: 'm1',
+        requestId: 'r1',
+      }) +
+        '\n' +
+        '{"type":"assistant","message":{"id":"tail"',
+      'utf-8'
+    );
+    await getSessionList(tmp);
+    expect(getParseStats().cachedFiles).toBe(1);
+
+    rmSync(join(tmp, 'a.jsonl'));
+    await getSessionList(tmp);
+
+    expect(getParseStats()).toMatchObject({ cachedFiles: 0, retainedPartialBytes: 0 });
+  });
+});

--- a/test/plans-reader.test.ts
+++ b/test/plans-reader.test.ts
@@ -257,3 +257,23 @@ describe('cache dei plan ref — potatura dei transcript spariti', () => {
     expect(getPlanRefStats()).toMatchObject({ cachedFiles: 1, evictions: 1, cacheHits: 1 });
   });
 });
+
+describe('ref cache — retained bytes', () => {
+  it('keeps the unterminated tail, not the transcript it was read from', async () => {
+    const lines: string[] = [];
+    for (let i = 0; i < 4000; i++) {
+      lines.push(planLine(`/p/${i}.md`, 'plan_mode', '2026-01-01T00:00:00Z'));
+    }
+    const body = lines.join('\n') + '\n' + '{"type":"attachment","attachment":{"type":"plan_mode"';
+    writeFileSync(transcript, body, 'utf-8');
+    expect(body.length).toBeGreaterThan(256 * 1024);
+
+    const refs = await readPlanRefs(transcript);
+
+    expect(refs).toHaveLength(4000);
+    // A `subarray` view of the tail would pin every byte just read, for the
+    // life of the process — see the same fix in cost-tracker.parseSession.
+    expect(getPlanRefStats()).toMatchObject({ cachedFiles: 1 });
+    expect(getPlanRefStats().retainedPartialBytes).toBeLessThan(64 * 1024);
+  });
+});


### PR DESCRIPTION
## The bug

`cost-tracker.parseSession` and `plans-reader.readPlanRefs` both end an incremental
read by parking the unterminated final line in a module-level cache that lives for
the whole process:

```js
entry.partial = combined.subarray(start);
```

`subarray` returns a **view**, sharing the backing `ArrayBuffer`. So every cache
entry pins all the bytes that parse just read — the entire transcript on a full
parse — in order to keep the few dozen bytes after the last newline.

## Measured

A/B on the same compiled module with only that line reverted, run over a real
`~/.claude/projects` (94 transcripts, 424 MB of JSONL), after a forced GC:

| | `subarray` view | `Buffer.from` copy |
|---|---|---|
| `external` | 375.2 MB | 1.5 MB |
| `rss` | 510 MB | 92 MB |
| bytes pinned by the cache | 373.7 MB | ~0 |
| cached files | 73 | 73 |
| result of `calculateCostSummary` | identical | identical |

Same number of cache entries and the same answer, so this is retention only, not
behaviour. In the packaged app it moves the main process on a fresh launch from
547 MB to 176 MB RSS (`RssAnon` 430 MB to 55 MB), and the whole app from 1029 MB
to 655 MB RSS / 684 MB to 309 MB PSS.

## The change

- `Buffer.from(...)` copies the tail instead of viewing it, in both modules.
- `getParseStats()` and `getPlanRefStats()` gained `retainedPartialBytes`, which is
  the number whose absence let this go unnoticed. It counts **distinct backing
  stores**, because a small copy comes out of Node's shared 8 KB buffer pool and
  per-entry accounting would bill that one slab once per cached file.
- Tests in `test/cost-tracker.test.ts` and `test/plans-reader.test.ts` that fail
  without the fix (they report ~950 KB and ~475 KB pinned against a 64 KB bound)
  and pass with it, plus one that the retained bytes go away with the entry when a
  transcript vanishes.

`transcript-tail.readAppend` uses the same idiom, but its `pending` is loop-local
and capped by `MAX_LINE_BYTES`, so it holds nothing after the call and is untouched.

## Checks

`format:check`, `typecheck`, `lint --max-warnings 0` and `build` are clean on top of
`main`. The suite is 1303 passed / 5 failed, and those 5 are
`test/memory-graph-real.test.ts` failing identically on unmodified `main` on this
machine: it probes the local memory archives, and three of mine are too small to
reach the modularity threshold.
