### PR TITLE
Strip the project landing to its hero and session list (design 3b)

### DIFF
--- a/src/components/project/CLAUDE.md
+++ b/src/components/project/CLAUDE.md
@@ -69,7 +69,7 @@ Formatter puri (nessuna dipendenza React):
 - **`useThoughtStream.ts`** — **Hook: una frase alla volta, temporizzata per la lettura.** La sorgente sono i `messages` che il chiamante ha già (la lettura watcher-driven del Lens, lo stream della chat live) — nessuna IPC e nessun watcher in più. La **coda vive in un ref e a renderizzare è l'orologio**: lo stato React è solo la frase a schermo e l'unico posto che la scrive è la callback del timer (`pump`). Non è un aggiramento della regola `react-hooks/set-state-in-effect` ma la forma onesta della cosa — una riga temporizzata è un sistema esterno con un clock, e questo hook lo pilota e lo ascolta; derivarla dai `messages` con un `setState` nel corpo dell'effect avrebbe anche ri-renderizzato a ogni raffica del watcher di una sessione che non aveva niente da dire. `until` è **assoluto**: l'effect ri-gira a ogni append, e re-armare il timer deve re-armare lo **stesso** istante, altrimenti una sessione attiva congelerebbe una frase a schermo (coperto da `test/thought-stream.test.tsx`, l'unico test che cade se la scadenza diventa relativa)
 - **`ThoughtLine.tsx`** — La riga di commento, resa da `ChatControlPill` **dentro `.cl-pill-wrap`** e posizionata in assoluto sopra di esso. Il posto **è** il progetto: erediterebbe — ed eredita — ogni offset di fondo che il wrap già porta (Lens nudo, composer, composer locked) senza ridichiararne uno, sta fuori dal flusso quindi non può allargare la pill su cui galleggia (il wrap è `align-items: stretch`: una frase da 58 caratteri come figlio flex la stirerebbe), e cade dentro il padding che la colonna di lettura riserva già sotto il transcript — quindi non copre nessun turno e non muove niente. Iniettarla nel transcript non è mai stata un'opzione: quella lista è finestrata con misura per riga e bottom-pinned, e righe effimere litigherebbero con entrambi
 - **`FocusMinimap.tsx`** — Minimap a filo del layout Focus (`cl-focus-rail`): un dot proporzionale per turno-messaggio, ruler adattivo (spacing/anelli scalano con la densità misurata via ResizeObserver), label in hover, scroll-spy
-- **`ChatControlPill.tsx`** — Pill flottante glass (`cl-pill`) coi controlli del transcript: filtri per tipo + toggle densità Min/Full, **agent dock** + **skill dock** (`AgentDockSheet`/`SkillDockSheet` + orb cluster), e lo sheet Export/Delete. Alza **un solo sheet alla volta** (`'agents' | 'skills' | 'export'`); registra un opener imperativo (`openExportRef`) per il bottone export per-turno. Estratto da `ChatView`. Ospita anche il **commento in corsa**: la `ThoughtLine` sopra il wrap e il toggle `Notes` (`.cl-pill-narrate`, `NarrateGlyph`) tra la densità e i dock. Il toggle compare **solo se `onToggleThoughts` è passato**, cosa che `ChatView` fa soltanto per una sessione viva nel registro: un controllo permanente per qualcosa che non può mai parlare è un controllo per niente
+- **`ChatControlPill.tsx`** — Pill flottante glass (`cl-pill`) coi controlli del transcript: filtri per tipo + toggle densità Min/Full, **agent dock** + **skill dock** (`AgentDockSheet`/`SkillDockSheet` + orb cluster), e lo sheet Export/Delete. Alza **un solo sheet alla volta** (`'agents' | 'skills' | 'models' | 'export'`); registra un opener imperativo (`openExportRef`) per il bottone export per-turno. Estratto da `ChatView`. Ospita anche il **commento in corsa**: la `ThoughtLine` sopra il wrap e il toggle `Notes` (`.cl-pill-narrate`, `NarrateGlyph`) tra la densità e i dock. Il toggle compare **solo se `onToggleThoughts` è passato**, cosa che `ChatView` fa soltanto per una sessione viva nel registro: un controllo permanente per qualcosa che non può mai parlare è un controllo per niente. Prima cella della pill: il **chip del modello** (`.cl-pill-model`) — con cosa si sta parlando adesso e a che **effort** — che è identità, non un controllo, quindi sta a sinistra di tutto il resto e lo etichetta. Il valore non è una proprietà della sessione: `/model` lo cambia a conversazione in corso e il transcript lo registra solo scrivendo un `model` diverso sui turni successivi, quindi il chip stampa **l'ultima** tratta di `collectModelRuns` (`chat/utils.ts`) e mai la prima. Una chat che ha cambiato modello — o effort, che si muove per conto suo — porta `+N` e un caret: diventa un dock come agents/skills, e il `ModelDockSheet` elenca ogni tratta col turno da cui parte e quanti turni ci sono girati, con il locate che ci salta. Tinta da `modelColor()` via `--mt`, la stessa dimensione-dato che codifica il chip per-turno: nessuna tinta nuova. L'effort arriva dalla **riga** di transcript, non da `message` (vedi `transcript-extras`), quindi manca sui transcript che non lo scrivono e il chip semplicemente non lo stampa invece di inventare un default
 - **`useTranscriptModel.ts`** → `useTranscriptModel`, `TranscriptModel` — **Hook: derivazione del transcript Focus.** Da `processed` + `detailsFilter` + resolver tinta agent ricava `descriptors`/`visibleItems`/`minimapItems`/`renderItems`/`rows`/`rowIndexByTurn`/`filterCounts` (tutto memoizzato; la logica pesante — `buildRenderItems`/`buildRenderRows`/`computeFilterCounts` — è in `utils.ts`, unit-tested). `rows` sono le righe già risolte che il virtualizer itera, `rowIndexByTurn` traduce numero di turno → indice di riga per lo scroll
 - **`ChatView.tsx`** — **Viewer read-only, disk-backed** di una sessione esistente — layout **"Focus"** (`cl-chat-workspace--focus`). `displayMessages = messages` (il read di `useChatSession`, memoizzato per stabilità referenziale), watcher-driven; **niente composer, niente stream** — la chat SDK live è una vista separata (`LiveChatView`) che non legge mai il disco. La derivazione del transcript è in `useTranscriptModel`, pill/minimap nei rispettivi file. Solo `TopBar` (back + titolo + toggle Chat/Timeline + tag + badge **"Live in terminal"** se la sessione è viva nel registro; il vecchio bottone "Continue chat" è stato rimosso — l'ingresso alla chat SDK è l'azione **"Chat"** sulla riga sessione, che apre direttamente `LiveChatView` in resume mode) sopra una **colonna di lettura centrata** (`cl-chat-reading`, ~820px). Il linguaggio visivo della superficie di lettura è la variante **"Nastro"** (design handoff _Lens variants_, sostituisce le "isole di vetro"): niente card e niente vetro — ogni turno è un **pallino di ruolo da 9px appeso a un filo verticale** (`.cl-turn-spine`, riabilitato con extra specificità perché ogni riga virtualizzata è figlio unico e il `:last-child` di base lo spegnerebbe ovunque), il corpo poggia sulla carta e si chiude con una **riga sottile allineata alla colonna di testo**; i tool scendono a **chip inline che vanno a capo** (`cl-tool-stack` in flex-wrap; un chip aperto — o che porta la striscia d'errore collassata, via `:has()` — si prende l'intera riga per avere spazio al pannello input/result); il codice inline perde la pastiglia. Un **turno di continuazione** (assistant senza testo dopo un altro assistant) non ha né pallino né riga: il filo lo attraversa intero, così una sequenza di turni tool-only in densità Full non diventa una scaletta di filetti. `.cl-transcript-inner` in `cl-chat-reading` ha `gap: 0` — il ritmo lo dà il padding del corpo, e un gap flex spezzerebbe il filo nella live chat (il transcript finestrato posiziona le righe in assoluto e il gap non lo vede). Coerentemente, `cl-pill` e `cl-turns-capsule` sono passate da vetro a **carta opaca + hairline**. La **Mission Control rail** (`terminal/MissionRail.tsx`) è andata oltre Nastro fino al design **1d · Feed**: niente più blocchi per specie, un solo **flusso cronologico** di eventi con le sezioni demolite a **filtri** (vedi il doc del componente). I due numeri della riga vitals (context %, spend) sono **hover target** che fanno scendere una readout card (`terminal/VitalsPopover.tsx`): recuperano i dati che i vecchi blocchi CONTEXT WINDOW / SPEND stampavano fissi (`used · left · total`, `cache −$x · y% saved`, rimasti per una release come `title` nativi) e ci aggiungono la **composizione** — cache read / fresh input / cache write per il contesto, il mix di token per la spesa — come part-of-whole su rampa monocroma accent (`color-mix` contro `--cl-paper`, così la scala si inverte da sola nel tema dark). Le card sono `pointer-events: none` (non contengono controlli: catturare il cursore le terrebbe aperte dopo che il puntatore ha lasciato il numero) e i trigger sono `tabIndex`+`onFocus`, così il secondo livello è raggiungibile da tastiera. È chrome condivisa con la vista Terminal: cambia anche lì, di proposito — le due metà di Mission Control devono leggersi come una superficie sola. La riga vitals è anche **l'unico posto** dove la spesa della sessione è stampata: la `TopBar` di `TerminalMissionControl` portava lo stesso `fmtCost` a poche centinaia di pixel di distanza, e due copie della stessa cifra si leggono come due letture diverse — lì resta solo l'indicatore RUNNING. Col rail collassato la cifra non è a schermo (è dentro il rail, un toggle di distanza). I controlli vivono nella **pill flottante** (`ChatControlPill` → `cl-pill`): filtri per tipo (All/Tools/Thinking/Questions/Plan) + toggle densità Min/Full + **agent/skill dock** + sheet Export/Delete (alza **un solo sheet alla volta**). Transcript a **tutta larghezza** + **minimap a filo** a destra (`FocusMinimap` → `cl-focus-rail`, dot per turno, scroll-spy). La lista è **finestrata** (`@tanstack/react-virtual`): solo le righe attorno al viewport sono montate, con misura dinamica per riga (`measureElement` — le altezze dipendono dal contenuto) dentro un sizer `.cl-vlist` alto quanto l'intera sessione, così scrollbar, bottom-pinning e minimap continuano a vedere tutto il transcript. Conseguenze progettuali: `isContinuation` è pre-derivato in `buildRenderRows` (niente lookahead sui vicini), lo **scroll-spy legge la geometria del virtualizer** invece di un IntersectionObserver sui nodi montati, `jumpToTurn` usa `scrollToIndex` (e sgancia il bottom-pinning, altrimenti la misura successiva riporterebbe in fondo) e un cambio di densità **non** azzera le misure: `rowVirtualizer.measure()` sembra corretto (lo stesso turno ha altezze diverse in MIN e FULL) ma manda la posizione di lettura a spasso — collassa la lista sulle stime e l'ancoraggio finisce per essere calcolato su un layout inesistente. Le righe montate si rimisurano da sole e quelle sopra il viewport, tenendo la dimensione precedente, tengono ferme le offset; le sole mai visitate restano approssimate finché non entrano in vista. Per la stessa ragione **non** si usa `anchorTo: 'end'`: questo feed ha già un'ancora di fondo (il pin di `useAutoScroll`) e le due inseguono coordinate diverse — il DOM, che include i 140px di padding sotto la lista, contro `getTotalSize()`. Il `content-visibility: auto` su `.cl-transcript-inner > .cl-turn` resta ai transcript non finestrati (live chat, pannello sub-agente) e **non deve** raggiungere le righe virtualizzate: una riga fuori schermo riporterebbe `contain-intrinsic-size` invece dell'altezza reale. Trade-off accettati: ricerca nativa del browser e selezione testo attraverso righe smontate non funzionano; gli highlight fuori finestra vengono ridipinti quando la riga rientra (il MutationObserver di `useHighlightLayer`). Mantiene tutte le affordance di lettura: export, highlights, timeline (`SessionGraphView`), tag, delete, transcript sub-agente. Overlay `ToolDetailPanel`/`SubagentTranscriptPanel` (e Timeline) **non smontano il workspace**: resta montato nascosto (`chatHidden` → `display:none`) per preservare scroll/highlight-layer/scroll-spy quando l'overlay si chiude (al ritorno un view anchored è ri-pinnato dal ResizeObserver, uno detached torna al turno attivo). `ChatView` è **keyed per `session.filename`** in `ProjectOverview`. `embedded` (Terminal/Lens) è un sotto-caso di chrome (niente TopBar/minimap)
 
@@ -980,19 +980,53 @@ due trigger per lo stesso popover erano ridondanti. Per la stessa ragione il
 collapse ha perso label e chip `⌘B`: era l'elemento più pesante della colonna
 per un controllo che la scorciatoia già copre.
 
-Il contenuto segue **5b**: l'hero perde la meta-riga e guadagna una **fascia
-metriche** (`.cl-hband`) di celle divise da hairline — Sessions/{retention}d con
-delta sulla finestra precedente, Tokens, Messages, **distribuzione modelli** come
-barra part-of-whole + legenda (`buildModelMix` in `../utils.ts`, quota sui
-**token** e non sulle sessioni: la cella sta accanto alla cifra dei token e ciò
-che la barra codifica è dove è finito il lavoro; unit-tested). La fascia ha
-**assorbito la vecchia stat strip a 4 celle** della Overview: le sparkline del
-periodo di retention sono scese dentro le prime due celle, media/costo sono
-diventati la riga piccola, e la cella "live" è migrata nel piede del rail (era
-duplicata in due punti). Il nome display scende a `clamp(40px, 4.2vw, 72px)`
-perché una cifra da 26px sotto un titolo da 132px non è una gerarchia.
-Le sessioni sono **righe** (`.cl-srow`): pin, **indice (che porta il colore
-della sessione)**, titolo, tag, spazio elastico, il gruppo cifre
+Il contenuto segue **5b** per la struttura e **3b** (design handoff _Project
+Overview Redesign_, turni 1a → 2a → 3b) per il trattamento dell'hero progetto:
+
+- **nome e descrizione sulla stessa linea di base** (2a), dentro un wrapper
+  `.cl-h-title` che va flex **solo** sotto `.cl-hero--band` — l'hero Teams
+  (`.cl-hero--compact`) monta lo stesso wrapper con un figlio solo e resta un
+  blocco. In edit la descrizione va a capo su tutta la riga (`flex: 1 0 100%`):
+  la textarea vuole la sua misura di lettura, non lo spazio accanto a un nome da
+  64px;
+- **fascia metriche a quattro colonne piatte** (`.cl-hband` dentro
+  `.cl-hero--band`): etichetta + cifra, separate da spazio e non da hairline —
+  Sessions/{retention}d, Tokens, Spend, **distribuzione modelli** come barra
+  part-of-whole + legenda (`buildModelMix` in `../utils.ts`, quota sui **token**
+  e non sulle sessioni: la cella sta accanto alla cifra dei token e ciò che la
+  barra codifica è dove è finito il lavoro; unit-tested). La finestra di
+  retention è dichiarata **una volta sola**, sulla prima colonna, e governa la
+  riga. Con la riscrittura sono caduti **la sparkline del periodo, il delta
+  sulla finestra precedente e la riga piccola di ogni cella** (`% cache read`,
+  `msg avg`, `N older · N total`) — è il punto dell'esercizio, non un effetto
+  collaterale. È caduto anche il `last … ago` accanto all'etichetta, che il mock
+  non porta: lo dice ora la prima riga della lista sotto, che da 3b è la
+  sessione **più recente** e non più una pinnata. Resta la **card di
+  composizione dei token** in hover sulla cifra, portalata su `<body>` e
+  annunciata dal filetto punteggiato sotto il numero;
+- **una sola azione** (3b): `Open in Claude Code` come pillola terracotta e
+  `SDK chat →` come etichetta accanto, **in flusso sotto le metriche**
+  (`.cl-hero-cta-row`) invece che flottanti in alto a destra — due bottoni di
+  vetro quasi identici non dicevano quale delle due cose la pagina serva.
+  Restano due `<button>` con il `title` che dichiara **su quale budget pesa
+  ciascuno** (crediti Agent SDK vs. piano di abbonamento): è l'unico posto in
+  cui l'app lo scrive, e le stringhe sono hoistate (`SDK_CHAT_TITLE`,
+  `CLAUDE_CODE_TITLE`) perché l'hero Teams disegna la stessa coppia in forma
+  compatta e il testo non deve divergere;
+- **niente `<Lens />`**: al posto degli anelli concentrici l'hero prende un
+  wash caldo che sfuma sulla carta (`--cl-hero-wash`, tinta accent a 40°, più
+  spenta nel tema dark dove un accent-soft a tutta fascia legge come campo di
+  colore). Il bordo inferiore in ink resta: il wash finisce in carta e senza
+  quel filetto la pagina non avrebbe più alcun confine lì.
+
+`.cl-hband`/`.cl-hcell` sono **condivise** con `SearchView` e
+`DuplicateProjectsNotice`, che continuano a disegnare le celle divise da
+hairline: il trattamento 3b vive tutto sotto `.cl-hero--band`. Il nome display
+resta a `clamp(40px, 4.2vw, 64px)` perché una cifra da 30px sotto un titolo da
+132px non è una gerarchia.
+Le sessioni della **vista Sessions** (non della landing, che da 3b ha una riga
+tutta sua — vedi sotto) sono **righe** (`.cl-srow`): pin, **indice (che porta il
+colore della sessione)**, titolo, tag, spazio elastico, il gruppo cifre
 `msg · modello · token · data` e in coda il **kebab delle azioni**. Due elementi
 di 5b sono caduti qui, per la stessa ragione:
 
