### PR TITLE
Bound the retained bytes by the buffer pool, not by a literal that matched it (#258)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,16 @@ concurrency:
 
 jobs:
   verify:
-    name: Format · Typecheck · Lint · Test · Build
+    name: Format · Typecheck · Lint · Test · Build (node ${{ matrix.node }})
     runs-on: ubuntu-latest
+    # `engines` says node >=22, so the suite has to hold on every major that
+    # satisfies it. Pinning 22 alone is what let #258 sit unnoticed: two
+    # assertions were bounded by a literal that happened to equal Node 22's
+    # `Buffer.poolSize`, and went red on 24 without CI ever saying so.
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [22, 24]
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -21,7 +29,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v7
         with:
-          node-version: 22
+          node-version: ${{ matrix.node }}
           cache: npm
 
       - name: Install dependencies

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,13 @@ cache's invalidation, and the merge of the rows the SDK read does not return
 (#245/#246 — a message absorbed mid-turn lands in chronological place and a
 slash-command skill gets its `skillPath`, both from one extra pass over the
 same file). CI (`.github/workflows/ci.yml`) runs format:check +
-typecheck + lint + test + build on every push/PR. **Test order is randomised**
+typecheck + lint + test + build on every push/PR, **on Node 22 and 24 both** —
+`engines` says `>=22`, so a claim the suite only holds on one of them is a claim
+the project does not make. Pinning 22 alone is what hid #258: two assertions were
+bounded by the literal `64 * 1024`, which happened to equal Node 22's
+`Buffer.poolSize`, and went red on 24 — where that pool is exactly 65536 — while
+CI stayed green. A bound that has to describe an allocation belongs to
+`Buffer.poolSize`, never to a number that matches it today. **Test order is randomised**
 (`sequence.shuffle` in `vitest.config.ts`): every `it` has to be an independent
 claim, and three files had quietly stopped being that — one test created the
 workflow the next edited, another appended to a transcript a later one measured,

--- a/test/cost-tracker.test.ts
+++ b/test/cost-tracker.test.ts
@@ -1142,7 +1142,16 @@ describe('parse cache — retained bytes', () => {
     expect(stats.cachedFiles).toBe(1);
     // …and it is a copy: a `subarray` view would pin all 512 KB+ of `combined`
     // for the life of the process, once per cached transcript.
-    expect(stats.retainedPartialBytes).toBeLessThan(64 * 1024);
+    //
+    // The bound is `Buffer.poolSize`, not a literal: a copy this small is served
+    // from Node's shared buffer pool, so the backing store it reports IS the
+    // pool chunk. The literal `64 * 1024` this used to carry was that chunk's
+    // size on Node 22 by coincidence — Node 24 raised `poolSize` from 8192 to
+    // exactly 65536 and the assertion failed on a copy it should have passed
+    // (#258). A `subarray` view still fails it: `combined` is far too large to
+    // be pooled, so its backing store is the whole half-megabyte.
+    expect(stats.retainedPartialBytes).toBeLessThanOrEqual(Buffer.poolSize);
+    expect(stats.retainedPartialBytes).toBeLessThan(body.length / 4);
   });
 
   it('drops the retained bytes with the entry when the transcript vanishes', async () => {

--- a/test/plans-reader.test.ts
+++ b/test/plans-reader.test.ts
@@ -274,6 +274,8 @@ describe('ref cache — retained bytes', () => {
     // A `subarray` view of the tail would pin every byte just read, for the
     // life of the process — see the same fix in cost-tracker.parseSession.
     expect(getPlanRefStats()).toMatchObject({ cachedFiles: 1 });
-    expect(getPlanRefStats().retainedPartialBytes).toBeLessThan(64 * 1024);
+    // Bounded by the buffer pool the copy is served from, not by a literal —
+    // see the same assertion in `cost-tracker.test.ts` and #258.
+    expect(getPlanRefStats().retainedPartialBytes).toBeLessThanOrEqual(Buffer.poolSize);
   });
 });


### PR DESCRIPTION
## What this changes

`npm test` is red on Node 24 and green on Node 22. Two assertions, one message: `expected 65536 to be less than 65536` (`test/cost-tracker.test.ts:1127`, `test/plans-reader.test.ts:277`).

Both bound `retainedPartialBytes`, which is the size of the backing `ArrayBuffer` of the retained partial line (`electron/modules/cost-tracker.ts:534-541`). The tail is stored as a copy rather than a `subarray` view precisely so it cannot pin the 512 KB+ transcript it came from (`cost-tracker.ts:770`) — and a copy that small is served out of Node's shared buffer pool, so the backing store it reports is the pool chunk, not the copy. Node 24 raised `Buffer.poolSize` from 8192 to exactly 65536, landing on the threshold:

```
v22.14.0  Buffer.poolSize = 8192   | Buffer.from(...).buffer.byteLength = 8192
v24.18.0  Buffer.poolSize = 65536  | Buffer.from(...).buffer.byteLength = 65536
```

The production code was right the whole time. What was stale is the bound: `64 * 1024` silently encoded an assumption about Node's allocator, so both assertions now read `toBeLessThanOrEqual(Buffer.poolSize)` — a bound that describes an allocation belongs to the allocator, not to a number that happens to match it today. The cost-tracker test also keeps a second assertion against the transcript's own size, which is the claim it was written to make.

CI now runs the suite on **Node 22 and 24 both**. `engines` says `>=22`, so a suite that only holds on one of them is a claim the project does not make — and pinning 22 alone is exactly what let this sit unnoticed.

Closes #258

## How to verify

```bash
npm test                      # on Node 22
nvm use 24 && npm test        # and on Node 24
```

Both green here: 1367 passed, 3 skipped, 81 files, on 22.14.0 and 24.18.0.

The assertion keeps the defect it was written for. Putting the bug back — `entry.partial = combined.subarray(start)` in `cost-tracker.ts` — fails it on Node 24 with `expected 953822 to be less than or equal to 65536`, so the test still tells a view from a copy rather than passing on everything.

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] `npm run build` passes
- [ ] Visual changes validated manually with `npm run dev`
- [x] Tests added or updated — pure modules under `electron/modules/`, and
      renderer hooks holding stream or cache state (see
      `test/helpers/fake-electron-api.ts`)
- [x] `CLAUDE.md` updated if the architecture, an IPC namespace, or a convention changed

## Screenshots

No UI changes.
