### PR TITLE
Teach the packager Electron 44's ABI, and run the packager before the tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,3 +98,38 @@ jobs:
         run: npm test -- terminal-spawn.integration claude-cli
         env:
           CLAUDE_E2E: '1'
+
+  # The step that used to run only on a tag — and so could only fail there.
+  #
+  # `npm run build` is tsc + Vite; it says nothing about whether the app can be
+  # PACKAGED. Electron 44 landed with electron-builder's bundled node-abi still
+  # unaware of its ABI, every platform job of release.yml died on `Could not
+  # detect abi for version 44.3.0`, and the Release was published with no
+  # binaries at all — because nothing between the dependency PR and the tag ever
+  # invoked electron-builder.
+  #
+  # `--dir` stops after the app directory: it resolves the ABI, packs the asar
+  # and runs the entry-point sanity check — the three things that broke — without
+  # spending the minutes an installer costs. Linux only; the failure mode is in
+  # the packager, not in any one platform's target.
+  package-smoke:
+    name: Package smoke (electron-builder --dir)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Pack (no installer)
+        run: npx electron-builder --dir --linux

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,19 @@ Before creating a GitHub Release, always run these steps **in order**:
 3. Commit both changes together (e.g., `chore: bump to v2.1.2, claude-code 2.1.191`)
 4. Create the GitHub Release with a `## Highlights` section at the top
 
+**A dependency bump can break packaging without CI noticing — that is what
+`package-smoke` is for.** `npm run build` is tsc + Vite and says nothing about
+whether the app can be PACKAGED: Electron 44 landed with electron-builder's
+bundled `node-abi` unaware of its ABI, every platform job died on `Could not
+detect abi for version 44.3.0`, and v2.2.20 was published with no binaries at
+all — because nothing between the dependency PR and the tag ever invoked
+electron-builder. The fix is an `overrides` pin on `node-abi` in `package.json`
+(electron-builder ships a range that lags new Electron majors), and the guard is
+the `package-smoke` job: `electron-builder --dir` resolves the ABI, packs the
+asar and runs the entry-point check without spending the minutes an installer
+costs. When an Electron major lands and packaging fails on the ABI, bump that
+pin rather than reverting Electron.
+
 **Binaries are built and attached by CI, not locally**: pushing the `v*` tag
 (which `gh release create` does) triggers `.github/workflows/release.yml` — it
 packages macOS DMG (x64 + arm64), Windows exe (windows-2022 runner) and Linux

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claudelens-app",
-  "version": "2.2.19",
+  "version": "2.2.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claudelens-app",
-      "version": "2.2.19",
+      "version": "2.2.20",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -9209,9 +9209,9 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.31.0.tgz",
-      "integrity": "sha512-Erq5w/t3syw3s4sDsUaX4QttIdBPsGKTT1DTRsCkTonGggczhlDKm/wDX3o+HPJpQ41EjXCbcmXf0tgr5YZJXw==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.35.0.tgz",
+      "integrity": "sha512-ymk4aIzxdPopw2giv8Fs1Ec6vybGkjmyxUwVqhkI4MCy2tVfXdkOGGWieWVjL0THgH+7a8lRdevyupoYj3Js/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
     "electron:build": "electron-builder",
     "screenshot": "SCREENSHOT_MODE=true concurrently -k \"vite\" \"tsc -p tsconfig.electron.json -w\" \"wait-on http://localhost:5173 dist-electron/main.js && electron .\""
   },
+  "overrides": {
+    "node-abi": "^4.35.0"
+  },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.235",
     "@tailwindcss/typography": "^0.5.20",


### PR DESCRIPTION
## What this changes

`v2.2.20` was published with **no binaries**. Every platform job of `release.yml` died on the same line:

```
⨯ Could not detect abi for version 44.3.0 and runtime electron.
  Updating "node-abi" might help solve this issue if it is a new release of electron
```

electron-builder 26.15.3 is the latest release, and it resolves `node-abi` 4.31.0, which predates Electron 44 and cannot map it to an ABI. `node-abi` 4.35.0 knows it (ABI 149), so this pins that floor with an `overrides` entry in `package.json`. Electron itself stays on 44.

The second half is why it reached a tag at all. CI runs `npm run build`, which is tsc + Vite and says nothing about whether the app can be *packaged*; `electron-builder` ran for the first time on the tag push, where the only way to find out is a failed release. `package-smoke` closes that: `electron-builder --dir` resolves the ABI, packs the asar and runs the entry-point sanity check — the three things that broke — and stops before building installers, so it costs a fraction of a real release. Linux only, since the failure is in the packager rather than in any one platform's target.

## How to verify

```bash
npm ci
node -e "console.log(require('node-abi').getAbi('44.3.0','electron'))"   # 149, was an error
npm run build && npx electron-builder --dir --linux
```

Verified end to end on this machine rather than at the ABI lookup alone — a full mac package with the override in place produces both installers:

```
release/ClaudeLens-2.2.20-arm64.dmg   245 MB
release/ClaudeLens-2.2.20-x64.dmg     249 MB
```

Gates: format, typecheck, lint and build clean; 1367 tests pass, 3 skipped.

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] `npm run build` passes
- [ ] Visual changes validated manually with `npm run dev`
- [ ] Tests added or updated — pure modules under `electron/modules/`, and
      renderer hooks holding stream or cache state (see
      `test/helpers/fake-electron-api.ts`)
- [x] `CLAUDE.md` updated if the architecture, an IPC namespace, or a convention changed

## Screenshots

No UI changes.