@@ -1062,62 +1096,96 @@ caricamento resta progressivo, prende solo l'idioma del pager del mock.
 La data della riga è formattata **en-US** come il resto dell'app: era l'ultimo
 `it-IT` rimasto in una UI english-only (`10 ago` accanto a colonne inglesi).
 
-**Landing di progetto — design handoff _Overview Redesign_, opzione 1c**
-(`section === 'overview'`). Le sessioni sono **un blocco solo**, non due: la
-sezione **Pinned sessions** e la striscia **Recent** (`RecentSessionsStrip`,
-`.cl-mrow`, entrambe rimosse col loro CSS) erano la stessa lista letta due
-volte, e la seconda doveva rinunciare a pin, tag e cluster di cifre per
-giustificare di stare sotto una sezione che li portava. Ora: testata
-`Sessions · N pinned · M total · View all` e **tre righe `.cl-srow` piene**
-(`LANDING_SESSIONS`), **pinnate per prime** — non avendo più una sezione
-propria, è la testa della terna che tiene raggiungibile dalla landing una
-conversazione pinnata e quindi magari vecchia. Il `rankOf` resta l'indice vero
-nella storia completa, così i numeri di riga non mentono. Il caption conta sul
-totale della storia (`sessions.length`).
+**Landing di progetto — design handoff _Project Overview Redesign_, 3b**
+(`section === 'overview'`). La landing è **l'hero e una lista sola**. Le
+sezioni **Memory** (griglia di index card `.cl-mem-cards`/`.cl-mcard`,
+`renderMemCard`) e **CLAUDE.md**, e la **striscia di config** in fondo
+(`.cl-config-strip`: Skills / Agents / MCP / Rules), sono cadute con il loro
+CSS: erano anteprime di cose che il rail già conta a un clic — `Memory`,
+`Skills`, `Agents`, `MCP` ci stanno con il badge, e `Rules` non aveva nemmeno
+una destinazione propria (portava a `project-mcp`, dove le regole
+condizionali vivono). Restava un'eccezione vera, ed è l'unica cosa che si è
+spostata invece di sparire: la **cascata CLAUDE.md** era l'unico ingresso a
+`project-claudemd`, e il rail non ha una voce CLAUDE.md — quindi il blocco
+(`.cl-md-cascade`/`.cl-md-layer`, `claudeMdPathParts`,
+`CLAUDE_MD_SCOPE_LABEL`, l'ordinamento della cascata) è emigrato in
+**`ProjectConfigView`**, che per questo prende ora un `onNavigate`. Ci sta di
+casa: sono istruzioni risolte a livelli, esattamente come le impostazioni
+sopra di esse.
 
-La **memoria** è la sezione che 1c cambia di più, ed era la più penalizzata:
-una definition-list a 3 colonne (`.cl-mem`/`.cl-mem-row`, rimosse) dove un
-topic si leggeva come una riga di tabella — niente tipo, niente tag, niente
-gerarchia. Diventa una **griglia di index card** (`.cl-mem-cards`/`.cl-mcard`,
-`renderMemCard`): header con glifo iniziale + tipo + età relativa, nome come
-titolo, **tre righe di prosa** in `--font-reading` (`memPreview` accetta ora un
-`max`, qui `MEM_CARD_PREVIEW_MAX`) e i tag a piede card. La prima card prende
-il wash accent, come la prima tile di Skills/Agents. I tag sono **read-only**
-qui: aggiungerli/rimuoverli resta nella subtab Memory, che possiede la lista
-intera (e il `TagPicker`). Cap a `LANDING_MEM_CARDS` (due file da tre), con
-`View all` verso la subtab.
-Il caption è `N topics · <due tipi più frequenti>`: un breakdown completo
-sfora la testata su qualsiasi memoria vera, e i due tipi dominanti sono ciò che
-dice che cosa questo progetto ricorda. **Una sola visualizzazione, newest
-first**: il segmented `Newest / By type` (stato locale `memCardView`, con il suo
-`landingMemGroups`) è stato **rimosso**. La landing mostra sei card di una
-storia che ne conta decine — a quella taglia il raggruppamento per tipo era un
-controllo su un campione, e la subtab a cui `View all` porta possiede la lista
-intera con l'ordinamento e il group-by che le appartengono
-(`memSort`/`memGroupBy`, tuttora suoi). La variante `.cl-seg--paper` **resta**:
-la usa la toolbar della subtab.
-**Non implementata** di 1c: la card tratteggiata "New topic" — l'app non ha
-(ancora) nessun ingresso di creazione memoria, solo l'IPC `memory:createTopic`
-e l'hook `useCreateTopic` inutilizzato; sarebbe una feature, non un cambio di
-layout. Fuori scope anche la «context chain» che collassa CLAUDE.md sotto
-l'hero.
+**Passata di rifinitura sull'hero 3b** (dopo il primo screenshot in app, che
+il mock non poteva mostrare: finestra larga, progetto live, un solo modello).
 
-La sezione **CLAUDE.md** ha invece lasciato la tile-grid per una **cascata a
-una colonna** (`.cl-md-cascade`/`.cl-md-layer`): ogni layer è un file con lo
-stesso nome, quindi lo scope da solo non distingue una riga dall'altra — con
-sei layer quattro righe si chiamavano `Subdir` e il path stava nella riga
-smorzata sotto. Ora **il path è il nome della riga**, spezzato da
-`claudeMdPathParts` in genitori smorzati + segmento identificante in evidenza +
-nome file smorzato (`src/components/`**`project/`**`CLAUDE.md`), e la parola
-generica scende a **chip di larghezza fissa** che allinea tutti i path sulla
-stessa colonna. L'ordine segue la cascata che la testata annuncia (global →
-project → local → subdir, i subdir per profondità poi alfabetici): la riga di
-intestazione fa da legenda solo se la lista la segue, mentre prima partiva dal
-project. L'accento passa quindi **dalla prima riga al layer `project`**, che
-resta quello che si apre più spesso. Una **barra proporzionale** dà la scala
-(36 righe contro 882) che una colonna di cifre lascia fare a mente; sotto i
-760px sparisce. Una colonna sola perché la cascata è una sequenza ordinata e la
-griglia a due colonne la faceva leggere a zig-zag.
+- il **wash** è sceso a metà croma (`--cl-hero-wash`, 0.018 invece di 0.035) e
+  arriva a carta al **58%**: il filetto d'inchiostro in fondo deve dividere
+  carta da carta. Chiudere il gradiente sul filetto disegnava un secondo bordo
+  colorato appena sopra — la banda dura che si vedeva per tutta la larghezza;
+- l'**aura `is-live`** (due campi accent animati, `::before`/`::after`) è
+  **spenta sotto `.cl-hero--band`**: sopra il wash era un secondo campo sul
+  primo, ed è ciò che smacchiava la fascia. Un alone sfocato non ha comunque
+  un bordo da leggere, quindi non dichiara granché; la `.cl-live-bar` non vive
+  in questo hero (è di `AgentsLiveView`), perciò il segnale si è spostato nel
+  **pip dell'eyebrow**, che con `is-live` diventa verde e pulsa come quello del
+  rail — e si ferma sotto `prefers-reduced-motion`;
+- la descrizione siede con l'**ultima** riga sulla baseline del nome
+  (`align-items: last baseline`, col valore semplice sotto come fallback: un
+  engine che non lo parsa scarterebbe la dichiarazione e stirerebbe la riga).
+  Con `baseline` era la prima riga a sedersi, e una descrizione su due righe
+  restava appesa in alto;
+- **una misura sola** per hero e lista (`--cl-measure`, 1080px): le cifre
+  dell'hero si fermavano a due terzi della finestra mentre la lista correva
+  fino al bordo, e su un monitor largo la riga mono di una sessione restava
+  sola contro mezzo schermo di carta;
+- la **barra dei modelli** scende a 6px per 220px e ogni segmento ha
+  `min-width: 2px`: con 99,6% Opus disegnava un blocco viola pieno mentre la
+  legenda sotto diceva `Sonnet <1%` — la barra smentiva le sue stesse parole;
+- il **path nell'eyebrow** esce dall'uppercase (`.cl-eyebrow .path`): è un dato
+  case-sensitive, e `/USERS/…` è una stringa che non risolve, stampata
+  nell'unico punto in cui la pagina dice dove sta il progetto;
+- via **l'anello** attorno al chevron del nome: un cerchio d'inchiostro da 36px
+  accanto a un titolo da 64px è una seconda cosa che chiede attenzione sulla
+  stessa riga. Resta il glifo, che si accende in accent all'hover;
+- `LANDING_SESSIONS` passa a **5**: il mock disegnava tre righe in un frame
+  alto 720px, su una finestra vera la pagina finiva a metà.
+
+Seconda passata, sullo stesso hero visto in app con un progetto reale:
+
+- il gradiente del wash è **verticale** (`to bottom`), non più a 168°. La linea
+  di un gradiente inclinato è lunga `|W·sin a| + |H·cos a|`: su un hero
+  1500×500 anche 168° la stirava a ~820px, quindi gli stop cadevano molto più
+  in basso di dove si leggono e il wash non arrivava mai a carta prima del
+  filetto. Verticale, le percentuali dicono quello che sembrano dire;
+- **`gap: 0`** sul nome: il gap della riga metteva uno spazio tra il nome e il
+  suo punto, e il titolo si leggeva `Personal .` — un refuso, in 64px. Il punto
+  appartiene alla parola; solo il chevron è una cosa a parte e prende il suo
+  `margin-left`;
+- la descrizione è **clampata a due righe** (con `line-clamp`, testo intero nel
+  `title` insieme alla provenienza): la terza riga sale sopra l'altezza delle
+  maiuscole del nome e la frase comincia a competere con ciò che descrive;
+- **la barra dei modelli sparisce quando una famiglia sola tiene la finestra**
+  (meno di due quote ≥ 1%): un part-of-whole ha bisogno di più di una parte
+  visibile, e con 99,6% Opus disegnava un rettangolo viola pieno — "tutto" —
+  mentre la legenda sotto diceva `Sonnet <1%`. Le etichette **restano** quelle
+  di `pctLabels` (i floor sommano sempre a 100, `<1` per le quote non nulle:
+  è unit-tested, non si tocca); è la barra a farsi da parte.
+
+La lista è **`RecentSessionRows`** con la sua `.cl-rsrow`, **non**
+`SessionRows` con un flag: titolo + `LiveTag` sulla stessa base, una riga mono
+`N msg · modello · N tokens · quando` sotto, righe divise da hairline e
+nient'altro. Pin, indice colorato, tag, expiry e kebab restano su `.cl-srow`
+nella vista Sessions, che possiede la lista come spazio di lavoro; una
+variante sul componente condiviso è il modo in cui quella vista cambia per
+sbaglio. La testata prende il modificatore **`.cl-sec-head--rule`** (la `h2`
+scende a etichetta mono uppercase, filetto d'inchiostro sotto) perché la base
+è condivisa da una decina di viste, e a destra c'è `All {N} →`.
+
+L'ordine è la **recenza**, non più le pinnate per prime (1c): la testata dice
+"Recent sessions" e la fascia non stampa più `last … ago`, quindi la prima
+riga è diventata l'unico posto in cui la pagina dichiara quando il progetto è
+stato toccato — una pinnata di tre settimane fa in quella posizione farebbe
+mentire la pagina. Le pinnate hanno comunque la **loro sezione** nella vista
+Sessions, che è dove si agisce su di esse.
+
 La sezione **Teams** conserva l'hero compatto (`cl-hero--compact`) e la
 vecchia meta-riga: è una vista operativa, non una landing di progetto.
 Il **filtro per tag** (`sessions/TagBar`) non è più una banda sotto il titolo:
@@ -1148,7 +1216,8 @@ pagina, pur essendo da leggere una volta sola. Ora la vista prende la chrome
 delle altre deep view (`TopBar` + `cl-hero` + `Lens` + `cl-section`, come
 `PluginsView`) e la spiegazione scende in un `<details className="set-disc">`
 chiuso — il testo resta, smette di dominare.
-La **fascia metriche** (`.cl-hband`, riusata dall'hero progetto) dichiara la
+La **fascia metriche** (`.cl-hband`, nella sua forma condivisa a celle divise
+da hairline — l'hero progetto la sovrascrive, vedi 3b) dichiara la
 scala del problema, che prima nessuno diceva: Projects, Folders
 (`N primary · N duplicate`), **Sessions to move** e **Memory to merge** —
 i due totali sommano solo le cartelle **non** primarie, cioè esattamente ciò che

--- a/src/components/project/overview/ProjectDescription.tsx
+++ b/src/components/project/overview/ProjectDescription.tsx
@@ -111,11 +111,13 @@ export function ProjectDescription({ hash, realPath }: Props) {
       type="button"
       className="cl-h-desc"
       onClick={startEditing}
-      title={
+      // The sentence is clamped to two lines beside the project name, so the
+      // tooltip carries the whole of it before saying where it came from.
+      title={`${shown}\n\n${
         override
           ? 'Your description (stored in ClaudeLens) — click to edit'
           : `From ${derived?.filePath ?? 'CLAUDE.md'} — click to edit`
-      }
+      }`}
     >
       {shown}
     </button>

--- a/src/components/project/overview/ProjectOverviewContent.tsx
+++ b/src/components/project/overview/ProjectOverviewContent.tsx
@@ -12,7 +12,6 @@ import { createPortal } from 'react-dom';
 import {
   useMemoryProject,
   useSessionList,
-  useClaudeMdHierarchy,
   useProjectRules,
   useGlobalMcp,
   useAllSkills,
@@ -32,8 +31,7 @@ import {
   formatTokens,
   buildModelMix,
 } from '../utils';
-import type { SessionSummary, MemoryTopic, ClaudeMdLayer } from '../../../types';
-import { Lens } from './Lens';
+import type { SessionSummary, MemoryTopic } from '../../../types';
 import { ProjectDescription } from './ProjectDescription';
 import { McpServerGrid } from '../mcp/McpServerGrid';
 import { AgentsLiveView } from '../agents-live/AgentsLiveView';
@@ -58,6 +56,15 @@ import { TagBar } from '../sessions/TagBar';
 import { TagPicker } from '../sessions/TagPicker';
 import { SessionRowMenu } from '../sessions/SessionRowMenu';
 import { DeleteSessionDialog } from '../shared/DeleteSessionDialog';
+
+// The two entry points a project hero offers, and the only place the app says
+// which budget each one spends. Hoisted because the Teams header and the
+// project hero draw them differently (compact glass pair vs. design 3b's pill
+// + label) and the wording must not drift between the two.
+const SDK_CHAT_TITLE =
+  'In-app chat through the Agent SDK — billed to Agent SDK credits, separate from your subscription plan';
+const CLAUDE_CODE_TITLE =
+  'Opens the interactive claude CLI embedded in ClaudeLens, with a Mission Control panel and a switch to read the same session as SDK chat (Lens). Terminal usage counts against your subscription plan.';
 
 function ChatGlyph() {
   return (
@@ -124,76 +131,9 @@ function shortWhen(iso: string): string {
 
 const DAY_MS = 86_400_000;
 const DEFAULT_RETENTION_DAYS = 30;
-const MAX_STAT_BARS = 12;
-
-type StatMetric = 'sessions' | 'tokens' | 'avg';
-
-type TimelineBucket = {
-  key: string;
-  label: string;
-  sessions: number;
-  tokens: number;
-};
 
 function normalizeRetentionDays(days: number): number {
   return Number.isFinite(days) && days > 0 ? Math.max(1, Math.round(days)) : DEFAULT_RETENTION_DAYS;
-}
-
-// en-US, not it-IT: the UI is english-only, and an it-IT month abbreviation
-// ("ago", "set") is the only italian word in the band's tooltips.
-function fmtBucketDate(ms: number): string {
-  return new Date(ms).toLocaleDateString('en-US', { day: '2-digit', month: 'short' });
-}
-
-function bucketLabel(startMs: number, endMs: number): string {
-  const start = fmtBucketDate(startMs);
-  const end = fmtBucketDate(Math.max(startMs, endMs - 1));
-  return start === end ? start : `${start} - ${end}`;
-}
-
-/** Local midnight, `offsetDays` away from the day `ms` falls in. Going through
- *  `setDate` rather than adding `DAY_MS` keeps every boundary on a true
- *  midnight across a DST change, where a day is 23 or 25 hours long. */
-function dayStart(ms: number, offsetDays = 0): number {
-  const d = new Date(ms);
-  d.setHours(0, 0, 0, 0);
-  d.setDate(d.getDate() + offsetDays);
-  return d.getTime();
-}
-
-// Buckets span whole days, aligned to local midnight. Slicing the window into
-// exactly MAX_STAT_BARS parts made 30 days into 2.5-day buckets cut at noon, so
-// two adjacent bars both printed the day they shared ("14 Aug - 16 Aug" next to
-// "16 Aug - 19 Aug") — the one thing a reader uses the label to rule out.
-function buildTimelineBuckets(
-  sessions: SessionSummary[],
-  days: number,
-  nowMs: number
-): TimelineBucket[] {
-  const daysPerBucket = Math.max(1, Math.ceil(days / MAX_STAT_BARS));
-  const bucketCount = Math.max(1, Math.ceil(days / daysPerBucket));
-  // Boundaries are computed, not derived by division: with DST in the window
-  // they are not equally spaced in milliseconds.
-  const edges = Array.from({ length: bucketCount + 1 }, (_, k) =>
-    dayStart(nowMs, 1 - (bucketCount - k) * daysPerBucket)
-  );
-  const buckets = Array.from({ length: bucketCount }, (_, i) => ({
-    key: `${edges[i]}-${edges[i + 1]}`,
-    label: bucketLabel(edges[i], edges[i + 1]),
-    sessions: 0,
-    tokens: 0,
-  }));
-
-  for (const s of sessions) {
-    const t = new Date(s.date).getTime();
-    if (isNaN(t) || t < edges[0] || t >= edges[bucketCount]) continue;
-    let idx = bucketCount - 1;
-    while (idx > 0 && t < edges[idx]) idx -= 1;
-    buckets[idx].sessions += 1;
-    buckets[idx].tokens += s.totalTokens;
-  }
-
-  return buckets;
 }
 
 /** Width of the token breakdown card — needed both to draw it and to clamp it
@@ -230,104 +170,12 @@ function pctOf(part: number, whole: number): number {
   return whole > 0 ? (part / whole) * 100 : 0;
 }
 
-function bucketValue(bucket: TimelineBucket, metric: StatMetric): number {
-  if (metric === 'sessions') return bucket.sessions;
-  if (metric === 'tokens') return bucket.tokens;
-  return bucket.sessions > 0 ? bucket.tokens / bucket.sessions : 0;
-}
-
-function bucketTooltip(bucket: TimelineBucket, metric: StatMetric): string {
-  if (metric === 'sessions')
-    return `${bucket.label} · ${fmt(bucket.sessions)} sessions · ${fmt(bucket.tokens)} tok`;
-  if (metric === 'tokens')
-    return `${bucket.label} · ${fmt(bucket.tokens)} tok · ${fmt(bucket.sessions)} sessions`;
-  const avg = bucket.sessions > 0 ? Math.round(bucket.tokens / bucket.sessions) : 0;
-  return `${bucket.label} · ${fmt(avg)} tok/session · ${fmt(bucket.sessions)} sessions`;
-}
-
-function Bars({ buckets, metric }: { buckets: TimelineBucket[]; metric: StatMetric }) {
-  const [active, setActive] = useState<{ index: number; text: string } | null>(null);
-  const values = buckets.map(bucket => bucketValue(bucket, metric));
-  const max = Math.max(...values, 1);
-  const peakIdx = values.indexOf(Math.max(...values));
-  const gridStyle: CSSProperties = {
-    gridTemplateColumns: `repeat(${buckets.length}, minmax(0, 1fr))`,
-  };
-  return (
-    <div className="cl-bars" style={gridStyle}>
-      {buckets.map((bucket, i) => {
-        const value = values[i] ?? 0;
-        const tooltip = bucketTooltip(bucket, metric);
-        return (
-          <span
-            key={bucket.key}
-            className={`cl-stat-bar${value > 0 && i === peakIdx ? ' peak' : ''}`}
-            tabIndex={0}
-            title={tooltip}
-            aria-label={tooltip}
-            onMouseEnter={() => setActive({ index: i, text: tooltip })}
-            onMouseLeave={() => setActive(null)}
-            onFocus={() => setActive({ index: i, text: tooltip })}
-            onBlur={() => setActive(null)}
-          >
-            <span
-              className="cl-stat-bar-fill"
-              style={{ height: `${value > 0 ? Math.max((value / max) * 100, 6) : 0}%` }}
-            />
-          </span>
-        );
-      })}
-      {active && (
-        <span
-          className="cl-bars-tip"
-          style={{ left: `${((active.index + 0.5) / Math.max(buckets.length, 1)) * 100}%` }}
-        >
-          {active.text}
-        </span>
-      )}
-    </div>
-  );
-}
-
 const MEM_PREVIEW_MAX = 70;
-// The landing's index cards give the preview three lines of prose instead of a
-// single mono line, so they get a longer slice of the same cleaned text.
-const MEM_CARD_PREVIEW_MAX = 190;
-/** How many sessions and memory topics the project landing shows before
- *  handing over to the subtab (design 1c: three rows, two rows of cards). */
-const LANDING_SESSIONS = 3;
-const LANDING_MEM_CARDS = 6;
-
-const CLAUDE_MD_SCOPE_LABEL: Record<'global' | 'project' | 'local' | 'subdir', string> = {
-  project: 'Project',
-  local: 'Local',
-  subdir: 'Subdir',
-  global: 'Global',
-};
-
-/** Ogni layer è un CLAUDE.md, quindi lo scope da solo non distingue una riga
- *  dall'altra: quattro righe su sei si chiamavano "Subdir". Quello che le
- *  distingue è la cartella che governano, così il path diventa il nome della
- *  riga e viene spezzato in genitori (smorzati) + segmento identificante +
- *  nome file (smorzato): la lista si legge sul segmento in evidenza senza
- *  perdere il path intero. */
-function claudeMdPathParts(layer: ClaudeMdLayer, rootPath: string) {
-  if (layer.scope === 'global') {
-    return { prefix: '~/.claude/', focus: 'CLAUDE.md', suffix: '' };
-  }
-  const rel = layer.filePath.startsWith(rootPath + '/')
-    ? layer.filePath.slice(rootPath.length + 1)
-    : layer.filePath;
-  const cut = rel.lastIndexOf('/');
-  if (cut === -1) return { prefix: '', focus: rel, suffix: '' };
-  const dir = rel.slice(0, cut);
-  const up = dir.lastIndexOf('/');
-  return {
-    prefix: up === -1 ? '' : dir.slice(0, up + 1),
-    focus: dir.slice(up + 1) + '/',
-    suffix: rel.slice(cut + 1),
-  };
-}
+/** How many sessions the project landing shows before handing over to the
+ *  Sessions subtab (design 3b, "All N →" in the head). Five, where the mock
+ *  drew three: it was drawn in a 720px-tall frame, and on a real window three
+ *  rows end the page halfway down. */
+const LANDING_SESSIONS = 5;
 
 // Ripulisce la sintassi markdown e tronca per un'anteprima pulita.
 function memPreview(raw: string, max: number = MEM_PREVIEW_MAX): string {
@@ -392,7 +240,6 @@ export function ProjectView({
   const [memLayout, setMemLayout] = useState<'list' | 'graph'>('list');
   const { data: memory } = useMemoryProject(project.hash);
   const { data: sessions = [] } = useSessionList(project.hash);
-  const { data: claudeMd } = useClaudeMdHierarchy(project.realPath);
   const { data: rules = [] } = useProjectRules(project.realPath);
   const { data: mcpData } = useGlobalMcp();
   const { data: allSkills = [] } = useAllSkills(project.realPath);
@@ -461,9 +308,7 @@ export function ProjectView({
   const sessionCount = statsSessions.length;
   const totalTokens = statsSessions.reduce((s, x) => s + x.totalTokens, 0);
   const totalCost = statsSessions.reduce((s, x) => s + x.estimatedCost, 0);
-  const totalMessages = statsSessions.reduce((s, x) => s + x.messageCount, 0);
   const tokensFmt = formatTokens(totalTokens);
-  const avgMessages = sessionCount > 0 ? Math.round(totalMessages / sessionCount) : 0;
   // What the token figure is made of. `totalTokens` sums cache reads at full
   // weight even though they bill at a tenth of input, so on a long project the
   // headline number mostly measures re-read context — the composition is what
@@ -483,24 +328,7 @@ export function ProjectView({
       cacheShare: total > 0 ? (cacheRead / total) * 100 : 0,
     };
   }, [statsSessions]);
-  const allSessionCount = sessions.length;
-  const olderSessionCount = Math.max(0, allSessionCount - sessionCount);
   const lastActive = sessions[0]?.date;
-  const statBuckets = useMemo(
-    () => buildTimelineBuckets(statsSessions, retentionDays, nowMs),
-    [statsSessions, retentionDays, nowMs]
-  );
-  // Sessions in the window immediately before the retention one, so the hero
-  // band's session figure can carry an honest delta instead of a bare count.
-  const prevWindowSessions = useMemo(() => {
-    const end = nowMs - retentionDays * DAY_MS;
-    const start = end - retentionDays * DAY_MS;
-    return sessions.filter(s => {
-      const t = new Date(s.date).getTime();
-      return !isNaN(t) && t >= start && t < end;
-    }).length;
-  }, [sessions, retentionDays, nowMs]);
-  const sessionDelta = sessionCount - prevWindowSessions;
   const modelMix = useMemo(() => buildModelMix(statsSessions), [statsSessions]);
 
   const pinnedSessions = useMemo(
@@ -690,103 +518,18 @@ export function ProjectView({
   // One session list, pins first: they no longer have a section of their own,
   // so putting them at the head of the three is what keeps a pinned — and
   // therefore possibly old — conversation reachable from the landing.
-  const landingSessions = useMemo(
-    () => [...pinnedSessions, ...unpinnedSessions].slice(0, LANDING_SESSIONS),
-    [pinnedSessions, unpinnedSessions]
-  );
-  const landingMemTopics = useMemo(
-    () =>
-      [...memTopics]
-        .sort((a, b) => (Date.parse(b.createdAt) || 0) - (Date.parse(a.createdAt) || 0))
-        .slice(0, LANDING_MEM_CARDS),
-    [memTopics]
-  );
-  // "12 topics · 5 reference · 4 feedback" — the total, then the two commonest
-  // kinds. A full breakdown runs past the section head on any real memory, and
-  // the two that dominate are what says what this project remembers.
-  const memTypeBreakdown = useMemo(() => {
-    const counts = new Map<string, number>();
-    for (const t of memTopics) counts.set(t.type, (counts.get(t.type) ?? 0) + 1);
-    return [...counts.entries()]
-      .sort((a, b) => b[1] - a[1])
-      .slice(0, 2)
-      .map(([type, n]) => `${n} ${type}`);
-  }, [memTopics]);
-  const renderMemCard = (t: MemoryTopic, accent: boolean) => {
-    const tTags = tagsForMemory(t.filename);
-    const open = () =>
-      onNavigate({
-        type: 'memory-topic',
-        topic: t,
-        content: topicContent(t.filename),
-        hash: project.hash,
-      });
-    return (
-      <div
-        key={t.filename}
-        role="button"
-        tabIndex={0}
-        className={`cl-mcard${accent ? ' accent' : ''}`}
-        title={t.description || t.name}
-        onClick={open}
-        onKeyDown={e => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            open();
-          }
-        }}
-      >
-        <div className="head">
-          <span className="glyph">{(t.name[0] ?? '?').toUpperCase()}</span>
-          <span className="kind">{t.type}</span>
-          {t.createdAt && <span className="when">{relIso(t.createdAt)}</span>}
-        </div>
-        <div className="name">
-          <SlugName text={t.name} />
-        </div>
-        <p className="preview">
-          {t.description ? memPreview(t.description, MEM_CARD_PREVIEW_MAX) : '—'}
-        </p>
-        {tTags.length > 0 && (
-          <div className="tags">
-            {tTags.map(name => (
-              <TagChip
-                key={name}
-                name={name}
-                tone="soft"
-                variant="plain"
-                style={{ fontSize: 10, height: 18 }}
-              />
-            ))}
-          </div>
-        )}
-      </div>
-    );
-  };
+  // Recency, not pins-first (design 3b): the head says "Recent sessions" and
+  // the band no longer prints "last … ago", so the top row is now the page's
+  // only statement of when this project was last touched — a pinned session
+  // from three weeks ago in that slot would make the page lie. Pins keep their
+  // own section in the Sessions view, which is where they are acted on.
+  const landingSessions = useMemo(() => sessions.slice(0, LANDING_SESSIONS), [sessions]);
 
   const enabledMcp = useMemo(() => {
     const all = [...(mcpData?.cloudServers ?? []), ...(mcpData?.localServers ?? [])];
     return all.filter(s => !s.disabledProjectPaths.includes(project.realPath));
   }, [mcpData, project.realPath]);
 
-  const claudeMdLayers = claudeMd?.layers.length ?? 0;
-  // Ordinati come la cascata che l'intestazione annuncia (global → project →
-  // local → subdir), non con il project in testa: la riga d'intestazione fa da
-  // legenda della lista solo se la lista la segue. I subdir vengono dopo, per
-  // profondità e poi alfabetici, così il ramo si legge dall'alto.
-  const claudeMdLayerList = useMemo(() => {
-    const order = { global: 0, project: 1, local: 2, subdir: 3 } as const;
-    const rows = [...(claudeMd?.layers ?? [])]
-      .map(layer => ({ layer, lines: layer.content.split('\n').length }))
-      .sort((a, b) => {
-        const byScope = order[a.layer.scope] - order[b.layer.scope];
-        if (byScope !== 0) return byScope;
-        const depth = a.layer.filePath.split('/').length - b.layer.filePath.split('/').length;
-        return depth !== 0 ? depth : a.layer.filePath.localeCompare(b.layer.filePath);
-      });
-    const maxLines = rows.reduce((m, r) => Math.max(m, r.lines), 1);
-    return rows.map(r => ({ ...r, weight: r.lines / maxLines }));
-  }, [claudeMd]);
   const skillCount = allSkills.length;
   const agents = useMemo(() => {
     const seen = new Map<string, (typeof globalAgents)[number]>();
@@ -815,30 +558,40 @@ export function ProjectView({
           isTeamsSection ? ' cl-hero--compact cl-hero--teams' : ' cl-hero--band'
         }`}
       >
-        {!isTeamsSection && <Lens />}
-        <div className="cl-hero-actions">
-          <button
-            className="cl-btn cl-btn--quiet"
-            type="button"
-            title="In-app chat through the Agent SDK — billed to Agent SDK credits, separate from your subscription plan"
-            onClick={() => onNavigate({ type: 'new-chat', project })}
-          >
-            <ChatGlyph />
-            SDK chat
-          </button>
-          <button
-            className="cl-btn"
-            type="button"
-            title="Opens the interactive claude CLI embedded in ClaudeLens, with a Mission Control panel and a switch to read the same session as SDK chat (Lens). Terminal usage counts against your subscription plan."
-            onClick={() => onNavigate({ type: 'terminal', project })}
-          >
-            Open in Claude Code
-          </button>
-        </div>
+        {/* Teams keeps the compact glass pair pinned top-right. The project
+            hero drops it: design 3b puts the actions in flow under the metrics,
+            where the page can give them a hierarchy. */}
+        {isTeamsSection && (
+          <div className="cl-hero-actions">
+            <button
+              className="cl-btn cl-btn--quiet"
+              type="button"
+              title={SDK_CHAT_TITLE}
+              onClick={() => onNavigate({ type: 'new-chat', project })}
+            >
+              <ChatGlyph />
+              SDK chat
+            </button>
+            <button
+              className="cl-btn"
+              type="button"
+              title={CLAUDE_CODE_TITLE}
+              onClick={() => onNavigate({ type: 'terminal', project })}
+            >
+              Open in Claude Code
+            </button>
+          </div>
+        )}
 
         <div className="cl-eyebrow">
           <span className="pip" />
-          <span title={project.realPath}>Project · {project.realPath}</span>
+          {/* The path keeps its own case. The eyebrow is uppercase, and a
+              path is not free text — `/Users/…` rendered as `/USERS/…` is a
+              string that would not resolve, printed in the one place the page
+              claims to say where the project lives. */}
+          <span title={project.realPath}>
+            Project · <span className="path">{project.realPath}</span>
+          </span>
           {isTeamsSection && <span className="cl-hero-section-label">Teams</span>}
           <button
             type="button"
@@ -853,23 +606,30 @@ export function ProjectView({
           </button>
         </div>
 
-        <button
-          className="cl-h-name"
-          type="button"
-          {...searchTriggerProps}
-          onClick={e => onToggleProjectSearch(e.currentTarget)}
-          aria-haspopup="dialog"
-        >
-          <span className="label-name">{projectName}</span>
-          <span className="glyph">.</span>
-          <span className="chev">↓</span>
-        </button>
+        {/* Name and description share one baseline (design 2a): a single
+            typographic unit instead of two stacked blocks. The wrapper only
+            goes flex under `.cl-hero--band`, so the Teams header is untouched. */}
+        <div className="cl-h-title">
+          <button
+            className="cl-h-name"
+            type="button"
+            {...searchTriggerProps}
+            onClick={e => onToggleProjectSearch(e.currentTarget)}
+            aria-haspopup="dialog"
+          >
+            <span className="label-name">{projectName}</span>
+            <span className="glyph">.</span>
+            <span className="chev">↓</span>
+          </button>
 
-        {/* What the project is, in one line — derived from its CLAUDE.md and
-            editable in place (the edit is stored in ClaudeLens' prefs, never
-            written back to the file). The Teams hero is a compact operational
-            header, so it keeps its meta line instead. */}
-        {!isTeamsSection && <ProjectDescription hash={project.hash} realPath={project.realPath} />}
+          {/* What the project is, in one line — derived from its CLAUDE.md and
+              editable in place (the edit is stored in ClaudeLens' prefs, never
+              written back to the file). The Teams hero is a compact operational
+              header, so it keeps its meta line instead. */}
+          {!isTeamsSection && (
+            <ProjectDescription hash={project.hash} realPath={project.realPath} />
+          )}
+        </div>
 
         {isTeamsSection ? (
           <div className="cl-h-meta">
@@ -886,314 +646,181 @@ export function ProjectView({
             )}
           </div>
         ) : (
-          /* Metrics band (design 5b): the project's numbers read as a strip of
-             hairline-divided cells under the name, replacing both the old meta
-             line and the 4-cell stat strip that used to sit below the hero. The
-             timeline bars ride inside the first two cells so the retention
-             distribution survives the move. */
-          <div className="cl-hband">
-            <div className="cl-hcell">
-              <div className="lbl">
-                Sessions / {retentionDays}d
-                {lastActive && <span className="when">last {relIso(lastActive)} ago</span>}
+          /* Metrics row (design 3b): four flat columns — a label and a
+             figure each — in place of the hairline-divided band. The retention
+             window is stated once, on the first column, and governs the row;
+             the sparkline, the session delta and the per-cell small print went
+             with the band, which is the point of the rewrite. */
+          <>
+            <div className="cl-hband">
+              <div className="cl-hcell">
+                <div className="lbl">Sessions / {retentionDays}d</div>
+                <div className="num">{fmt(sessionCount)}</div>
               </div>
-              <div className="num">
-                {fmt(sessionCount)}
-                {sessionDelta !== 0 && (
-                  /* The delta is against the window immediately before this one.
-                     It carried no reference at all, and a green "+3" also read as
-                     a verdict the data does not hold — more sessions is not
-                     better — so it states its baseline and stays neutral. */
-                  <span
-                    className="delta"
-                    title={`${fmt(prevWindowSessions)} in the previous ${retentionDays} days`}
-                  >
-                    {sessionDelta > 0 ? '+' : '−'}
-                    {Math.abs(sessionDelta)}
-                  </span>
-                )}
-              </div>
-              {/* The only sparkline left: sessions and tokens trace nearly the
-                  same curve, so a second one spent a quarter of the band
-                  re-drawing this one. */}
-              <Bars buckets={statBuckets} metric="sessions" />
-              <div className="sub">
-                {olderSessionCount > 0
-                  ? `${fmt(olderSessionCount)} older · ${fmt(allSessionCount)} total`
-                  : `all ${fmt(allSessionCount)} in window`}
-              </div>
-            </div>
 
-            <div
-              className="cl-hcell cl-hcell--hover"
-              onMouseEnter={openTokenPeek}
-              onMouseLeave={closeTokenPeek}
-            >
-              <div className="lbl">Tokens / {retentionDays}d</div>
               <div
-                className="num"
-                ref={tokenNumRef}
-                tabIndex={0}
-                onFocus={openTokenPeek}
-                onBlur={closeTokenPeek}
+                className="cl-hcell cl-hcell--hover"
+                onMouseEnter={openTokenPeek}
+                onMouseLeave={closeTokenPeek}
               >
-                {tokensFmt.value}
-                <small>{tokensFmt.unit}</small>
-              </div>
-              <div className="sub">
-                {Math.round(tokenParts.cacheShare)}% cache read
-                <span className="cl-hpeek-hint"> · hover</span>
-              </div>
-              {/* Portalled to <body> on purpose: `.cl-hero` clips its children
-                  (`overflow: hidden` keeps the Lens, which overhangs by 120px,
-                  inside), so a card anchored inside the cell was cut off at the
-                  hero's bottom edge. Same move MemoryPeekCard makes. */}
-              {tokenPeek &&
-                totalTokens > 0 &&
-                createPortal(
-                  <ReadoutShell
-                    title="TOKENS"
-                    meta={`${retentionDays}d`}
-                    style={{
-                      position: 'fixed',
-                      top: tokenPeek.top,
-                      left: tokenPeek.left,
-                      width: PEEK_W,
-                    }}
-                  >
-                    <div className="flex" style={{ gap: 12, marginTop: 11 }}>
-                      <ReadoutCell label="TOTAL" value={kTok(totalTokens)} />
-                      <ReadoutCell
-                        label="CACHE READ"
-                        value={`${Math.round(tokenParts.cacheShare)}%`}
+                <div className="lbl">Tokens</div>
+                <div
+                  className="num"
+                  ref={tokenNumRef}
+                  tabIndex={0}
+                  onFocus={openTokenPeek}
+                  onBlur={closeTokenPeek}
+                >
+                  {tokensFmt.value}
+                  <small>{tokensFmt.unit}</small>
+                </div>
+                {/* Portalled to <body> on purpose: `.cl-hero` clips its children
+                    (`overflow: hidden` keeps the live aura inside), so a card
+                    anchored inside the cell was cut off at the hero's bottom
+                    edge. Same move MemoryPeekCard makes. The composition of the
+                    figure now lives only here — the band's "% cache read" line
+                    is gone — so the dotted rule under the number is the
+                    affordance. */}
+                {tokenPeek &&
+                  totalTokens > 0 &&
+                  createPortal(
+                    <ReadoutShell
+                      title="TOKENS"
+                      meta={`${retentionDays}d`}
+                      style={{
+                        position: 'fixed',
+                        top: tokenPeek.top,
+                        left: tokenPeek.left,
+                        width: PEEK_W,
+                      }}
+                    >
+                      <div className="flex" style={{ gap: 12, marginTop: 11 }}>
+                        <ReadoutCell label="TOTAL" value={kTok(totalTokens)} />
+                        <ReadoutCell
+                          label="CACHE READ"
+                          value={`${Math.round(tokenParts.cacheShare)}%`}
+                        />
+                        <ReadoutCell
+                          label="SAVED"
+                          value={fmtCost(tokenParts.cacheSavings)}
+                          color="var(--cl-ok)"
+                        />
+                      </div>
+                      <ReadoutRule />
+                      <ReadoutPart
+                        label="fresh in/out"
+                        value={kTok(tokenParts.fresh)}
+                        share={pctOf(tokenParts.fresh, totalTokens)}
+                        color={READOUT_RAMP.soft}
                       />
-                      <ReadoutCell
-                        label="SAVED"
-                        value={fmtCost(tokenParts.cacheSavings)}
-                        color="var(--cl-ok)"
+                      <ReadoutPart
+                        label="cache read"
+                        value={kTok(tokenParts.cacheRead)}
+                        share={pctOf(tokenParts.cacheRead, totalTokens)}
+                        color={READOUT_RAMP.full}
                       />
+                      <ReadoutPart
+                        label="cache write"
+                        value={kTok(tokenParts.cacheWrite)}
+                        share={pctOf(tokenParts.cacheWrite, totalTokens)}
+                        color={READOUT_RAMP.mid}
+                      />
+                    </ReadoutShell>,
+                    document.body
+                  )}
+              </div>
+
+              <div className="cl-hcell">
+                <div className="lbl">Spend</div>
+                <div className="num">{fmtCost(totalCost)}</div>
+              </div>
+
+              <div className="cl-hcell cl-hcell--mix">
+                <div className="lbl">Models</div>
+                {modelMix.length === 0 ? (
+                  <div className="sub">No usage in this window</div>
+                ) : (
+                  <>
+                    {/* A part-of-whole bar needs more than one visible part.
+                        On a project that ran 99.6% Opus it drew a solid violet
+                        block — a filled rectangle, saying only "all of it" —
+                        while the legend under it read `Sonnet <1%`. When one
+                        family takes the window, the legend says so on its own
+                        and the bar is dropped. */}
+                    {modelMix.filter(s => s.pct >= 1).length > 1 && (
+                      <div className="cl-mixbar">
+                        {modelMix.map(slice => (
+                          <i
+                            key={slice.key}
+                            className={`seg ${slice.key}`}
+                            style={{ width: `${slice.pct}%` }}
+                            title={`${slice.label} · ${fmt(slice.tokens)} tok · ${slice.sessions} ${
+                              slice.sessions === 1 ? 'session' : 'sessions'
+                            }`}
+                          />
+                        ))}
+                      </div>
+                    )}
+                    {/* One line, dot-separated: bar plus a stacked legend was the
+                        same share encoded twice, over two rows. */}
+                    <div className="cl-mixlegend">
+                      {modelMix.map(slice => (
+                        <span key={slice.key}>
+                          <i className={`dot ${slice.key}`} />
+                          {slice.label} {slice.pctLabel}%
+                        </span>
+                      ))}
                     </div>
-                    <ReadoutRule />
-                    <ReadoutPart
-                      label="fresh in/out"
-                      value={kTok(tokenParts.fresh)}
-                      share={pctOf(tokenParts.fresh, totalTokens)}
-                      color={READOUT_RAMP.soft}
-                    />
-                    <ReadoutPart
-                      label="cache read"
-                      value={kTok(tokenParts.cacheRead)}
-                      share={pctOf(tokenParts.cacheRead, totalTokens)}
-                      color={READOUT_RAMP.full}
-                    />
-                    <ReadoutPart
-                      label="cache write"
-                      value={kTok(tokenParts.cacheWrite)}
-                      share={pctOf(tokenParts.cacheWrite, totalTokens)}
-                      color={READOUT_RAMP.mid}
-                    />
-                  </ReadoutShell>,
-                  document.body
+                  </>
                 )}
-            </div>
-
-            {/* Spend takes the cell Messages held: it is the question an
-                overview gets asked, and it used to be the smallest line of the
-                band. Messages survives as the qualifier it always was. */}
-            <div className="cl-hcell">
-              <div className="lbl">Spend / {retentionDays}d</div>
-              <div className="num">{fmtCost(totalCost)}</div>
-              <div className="sub">
-                {fmt(avgMessages)} msg avg · {fmt(totalMessages)} total
               </div>
             </div>
 
-            <div className="cl-hcell cl-hcell--mix">
-              <div className="lbl">Model mix / {retentionDays}d</div>
-              {modelMix.length === 0 ? (
-                <div className="sub">No usage in this window</div>
-              ) : (
-                <>
-                  <div className="cl-mixbar">
-                    {modelMix.map(slice => (
-                      <i
-                        key={slice.key}
-                        className={`seg ${slice.key}`}
-                        style={{ width: `${slice.pct}%` }}
-                        title={`${slice.label} · ${fmt(slice.tokens)} tok · ${slice.sessions} ${
-                          slice.sessions === 1 ? 'session' : 'sessions'
-                        }`}
-                      />
-                    ))}
-                  </div>
-                  {/* One line, dot-separated: bar plus a stacked legend was the
-                      same share encoded twice, over two rows. */}
-                  <div className="cl-mixlegend">
-                    {modelMix.map(slice => (
-                      <span key={slice.key}>
-                        <i className={`dot ${slice.key}`} />
-                        {slice.label} {slice.pctLabel}%
-                      </span>
-                    ))}
-                  </div>
-                </>
-              )}
+            {/* One action (design 3b): a terracotta pill for the thing the page
+                is actually for, SDK chat as a label beside it. Both keep the
+                tooltip that says which budget each one spends — the only place
+                the app draws that line. */}
+            <div className="cl-hero-cta-row">
+              <button
+                className="cl-hero-cta"
+                type="button"
+                title={CLAUDE_CODE_TITLE}
+                onClick={() => onNavigate({ type: 'terminal', project })}
+              >
+                Open in Claude Code
+              </button>
+              <button
+                className="cl-hero-alt"
+                type="button"
+                title={SDK_CHAT_TITLE}
+                onClick={() => onNavigate({ type: 'new-chat', project })}
+              >
+                SDK chat
+              </button>
             </div>
-          </div>
+          </>
         )}
       </section>
 
       {/* ─── SECTION CONTENT ──────────────────────────── */}
       {section === 'overview' && (
-        <>
-          {/* One session block, not two (design 1c): the pinned section and the
-              thinner "Recent" strip were the same list read twice, and the strip
-              had to drop pins, tags and the figure cluster to justify sitting
-              under a section that carried them. Three full rows instead, pins
-              first, with the caption saying how many pins the history holds. */}
-          <section className="cl-section">
-            <div className="cl-sec-head">
-              <h2>Sessions</h2>
-              <span className="ct">
-                {hasPinnedSession ? `${pinnedSessions.length} pinned · ` : ''}
-                {fmt(sessions.length)} total
-              </span>
-              <button
-                className="all"
-                type="button"
-                onClick={() => onNavigate({ type: 'sessions', project })}
-              >
-                View all
-              </button>
-            </div>
-            {/* SessionRows prints its own "No sessions yet." empty state. */}
-            <SessionRows
-              sessions={landingSessions}
-              projectHash={project.hash}
-              cleanupDays={cleanupDays}
-              onOpen={openTerminal}
-              onOpenChat={openChat}
-              rankOf={s => sessionRank.get(s.filename) ?? 0}
-            />
-          </section>
-
-          <section className="cl-section">
-            <div className="cl-sec-head">
-              <h2>Memory</h2>
-              <span className="ct">
-                {memoryCount} {memoryCount === 1 ? 'topic' : 'topics'}
-                {memTypeBreakdown.length > 0 && ` · ${memTypeBreakdown.join(' · ')}`}
-              </span>
-              <button
-                className="all"
-                type="button"
-                onClick={() => onNavigate({ type: 'project-memory', project })}
-              >
-                View all
-              </button>
-            </div>
-            {/* One view, newest first. The landing shows six cards out of a
-                history that runs to dozens: at that size grouping by type was a
-                control over a sample, and the subtab it links to owns the
-                complete list with the sorting and grouping that belong there. */}
-            {landingMemTopics.length === 0 ? (
-              <div className="cl-empty">No memory topics yet.</div>
-            ) : (
-              <div className="cl-mem-cards">
-                {landingMemTopics.map((t, i) => renderMemCard(t, i === 0))}
-              </div>
-            )}
-          </section>
-
-          <section className="cl-section">
-            <div className="cl-sec-head">
-              <h2>CLAUDE.md</h2>
-              <span className="ct">
-                {claudeMdLayers} {claudeMdLayers === 1 ? 'layer' : 'layers'} · global → project →
-                local → subdir
-              </span>
-            </div>
-            {claudeMdLayers === 0 ? (
-              <div className="cl-empty">No CLAUDE.md instructions for this project.</div>
-            ) : (
-              /* Una colonna sola: la cascata è una sequenza ordinata, e la
-                 griglia a due colonne la faceva leggere a zig-zag. */
-              <div className="cl-md-cascade">
-                {claudeMdLayerList.map(({ layer: l, lines, weight }) => {
-                  const { prefix, focus, suffix } = claudeMdPathParts(l, project.realPath);
-                  return (
-                    <button
-                      key={l.filePath}
-                      type="button"
-                      className="cl-md-layer"
-                      data-scope={l.scope}
-                      title={l.scope === 'global' ? '~/.claude/CLAUDE.md' : l.filePath}
-                      onClick={() =>
-                        l.scope === 'global'
-                          ? onNavigate({ type: 'global-claudemd' })
-                          : onNavigate({ type: 'project-claudemd', project, layer: l })
-                      }
-                    >
-                      <span className="scope">{CLAUDE_MD_SCOPE_LABEL[l.scope]}</span>
-                      <span className="path">
-                        {prefix && <span className="dim">{prefix}</span>}
-                        <span className="focus">{focus}</span>
-                        {suffix && <span className="dim">{suffix}</span>}
-                      </span>
-                      {/* 36 righe contro 882: la barra dice a colpo d'occhio
-                          quale layer pesa davvero nel contesto. */}
-                      <span className="weight" aria-hidden="true">
-                        <i style={{ width: `${Math.max(4, Math.round(weight * 100))}%` }} />
-                      </span>
-                      <span className="lines">
-                        <b>{lines}</b> lines
-                      </span>
-                    </button>
-                  );
-                })}
-              </div>
-            )}
-          </section>
-
-          <section className="cl-config-strip">
+        /* Design 3b: the landing is the hero and one list, nothing else. The
+           Memory cards, the CLAUDE.md cascade and the Skills/Agents/MCP/Rules
+           strip were previews of things the rail already counts one click
+           away; the cascade moved to Config, where a configuration belongs. */
+        <section className="cl-section cl-section--landing">
+          <div className="cl-sec-head cl-sec-head--rule">
+            <h2>Recent sessions</h2>
             <button
-              className={`item ${skillCount ? 'on' : ''}`}
+              className="all"
               type="button"
-              onClick={() => onNavigate({ type: 'project-skills', project })}
+              onClick={() => onNavigate({ type: 'sessions', project })}
             >
-              <span className="pip" />
-              <span>Skills</span>
-              <span className="num">{skillCount}</span>
+              All {fmt(sessions.length)}
             </button>
-            <button
-              className={`item ${agentCount ? 'on' : ''}`}
-              type="button"
-              onClick={() => onNavigate({ type: 'project-agents', project })}
-            >
-              <span className="pip" />
-              <span>Agents</span>
-              <span className="num">{agentCount}</span>
-            </button>
-            <button
-              className={`item ${enabledMcp.length ? 'on' : ''}`}
-              type="button"
-              onClick={() => onNavigate({ type: 'project-mcp', project })}
-            >
-              <span className="pip" />
-              <span>MCP</span>
-              <span className="num">{enabledMcp.length}</span>
-            </button>
-            <button
-              className={`item ${rules.length ? 'on' : ''}`}
-              type="button"
-              onClick={() => onNavigate({ type: 'project-mcp', project })}
-            >
-              <span className="pip" />
-              <span>Rules</span>
-              <span className="num">{rules.length} active</span>
-            </button>
-          </section>
-        </>
+          </div>
+          <RecentSessionRows sessions={landingSessions} onOpen={openTerminal} />
+        </section>
       )}
 
       {section === 'sessions' && (
@@ -1701,7 +1328,11 @@ export function ProjectView({
       )}
 
       {section === 'config' && (
-        <ProjectConfigView project={project} onDeleteProject={() => onDeleteProject(project)} />
+        <ProjectConfigView
+          project={project}
+          onNavigate={onNavigate}
+          onDeleteProject={() => onDeleteProject(project)}
+        />
       )}
     </div>
   );
@@ -2101,6 +1732,66 @@ function SessionRows({
           onDeleted={() => setDeleteFor(null)}
         />
       )}
+    </div>
+  );
+}
+
+/**
+ * The Overview's session list, drawn to design 3b: a title with the running
+ * chip beside it and one mono line of figures underneath, rows divided by
+ * hairlines. Deliberately *not* `SessionRows` with a variant flag — the pin,
+ * the coloured ordinal, the tags and the kebab belong to the Sessions view,
+ * which owns the list as a workspace; the landing reads three recent sessions
+ * and hands the rest over with "View all". A flag on the shared component is
+ * how that view changes by accident.
+ */
+function RecentSessionRows({
+  sessions,
+  onOpen,
+}: {
+  sessions: SessionSummary[];
+  onOpen: (s: SessionSummary) => void;
+}) {
+  const { data: activeSessions = [] } = useActiveSessions();
+  const liveIds = useMemo(
+    () => new Set(activeSessions.map(a => a.sessionId).filter(Boolean)),
+    [activeSessions]
+  );
+
+  if (sessions.length === 0) return <div className="cl-empty">No sessions yet.</div>;
+
+  return (
+    <div className="cl-rsrows">
+      {sessions.map(s => {
+        const untitled = sessionName(s) === null;
+        return (
+          <div
+            key={s.filename}
+            role="button"
+            tabIndex={0}
+            className="cl-rsrow"
+            onClick={() => onOpen(s)}
+            onKeyDown={e => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                onOpen(s);
+              }
+            }}
+          >
+            <div className="head">
+              <span className={`title${untitled ? ' is-untitled' : ''}`}>{sessionTitle(s)}</span>
+              {liveIds.has(s.filename.replace(/\.jsonl$/, '')) && <LiveTag />}
+            </div>
+            {/* One mono line, in the mock's order: messages, model, tokens,
+                when. No model dot — the row has no other colour to sit against
+                and the name already says which model it was. */}
+            <div className="meta">
+              {fmt(s.messageCount)} msg · {s.model ? fmtModel(s.model) : '—'} · {fmt(s.totalTokens)}{' '}
+              tokens · {shortWhen(s.date)}
+            </div>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/src/components/project/settings/ProjectConfigView.tsx
+++ b/src/components/project/settings/ProjectConfigView.tsx
@@ -1,6 +1,40 @@
-import { useEffectiveConfig } from '../../../hooks/useIPC';
+import { useMemo } from 'react';
+import type { ClaudeMdLayer } from '../../../types';
+import { useClaudeMdHierarchy, useEffectiveConfig } from '../../../hooks/useIPC';
 import { PROJECT_PURGE_ENABLED } from '../shared/project-purge';
+import type { View } from '../types';
 import { GeneralTab, PermissionsTab, ToolsTab, McpTab, ExtensionsTab } from './SettingsView';
+
+const CLAUDE_MD_SCOPE_LABEL: Record<'global' | 'project' | 'local' | 'subdir', string> = {
+  project: 'Project',
+  local: 'Local',
+  subdir: 'Subdir',
+  global: 'Global',
+};
+
+/** Ogni layer è un CLAUDE.md, quindi lo scope da solo non distingue una riga
+ *  dall'altra: quattro righe su sei si chiamavano "Subdir". Quello che le
+ *  distingue è la cartella che governano, così il path diventa il nome della
+ *  riga e viene spezzato in genitori (smorzati) + segmento identificante +
+ *  nome file (smorzato): la lista si legge sul segmento in evidenza senza
+ *  perdere il path intero. */
+function claudeMdPathParts(layer: ClaudeMdLayer, rootPath: string) {
+  if (layer.scope === 'global') {
+    return { prefix: '~/.claude/', focus: 'CLAUDE.md', suffix: '' };
+  }
+  const rel = layer.filePath.startsWith(rootPath + '/')
+    ? layer.filePath.slice(rootPath.length + 1)
+    : layer.filePath;
+  const cut = rel.lastIndexOf('/');
+  if (cut === -1) return { prefix: '', focus: rel, suffix: '' };
+  const dir = rel.slice(0, cut);
+  const up = dir.lastIndexOf('/');
+  return {
+    prefix: up === -1 ? '' : dir.slice(0, up + 1),
+    focus: dir.slice(up + 1) + '/',
+    suffix: rel.slice(cut + 1),
+  };
+}
 
 // Project-scoped variant of the Settings page. Resolves the effective config
 // against the project's own working directory (so the `project`/`local` tiers
@@ -12,12 +46,34 @@ type Project = { hash: string; realPath: string };
 
 export function ProjectConfigView({
   project,
+  onNavigate,
   onDeleteProject,
 }: {
   project: Project;
+  onNavigate: (v: View) => void;
   onDeleteProject: () => void;
 }) {
   const { data, isLoading, error, refetch, isFetching } = useEffectiveConfig(project.realPath);
+  const { data: claudeMd } = useClaudeMdHierarchy(project.realPath);
+
+  // Ordinati come la cascata che l'intestazione annuncia (global → project →
+  // local → subdir), non con il project in testa: la riga d'intestazione fa da
+  // legenda della lista solo se la lista la segue. I subdir vengono dopo, per
+  // profondità e poi alfabetici, così il ramo si legge dall'alto.
+  const claudeMdLayerList = useMemo(() => {
+    const order = { global: 0, project: 1, local: 2, subdir: 3 } as const;
+    const rows = [...(claudeMd?.layers ?? [])]
+      .map(layer => ({ layer, lines: layer.content.split('\n').length }))
+      .sort((a, b) => {
+        const byScope = order[a.layer.scope] - order[b.layer.scope];
+        if (byScope !== 0) return byScope;
+        const depth = a.layer.filePath.split('/').length - b.layer.filePath.split('/').length;
+        return depth !== 0 ? depth : a.layer.filePath.localeCompare(b.layer.filePath);
+      });
+    const maxLines = rows.reduce((m, r) => Math.max(m, r.lines), 1);
+    return rows.map(r => ({ ...r, weight: r.lines / maxLines }));
+  }, [claudeMd]);
+  const claudeMdLayers = claudeMdLayerList.length;
 
   return (
     <section className="cl-section" style={{ paddingTop: 38 }}>
@@ -46,6 +102,59 @@ export function ProjectConfigView({
               on the global Settings page. */}
         </div>
       ) : null}
+
+      {/* The CLAUDE.md cascade, moved here from the Overview when design 3b
+          stripped the landing to the hero and its session list. It belongs to
+          a configuration page anyway: these files are instructions resolved in
+          tiers, exactly like the settings above, and this is the only way into
+          a project layer. */}
+      <div className="cl-sec-head" style={{ marginTop: 44 }}>
+        <h2>CLAUDE.md</h2>
+        <span className="ct">
+          {claudeMdLayers} {claudeMdLayers === 1 ? 'layer' : 'layers'} · global → project → local →
+          subdir
+        </span>
+      </div>
+      {claudeMdLayers === 0 ? (
+        <div className="cl-empty">No CLAUDE.md instructions for this project.</div>
+      ) : (
+        /* Una colonna sola: la cascata è una sequenza ordinata, e la
+           griglia a due colonne la faceva leggere a zig-zag. */
+        <div className="cl-md-cascade" style={{ maxWidth: 660 }}>
+          {claudeMdLayerList.map(({ layer: l, lines, weight }) => {
+            const { prefix, focus, suffix } = claudeMdPathParts(l, project.realPath);
+            return (
+              <button
+                key={l.filePath}
+                type="button"
+                className="cl-md-layer"
+                data-scope={l.scope}
+                title={l.scope === 'global' ? '~/.claude/CLAUDE.md' : l.filePath}
+                onClick={() =>
+                  l.scope === 'global'
+                    ? onNavigate({ type: 'global-claudemd' })
+                    : onNavigate({ type: 'project-claudemd', project, layer: l })
+                }
+              >
+                <span className="scope">{CLAUDE_MD_SCOPE_LABEL[l.scope]}</span>
+                <span className="path">
+                  {prefix && <span className="dim">{prefix}</span>}
+                  <span className="focus">{focus}</span>
+                  {suffix && <span className="dim">{suffix}</span>}
+                </span>
+                {/* 36 righe contro 882: la barra dice a colpo d'occhio
+                    quale layer pesa davvero nel contesto. */}
+                <span className="weight" aria-hidden="true">
+                  <i style={{ width: `${Math.max(4, Math.round(weight * 100))}%` }} />
+                </span>
+                <span className="lines">
+                  <b>{lines}</b> lines
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      )}
 
       {/* The only visible way to delete a project. It used to be a "Remove
           current" button in the search popover's status bar — findable only by

--- a/src/index.css
+++ b/src/index.css
@@ -37,6 +37,12 @@
   --cl-accent-soft: oklch(0.95 0.035 50);
   --cl-accent-ink: oklch(0.42 0.13 40);
   --cl-on-accent: oklch(1 0 0);
+  /* the project hero's ground (design 3b) — the same warm tint accent-soft
+     carries, named for its job because dark needs a quieter one than a chip
+     bevel does. Half the chroma of the chip: a chip is 24px of colour, the
+     hero is 500px of it, and the same value that reads as a tint on one reads
+     as a pink field on the other. */
+  --cl-hero-wash: oklch(0.966 0.018 40);
   --cl-ok: oklch(0.62 0.1 145); /* warm sage — "live/ok" semantic, palette-friendly */
   --cl-violet: oklch(0.58 0.2 305);
   --cl-violet-soft: oklch(0.95 0.04 305);
@@ -54,6 +60,11 @@
   --cl-scroll: oklch(0.82 0.008 90 / 0.6);
   /* shared editorial gutter (hero / section horizontal padding) */
   --cl-gutter: clamp(32px, 5.5vw, 80px);
+  /* One measure for the project landing. The hero's figures stopped around
+     two thirds of the window while the session list ran to the far edge, so
+     the two blocks shared a left edge and nothing else; on a wide window that
+     left a mono line of metadata stranded against 600px of paper. */
+  --cl-measure: min(1080px, 100%);
 
   /* Radii, as the design system declares them. These were referenced before
      they were ever defined (.cl-plan-card and .cl-ask-card ask for
@@ -97,6 +108,9 @@
   --cl-accent-soft: oklch(0.32 0.08 40);
   --cl-accent-ink: oklch(0.86 0.1 50);
   --cl-on-accent: oklch(0.16 0.02 40);
+  /* a whole hero's worth of accent-soft reads as a colour field in dark, so
+     the wash keeps the hue and steps back toward paper */
+  --cl-hero-wash: oklch(0.235 0.018 40);
   --cl-ok: oklch(0.72 0.1 145); /* warm sage (dark lift) */
   --cl-violet: oklch(0.7 0.18 305);
   --cl-violet-soft: oklch(0.32 0.09 305);
@@ -2046,6 +2060,12 @@ body {
   width: max-content;
   max-width: 100%;
   margin-bottom: 14px;
+}
+/* A path inside the eyebrow keeps its own case and a normal tracking: the
+   label is a label, the path is data. */
+.cl-eyebrow .path {
+  text-transform: none;
+  letter-spacing: 0.04em;
 }
 .cl-eyebrow .pip {
   width: 7px;
@@ -4888,11 +4908,65 @@ body {
   background: color-mix(in oklch, var(--cl-violet-soft) 40%, transparent);
 }
 
+/* ──────────────────────────────────────────────────────────
+   MODEL CHIP — what the conversation is running on, and at what
+   effort. Leftmost cell of the pill: identity, not a control, so it
+   reads as the label of everything to its right. A chat that changed
+   model mid-way turns the chip into a dock (`+N` + caret) whose sheet
+   lists each run. Tinted by `modelColor()` through `--mt`, the same
+   data dimension the per-turn chip encodes — no new hue.
+   ────────────────────────────────────────────────────────── */
+.cl-pill-model {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 5px 11px;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  line-height: 1;
+  color: var(--cl-ink-2);
+}
+button.cl-pill-model {
+  cursor: pointer;
+  transition:
+    background 0.14s,
+    color 0.14s;
+}
+button.cl-pill-model:hover,
+button.cl-pill-model[data-on] {
+  background: color-mix(in oklch, var(--mt, var(--cl-accent)) 12%, transparent);
+}
+.cl-pill-model-dot {
+  width: 6px;
+  height: 6px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: var(--mt, var(--cl-ink-3));
+}
+.cl-pill-model-effort {
+  color: var(--cl-ink-4);
+  font-weight: 500;
+  text-transform: lowercase;
+  letter-spacing: 0.04em;
+}
+.cl-pill-model-switched {
+  color: var(--mt, var(--cl-accent));
+  font-weight: 600;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .cl-focus-tick,
   .cl-focus-current,
   .cl-pill-filter,
   .cl-pill-more,
+  .cl-pill-model,
   .cl-pill-dock,
   .cl-dock-row,
   .cl-dock-row-locate,
@@ -7617,65 +7691,6 @@ body {
   margin-top: 12px;
   letter-spacing: 0.02em;
 }
-.cl-bars {
-  margin-top: 14px;
-  display: grid;
-  grid-template-columns: repeat(12, minmax(0, 1fr));
-  align-items: end;
-  gap: 3px;
-  height: 28px;
-  min-width: 0;
-  width: 100%;
-  position: relative;
-  overflow: visible;
-}
-.cl-stat-bar {
-  position: relative;
-  display: flex;
-  align-items: end;
-  height: 28px;
-  min-width: 0;
-  overflow: hidden;
-  justify-self: stretch;
-  outline: none;
-}
-.cl-stat-bar-fill {
-  display: block;
-  background: var(--cl-ink);
-  width: 100%;
-  opacity: 0.85;
-  min-height: 1px;
-  transition:
-    height 160ms ease,
-    opacity 120ms ease,
-    background 120ms ease;
-}
-.cl-stat-bar.peak .cl-stat-bar-fill,
-.cl-stat-bar:hover .cl-stat-bar-fill,
-.cl-stat-bar:focus-visible .cl-stat-bar-fill {
-  background: var(--cl-accent);
-  opacity: 1;
-}
-.cl-bars-tip {
-  position: absolute;
-  bottom: calc(100% + 8px);
-  transform: translateX(-20%);
-  z-index: 6;
-  pointer-events: none;
-  white-space: nowrap;
-  width: 190px;
-  padding: 6px 8px;
-  border: 1px solid var(--cl-line);
-  border-radius: 6px;
-  background: var(--cl-paper);
-  color: var(--cl-ink);
-  box-shadow: 0 10px 24px oklch(0 0 0 / 0.12);
-  font-family: var(--font-mono);
-  font-size: 10px;
-  line-height: 1.2;
-  letter-spacing: 0;
-}
-
 .cl-stat.live {
   display: flex;
   flex-direction: column;
@@ -11337,169 +11352,6 @@ button.cl-sw-member:focus-visible,
   gap: 10px;
 }
 
-/* ── Memory index cards (project landing, design 1c) ──
-   The landing's memory used to be a 3-column definition list, where a topic
-   read as a table row: no type, no tags, no hierarchy — the most penalised
-   section of the page. It is now a grid of index cards carrying the four
-   things that identify a memory: what kind it is and how old (header), what
-   it is called (headline), what it says (three lines of prose) and how it is
-   filed (tags). The tags are read-only here; editing them lives in the
-   Memory subtab, which owns the full list. */
-.cl-mem-cards {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(248px, 1fr));
-  gap: 16px;
-}
-.cl-mcard {
-  display: flex;
-  flex-direction: column;
-  gap: 9px;
-  min-height: 176px;
-  padding: 18px;
-  border: 1px solid var(--cl-line);
-  border-radius: 14px;
-  background: var(--cl-paper);
-  text-align: left;
-  cursor: pointer;
-  transition:
-    border-color 120ms,
-    box-shadow 120ms;
-}
-.cl-mcard:hover {
-  border-color: color-mix(in oklch, var(--cl-accent) 30%, var(--cl-line));
-  box-shadow: 0 2px 12px -6px oklch(0 0 0 / 0.18);
-}
-:root[data-theme='dark'] .cl-mcard:hover {
-  box-shadow: 0 2px 12px -6px oklch(0 0 0 / 0.5);
-}
-.cl-mcard:focus-visible {
-  outline: 2px solid var(--cl-accent);
-  outline-offset: -2px;
-}
-.cl-mcard.accent {
-  border-color: color-mix(in oklch, var(--cl-accent) 34%, var(--cl-line));
-  background: linear-gradient(180deg, var(--cl-accent-soft), var(--cl-paper) 62%);
-  box-shadow: inset 0 1px 0 oklch(1 0 0 / 0.6);
-}
-:root[data-theme='dark'] .cl-mcard.accent {
-  box-shadow: inset 0 1px 0 oklch(1 0 0 / 0.06);
-}
-.cl-mcard .head {
-  display: flex;
-  align-items: center;
-  gap: 9px;
-}
-.cl-mcard .glyph {
-  flex: none;
-  width: 28px;
-  height: 28px;
-  border: 1.5px solid var(--cl-ink);
-  border-radius: 8px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-family: var(--font-mono);
-  font-weight: 600;
-  font-size: 12px;
-  color: var(--cl-ink);
-}
-.cl-mcard.accent .glyph {
-  background: var(--cl-accent);
-  border-color: var(--cl-accent);
-  color: var(--cl-on-accent);
-}
-.cl-mcard .kind {
-  font-family: var(--font-mono);
-  font-size: 9.5px;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  color: var(--cl-ink-4);
-}
-.cl-mcard.accent .kind {
-  color: var(--cl-accent-ink);
-}
-.cl-mcard .when {
-  margin-left: auto;
-  font-family: var(--font-mono);
-  font-size: 9.5px;
-  color: var(--cl-ink-4);
-}
-/* Memory names are slugs, and `feedback_no_manual_app_launch` is ONE word to a
-   line breaker: underscores are not break opportunities, so a snake_case title
-   ran straight out of its card while its kebab-case neighbours wrapped fine.
-   `<wbr>` after each underscore (see `SlugName`) gives it a decent break; this
-   is the net under it, for a name that has no separator at all. */
-.cl-mcard .name {
-  font-size: 16px;
-  font-weight: 600;
-  line-height: 1.25;
-  letter-spacing: -0.015em;
-  color: var(--cl-ink);
-  overflow-wrap: anywhere;
-}
-.cl-mcard .preview {
-  margin: 0;
-  font-family: var(--font-reading);
-  font-size: 13px;
-  line-height: 1.55;
-  color: var(--cl-ink-2);
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 3;
-  overflow: hidden;
-}
-.cl-mcard .tags {
-  margin-top: auto;
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 5px;
-}
-
-/* Config strip */
-.cl-config-strip {
-  padding: 24px var(--cl-gutter) 40px;
-  display: flex;
-  align-items: center;
-  gap: 0;
-  font-family: var(--font-mono);
-  font-size: 12px;
-  color: var(--cl-ink-3);
-  flex-wrap: wrap;
-}
-.cl-config-strip .item {
-  display: inline-flex;
-  align-items: center;
-  gap: 9px;
-  padding: 8px 22px 8px 0;
-  cursor: pointer;
-  transition: color 120ms;
-  background: none;
-  border: none;
-  font: inherit;
-  color: inherit;
-}
-.cl-config-strip .item:hover {
-  color: var(--cl-ink);
-}
-.cl-config-strip .item + .item {
-  padding-left: 22px;
-  border-left: 1px solid var(--cl-line);
-}
-.cl-config-strip .item .pip {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--cl-ink-4);
-}
-.cl-config-strip .item.on .pip {
-  background: var(--cl-accent);
-}
-.cl-config-strip .item .num {
-  color: var(--cl-ink);
-  font-weight: 500;
-}
-
 /* Skill / Agent tiles */
 .cl-tile-grid {
   display: grid;
@@ -11570,8 +11422,8 @@ button.cl-sw-member:focus-visible,
   border-color: var(--cl-accent);
   color: var(--cl-on-accent);
 }
-/* Same exposure as `.cl-mcard .name`: the tiles carry the very same slugs in
-   the Memory subtab, and skills/agents names are free text. */
+/* Full exposure: the tiles carry the very same slugs as the Memory subtab, and
+   skills/agents names are free text. */
 .cl-tile .t-name {
   font-size: 16px;
   font-weight: 600;
@@ -11588,6 +11440,7 @@ button.cl-sw-member:focus-visible,
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
+  line-clamp: 2;
   overflow: hidden;
 }
 .cl-tile .t-meta {
@@ -15681,35 +15534,129 @@ select.cl-opt-input {
 }
 
 /* ════════════════════════════════════════════════════════════════════════
-   HERO METRICS BAND (design 5b)
+   PROJECT HERO (design 3b — handoff "Project Overview Redesign", 1a → 2a → 3b)
    The band carries the project's figures, so the display name steps back from
    the full editorial clamp to roughly the mock's name:figure proportion —
-   otherwise a 132px name would swamp a strip of 26px numbers.
+   otherwise a 132px name would swamp a row of 30px numbers.
+   Everything here is scoped to `.cl-hero--band`: the Teams header
+   (`.cl-hero--compact`) shares the hero and none of its treatment.
    ════════════════════════════════════════════════════════════════════════ */
 .cl-hero--band {
   padding-top: 34px;
-  padding-bottom: 28px;
+  padding-bottom: 34px;
+  /* The Lens' concentric rings are gone: 3b dresses the hero with a warm wash
+     that fades to paper instead, so the figures sit on a plain ground. The
+     hero keeps its ink rule at the bottom — the wash ends in paper, and
+     without the rule the page would have no boundary there at all. */
+  /* Straight down, and no angle. A tilted gradient's line is
+     |W·sin a| + |H·cos a| long, so on a 1500×500 hero even 168deg stretched
+     the ramp to ~820px: the stops then landed far below where they read on
+     paper and the wash never reached paper before the rule. Vertical, the
+     percentages mean what they say — colour for the top third, paper from
+     halfway down, and the ink rule divides paper from paper. */
+  background: linear-gradient(
+    to bottom,
+    var(--cl-hero-wash) 0%,
+    color-mix(in oklch, var(--cl-hero-wash) 40%, var(--cl-paper)) 34%,
+    var(--cl-paper) 62%
+  );
 }
-.cl-hero--band .cl-hero-actions {
-  top: 34px;
+/* The live aura belongs to a hero with no ground of its own. Under the wash it
+   is a second animated accent field on top of a first — that is what mottled
+   the band, and a blurred glow behind the title is a poor way to say "a
+   process is running" anyway: it has no edge, so there is nothing to read.
+   The two aura layers go, and the claim moves into the eyebrow's pip, which
+   turns the running green and pulses like the rail's. One small mark that
+   means something, instead of 500px of weather. */
+.cl-hero--band.is-live::before,
+.cl-hero--band.is-live::after {
+  display: none;
 }
+.cl-hero--band.is-live .cl-eyebrow .pip {
+  background: var(--cl-ok);
+  animation: cl-rail-pulse 1.8s infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .cl-hero--band.is-live .cl-eyebrow .pip {
+    animation: none;
+  }
+}
+
 .cl-hero--band .cl-h-name {
-  font-size: clamp(40px, 4.2vw, 72px);
-  gap: 14px;
+  font-size: clamp(40px, 4.2vw, 64px);
+  /* No gap: the row's own gap put a space between the name and its full stop,
+     so the title read as "Personal ." — a typo, in 64px. The stop is part of
+     the word; only the chevron is a separate thing, and it asks for its own
+     margin below. */
+  gap: 0;
 }
 .cl-hero--band .cl-h-name .chev {
-  width: 28px;
-  height: 28px;
-  font-size: 14px;
-  margin-bottom: 10px;
-  border-width: 1.5px;
+  margin-left: 16px;
 }
-.cl-hero--band .cl-lens {
-  width: 400px;
-  height: 400px;
-  right: -120px;
-  top: -90px;
+/* No ring here. A 36px ink circle beside a 64px name is a second thing asking
+   to be looked at in the same line; the glyph alone still says the name opens
+   something, and it comes forward on hover like every other quiet control. */
+.cl-hero--band .cl-h-name .chev {
+  width: auto;
+  height: auto;
+  border: none;
+  background: none;
+  font-size: 20px;
+  line-height: 1;
+  margin-bottom: 14px;
+  color: var(--cl-ink-4);
+  transition: color 120ms;
 }
+.cl-hero--band .cl-h-name:hover .chev,
+.cl-hero--band .cl-h-name:focus-visible .chev {
+  background: none;
+  color: var(--cl-accent);
+}
+
+/* Name and description on one baseline (design 2a). Flex only here: the Teams
+   header renders the same wrapper with a single child and must keep its own
+   block layout. */
+.cl-hero--band .cl-h-title {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  /* `last baseline`, not `baseline`: a description that wraps to two lines sat
+     on the name's baseline with its FIRST line, which pushed the second one
+     below it and left the block floating high. The sentence should finish
+     level with the name. The plain value stays underneath as the fallback —
+     an engine that does not parse `last baseline` would otherwise drop the
+     declaration entirely and stretch the row. */
+  align-items: baseline;
+  align-items: last baseline;
+  flex-wrap: wrap;
+  gap: 18px;
+}
+.cl-hero--band .cl-h-title .cl-h-desc,
+.cl-hero--band .cl-h-title .cl-h-desc-add {
+  margin-top: 0;
+  /* A reading measure beside the name, not under it: the sentence has to read
+     as the name's apposition, so it stops well before the hero's width. */
+  max-width: 34ch;
+  font-size: 15px;
+  line-height: 1.45;
+  padding-bottom: 6px;
+  /* Two lines. A third one climbs above the name's cap height and the
+     description starts competing with the thing it describes; the full text
+     stays in the element's title. */
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+}
+/* The editor needs the full measure, so it breaks to its own line instead of
+   squeezing in beside a 64px name. */
+.cl-hero--band .cl-h-title .cl-h-desc-edit {
+  flex: 1 0 100%;
+  margin-top: 4px;
+}
+/* The shared metrics band: hairline-divided cells. Drawn by SearchView and
+   DuplicateProjectsNotice as well as the project hero, which overrides it
+   below — design 3b applies to the hero only. */
 .cl-hband {
   display: flex;
   align-items: stretch;
@@ -15724,8 +15671,7 @@ select.cl-opt-input {
   border-right: 1px solid var(--cl-line);
   flex: 0 0 auto;
   min-width: 0;
-  /* column so the small print bottom-aligns across cells of unequal height
-     (only two of them carry a sparkline) */
+  /* column so the small print bottom-aligns across cells of unequal height */
   display: flex;
   flex-direction: column;
 }
@@ -15771,16 +15717,6 @@ select.cl-opt-input {
   letter-spacing: 0;
   color: var(--cl-ink-4);
 }
-/* Neutral in both directions: green on "+3 sessions" encoded a verdict the
-   figure does not carry. The sign already says which way it went. */
-.cl-hcell .num .delta {
-  font-family: var(--font-mono);
-  font-size: 11px;
-  font-weight: 400;
-  letter-spacing: 0;
-  color: var(--cl-ink-4);
-  margin-left: 8px;
-}
 .cl-hcell .sub {
   font-family: var(--font-mono);
   font-size: 10px;
@@ -15789,26 +15725,72 @@ select.cl-opt-input {
   margin-top: auto;
   padding-top: 10px;
 }
-/* the retention sparkline rides inside the cell, compact */
-.cl-hcell .cl-bars {
-  margin-top: 11px;
-  height: 20px;
-  min-width: 140px;
+
+/* ── PROJECT HERO ONLY (design 3b) ────────────────────────────────────────
+   Four flat columns — a label and a figure each — separated by space instead
+   of rules. The hero is the one place that carries the band as the page's
+   headline; the search and duplicate views keep the divided cells, where the
+   figures are a caption to a result set rather than the subject. */
+.cl-hero--band .cl-hband {
+  max-width: var(--cl-measure);
+  align-items: flex-start;
+  margin-top: 40px;
+  border-top: none;
+  gap: 20px 56px;
 }
-.cl-hcell .cl-stat-bar {
-  height: 20px;
+.cl-hero--band .cl-hcell {
+  padding: 0;
+  border-right: none;
+  gap: 9px;
 }
+.cl-hero--band .cl-hcell--mix {
+  flex: 0 0 auto;
+  gap: 12px;
+  min-width: 190px;
+}
+.cl-hero--band .cl-hcell .lbl {
+  letter-spacing: 0.18em;
+}
+.cl-hero--band .cl-hcell .num {
+  font-size: 30px;
+  letter-spacing: -0.035em;
+  margin-top: 0;
+}
+.cl-hero--band .cl-hcell .num small {
+  font-size: 13px;
+}
+/* the mix cell's empty state is the only small print left in the hero row */
+.cl-hero--band .cl-hcell .sub {
+  margin-top: 0;
+  padding-top: 0;
+}
+/* the column's own gap does the spacing here — the shared margins would add
+   to it and pull the legend away from its bar */
+.cl-hero--band .cl-mixbar,
+.cl-hero--band .cl-mixlegend {
+  margin-top: 0;
+}
+/* the trailing cell closes the divided band — nothing sits to its right */
+.cl-hband > .cl-hcell:last-child {
+  border-right: none;
+}
+
 .cl-mixbar {
   display: flex;
-  height: 8px;
+  height: 6px;
   border-radius: 999px;
   overflow: hidden;
   margin-top: 13px;
-  max-width: 420px;
+  max-width: 220px;
   background: var(--cl-line-soft);
 }
+/* Every share that exists gets a mark. A project that ran 99.6% Opus drew one
+   unbroken violet block and a legend saying "Sonnet <1%" against nothing —
+   the bar denied what the words underneath it said. Two pixels is enough to
+   keep the claim honest, and it costs the majority slice nothing. */
 .cl-mixbar .seg {
   display: block;
+  min-width: 2px;
   background: var(--cl-accent);
 }
 .cl-mixbar .seg.opus {
@@ -15829,7 +15811,7 @@ select.cl-opt-input {
   display: flex;
   flex-wrap: nowrap;
   overflow: hidden;
-  gap: 14px;
+  gap: 12px;
   margin-top: 9px;
   font-family: var(--font-mono);
   font-size: 10px;
@@ -15861,11 +15843,6 @@ select.cl-opt-input {
   background: var(--cl-ink-4);
 }
 
-/* the trailing cell closes the band — nothing sits to the right of it */
-.cl-hband > .cl-hcell:last-child {
-  border-right: none;
-}
-
 /* The cell whose figure opens a breakdown card: it anchors the card and says so
    with a hint that only shows on approach. */
 .cl-hcell--hover {
@@ -15881,22 +15858,168 @@ select.cl-opt-input {
 .cl-hcell--hover .num:focus-visible {
   border-bottom-color: var(--cl-accent);
 }
-.cl-hpeek-hint {
-  opacity: 0;
-  transition: opacity 120ms ease;
-}
-.cl-hcell--hover:hover .cl-hpeek-hint,
-.cl-hcell--hover:focus-within .cl-hpeek-hint {
-  opacity: 1;
-}
 
 @media (max-width: 980px) {
   .cl-hcell {
     padding: 14px 18px 0;
   }
-  .cl-hcell .cl-bars {
-    display: none;
+  .cl-hero--band .cl-hband {
+    gap: 18px 32px;
   }
+}
+
+/* ── HERO ACTIONS (design 3b) ──────────────────────────────────────────────
+   The pair used to float top-right as two near-identical glass buttons, which
+   gave the page no way to say which one it is for. In flow under the metrics
+   they can carry a hierarchy: a terracotta pill for opening the project, and
+   SDK chat as a label beside it — still a button, still carrying the tooltip
+   that says which budget each one spends.
+   Scoped to `.cl-hero-cta-row`, which only the project hero renders; the Teams
+   header keeps `.cl-hero-actions` and its compact glass pair untouched. */
+.cl-hero-cta-row {
+  position: relative;
+  z-index: 3;
+  margin-top: 38px;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 22px;
+}
+.cl-hero-cta {
+  display: inline-flex;
+  align-items: center;
+  padding: 12px 22px;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: var(--cl-accent);
+  /* the established token for ink on an accent fill — white in light, near-ink
+     in dark, where the accent is lifted */
+  color: var(--cl-on-accent);
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  cursor: pointer;
+  transition:
+    background 140ms,
+    box-shadow 140ms,
+    transform 140ms;
+}
+.cl-hero-cta:hover {
+  background: color-mix(in oklch, var(--cl-accent) 88%, var(--cl-ink));
+  box-shadow: 0 10px 24px -12px color-mix(in oklch, var(--cl-accent) 70%, transparent);
+  transform: translateY(-1px);
+}
+.cl-hero-cta:active {
+  transform: translateY(0.5px);
+  box-shadow: none;
+}
+.cl-hero-alt {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0;
+  background: none;
+  border: none;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--cl-ink-3);
+  cursor: pointer;
+  transition: color 140ms;
+}
+.cl-hero-alt::after {
+  content: '→';
+  font-family: var(--font-sans);
+  font-size: 14px;
+  letter-spacing: 0;
+}
+.cl-hero-alt:hover {
+  color: var(--cl-accent-ink);
+}
+
+/* Dark: the accent is the light end here, so the hover darkens toward paper
+   instead of toward ink. */
+:root[data-theme='dark'] .cl-hero-cta:hover {
+  background: color-mix(in oklch, var(--cl-accent) 88%, var(--cl-paper));
+}
+
+/* ── LANDING SESSION LIST (design 3b) ──────────────────────────────────────
+   The Overview's list, which the mock draws as three quiet records: a title
+   with the running chip beside it, one mono line of figures underneath, rows
+   divided by hairlines and nothing else. The workspace row — pin, coloured
+   ordinal, tags, expiry, kebab — stays on `.cl-srow` in the Sessions view,
+   which is where a session is acted on rather than just read.
+   ═══════════════════════════════════════════════════════════════════════ */
+.cl-section--landing > * {
+  max-width: var(--cl-measure);
+}
+.cl-sec-head--rule {
+  align-items: baseline;
+  padding-bottom: 12px;
+  margin-bottom: 0;
+  border-bottom: 1px solid var(--cl-ink);
+}
+/* The head steps down to the mono label of the mock: the figures and the
+   session titles are the type on this page, and a 24px heading over an 18px
+   title was competing with the list it introduces. */
+.cl-sec-head--rule h2 {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--cl-ink-4);
+}
+
+.cl-rsrow {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 18px 0;
+  border-bottom: 1px solid var(--cl-line-soft);
+  cursor: pointer;
+  outline: none;
+  transition: background 120ms;
+  /* the row bleeds its hover into the gutter, so the band of colour lines up
+     with the section rule above it rather than floating inside it */
+  margin: 0 -10px;
+  padding-left: 10px;
+  padding-right: 10px;
+}
+.cl-rsrow:hover,
+.cl-rsrow:focus-visible {
+  background: var(--cl-paper-2);
+}
+/* The row has no outline, so the hover tint would be the only focus indicator —
+   and in dark mode paper and paper-2 are 0.04 of lightness apart, which is a
+   hover, not an "you are here". The accent edge says it in both themes; inset
+   so it never moves the row. */
+.cl-rsrow:focus-visible {
+  box-shadow: inset 2px 0 0 var(--cl-accent);
+}
+.cl-rsrow .head {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+.cl-rsrow .title {
+  font-size: 18px;
+  font-weight: 500;
+  letter-spacing: -0.018em;
+  color: var(--cl-ink);
+}
+.cl-rsrow .title.is-untitled {
+  font-style: italic;
+  color: var(--cl-ink-4);
+}
+.cl-rsrow .meta {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  color: var(--cl-ink-4);
 }
 
 /* Below this the four cells cannot sit on one line. Free wrapping left the
@@ -16412,7 +16535,7 @@ select.cl-opt-input {
    also reads as a foreign object. Nothing about a process makes it a terminal —
    that analogy was borrowed, and it cost the page twice.
 
-   So: the memory index card (`.cl-mcard`), on paper, in the app's own language —
+   So: an index card in the memory idiom, on paper, in the app's own language —
    and the body is what the session actually DID, six lines of `Edit
    MonitorView.tsx` / `Bash npm run typecheck ✕`. A card whose body is real text
    cannot look empty, because the content fills it.

--- a/test/project-purge-entrypoints.test.tsx
+++ b/test/project-purge-entrypoints.test.tsx
@@ -39,12 +39,19 @@ afterEach(() => {
 
 function mount() {
   let deleteRequests = 0;
+  const navigations: unknown[] = [];
   const view = render(
     createElement(
       QueryClientProvider,
       { client: queryClient },
       createElement(ProjectConfigView, {
         project: PROJECT,
+        // The view owns the CLAUDE.md cascade since design 3b stripped the
+        // Overview; nothing in this file clicks a layer, so the navigator only
+        // has to exist.
+        onNavigate: (v: unknown) => {
+          navigations.push(v);
+        },
         onDeleteProject: () => {
           deleteRequests++;
         },


### PR DESCRIPTION
## What this changes

The project Overview carried four blocks under the hero — recent sessions, a grid of memory cards, the CLAUDE.md cascade and a Skills/Agents/MCP/Rules strip. Three of them previewed things the rail already counts one click away (`Memory`, `Skills`, `Agents`, `MCP` all carry a badge, and `Rules` never had a destination of its own — it navigated to `project-mcp`, where the conditional rules live), so they go with their CSS. The CLAUDE.md cascade was the one real exception: it was the only entry into `project-claudemd` and the rail has no CLAUDE.md item, so it moves to `ProjectConfigView` rather than disappearing — the layer list belongs with the settings it is resolved alongside, and the view takes an `onNavigate` for it.

The landing list is a new `RecentSessionRows`, not a variant flag on the shared `SessionRows`: a title with the running chip, one mono line of figures, rows divided by hairlines. Pin, coloured ordinal, tags and the row menu stay on `.cl-srow` in the Sessions view, which owns the list as a workspace. Ordering is recency now instead of pins-first, because the metrics band no longer prints `last … ago` — the top row became the page's only statement of when the project was last touched, and a pinned session from three weeks ago in that slot would make the page lie. Pinned sessions keep their own section in the Sessions view.

The hero follows design 3b (handoff _Project Overview Redesign_) and drops what it had borrowed from the previous treatment: the `is-live` aura was a second animated accent field stacked on the wash and mottled the band, so the live claim moves to the eyebrow's pip, which turns green and pulses like the rail's; the wash halves its chroma and runs straight down, since a tilted gradient's line is `|W·sin a| + |H·cos a|` long and at 168deg on a 1500×500 hero the ramp stretched well past the ink rule; the name's full stop is no longer held off by the row gap (`src/index.css` — the title read `Personal .` at 64px); the description is clamped to two lines sitting on the name's last baseline; the eyebrow path leaves uppercase, since a path is case-sensitive and `/USERS/…` would not resolve; and the model bar steps aside when one family owns the window, where a part-of-whole with a single visible part drew a filled rectangle against a legend reading `Sonnet <1%`. The percentage labels are untouched — `pctLabels` floors always sum to 100 and it is unit-tested.

## How to verify

```
npm run format:check && npm run typecheck && npm run lint && npm test && npm run build
```

All five pass on this branch: 1367 tests, 81 files (3 skipped). `test/project-purge-entrypoints.test.tsx` gained the `onNavigate` prop the config view now requires.

Against your own `~/.claude/`: open a project. The Overview should be the hero and one list of five sessions with `All N →`; Memory, Skills, Agents and MCP are reached from the rail, and the CLAUDE.md cascade from **Config**, under the effective configuration. On a project with a running process the eyebrow pip is green and pulsing instead of the hero glowing. On a project that ran a single model the Models cell shows the legend without a bar.

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] `npm run build` passes
- [ ] Visual changes validated manually with `npm run dev`
- [ ] Tests added or updated — pure modules under `electron/modules/`, and
      renderer hooks holding stream or cache state (see
      `test/helpers/fake-electron-api.ts`)
- [x] `CLAUDE.md` updated if the architecture, an IPC namespace, or a convention changed

Two boxes are unticked on purpose. The app was not launched from here — layout and styling have no automated coverage in this repo, so the hero and the list still need a pass by eye in both themes. And no test was added: the change is presentational, and the only state it touches (which rows the landing takes, and the config view's new prop) is covered by the existing suite plus the updated purge test.

## Screenshots

Not attached — the app was not launched from this branch.
